### PR TITLE
docker: wrap the client to produce more user-friendly error messages.

### DIFF
--- a/internal/sdk/k3d/k3d.go
+++ b/internal/sdk/k3d/k3d.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/client"
 	"golang.org/x/mod/semver"
 	"namespacelabs.dev/foundation/internal/artifacts"
 	"namespacelabs.dev/foundation/internal/artifacts/download"
@@ -22,6 +21,7 @@ import (
 	"namespacelabs.dev/foundation/internal/disk"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/localexec"
+	"namespacelabs.dev/foundation/runtime/docker"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/workspace/compute"
 	"namespacelabs.dev/foundation/workspace/devhost"
@@ -124,7 +124,7 @@ func AllDownloads() []compute.Computable[compute.ByteStream] {
 const minimumDockerVer = "20.10.5"
 const minimumRuncVer = "1.0.0-rc93"
 
-func ValidateDocker(ctx context.Context, cli *client.Client) error {
+func ValidateDocker(ctx context.Context, cli docker.Client) error {
 	ver, err := cli.ServerVersion(ctx)
 	if err != nil {
 		return fnerrors.RemoteError("failed to obtain docker version: %w", err)

--- a/runtime/docker/client.go
+++ b/runtime/docker/client.go
@@ -5,22 +5,109 @@
 package docker
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"runtime"
+	"strings"
 
-	"github.com/docker/cli/cli/config/types"
+	configtypes "github.com/docker/cli/cli/config/types"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"namespacelabs.dev/foundation/internal/fnerrors"
 )
 
-func NewClient() (*client.Client, error) {
-	return client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+// Client implements the Docker client, but only with the bits that Foundation requires.
+// It also performs Foundation-specific error handling
+type Client interface {
+	ServerVersion(ctx context.Context) (types.Version, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
+	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
+	ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
+	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
+	ImageTag(ctx context.Context, source, target string) error
+	Close() error
+}
+
+func NewClient() (Client, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	return wrappedClient{cli}, err
 }
 
 // From "github.com/docker/cli/cli/command", but avoiding dep creep.
-func EncodeAuthToBase64(authConfig types.AuthConfig) (string, error) {
+func EncodeAuthToBase64(authConfig configtypes.AuthConfig) (string, error) {
 	buf, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(buf), nil
+}
+
+type wrappedClient struct {
+	cli *client.Client
+}
+
+func (w wrappedClient) ServerVersion(ctx context.Context) (types.Version, error) {
+	v, err := w.cli.ServerVersion(ctx)
+	return v, maybeReplaceErr(err)
+}
+
+func (w wrappedClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	v, err := w.cli.ContainerInspect(ctx, containerID)
+	return v, maybeReplaceErr(err)
+}
+
+func (w wrappedClient) ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error {
+	return maybeReplaceErr(w.cli.ContainerStart(ctx, containerID, options))
+}
+
+func (w wrappedClient) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
+	return maybeReplaceErr(w.cli.ContainerRemove(ctx, containerID, options))
+}
+
+func (w wrappedClient) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	i, b, err := w.cli.ImageInspectWithRaw(ctx, imageID)
+	return i, b, maybeReplaceErr(err)
+}
+
+func (w wrappedClient) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
+	v, err := w.cli.ImageLoad(ctx, input, quiet)
+	return v, maybeReplaceErr(err)
+}
+
+func (w wrappedClient) ImageTag(ctx context.Context, source, target string) error {
+	return maybeReplaceErr(w.cli.ImageTag(ctx, source, target))
+}
+
+func (w wrappedClient) Close() error {
+	return maybeReplaceErr(w.cli.Close())
+}
+
+func maybeReplaceErr(err error) error {
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		if os.IsPermission(unwrapped) {
+			var lines = []string{
+				"Failed to connect to Docker, due to lack of permissions. This is likely",
+				"due to your user not being in the right group to be able to use Docker.",
+				"",
+			}
+
+			if runtime.GOOS == "linux" {
+				lines = append(lines,
+					"Checkout the following URL for instructions on how to handle this error:",
+					"",
+					"https://docs.docker.com/engine/install/linux-postinstall/")
+			} else {
+				lines = append(lines, "Please refer to Docker's documentation on how to solve this issue.")
+			}
+
+			return fnerrors.Wrapf(nil, err, strings.Join(lines, "\n"))
+		}
+	}
+
+	return err
 }

--- a/runtime/docker/imageload.go
+++ b/runtime/docker/imageload.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -66,7 +65,7 @@ func WriteImage(ctx context.Context, img v1.Image, ref name.Tag, ensureTag bool)
 }
 
 // Write saves the image into the daemon as the given tag.
-func writeImage(ctx context.Context, client *client.Client, tag name.Tag, img v1.Image) (string, error) {
+func writeImage(ctx context.Context, client Client, tag name.Tag, img v1.Image) (string, error) {
 	pr, pw := io.Pipe()
 	go func() {
 		pw.CloseWithError(tarball.Write(tag, img, ctxio.WriterWithContext(ctx, pw, nil)))


### PR DESCRIPTION
This is necessary because docker is invoked from multiple places, and
permissions can be changed after `prepare` is run, so we also need to
check during normal operations.

Fixes #140.