### PR TITLE
Properly format duration in log messages.

### DIFF
--- a/std/go/core/env.go
+++ b/std/go/core/env.go
@@ -117,7 +117,7 @@ func (di *DepInitializer) Wait(ctx context.Context) error {
 		took := time.Since(start)
 
 		if took > maximumInitTime {
-			Log.Printf("[init] %s took %d (log thresh is %d)", init.Desc(), took, maximumInitTime)
+			Log.Printf("[init] %s took %s (log thresh is %s)", init.Desc(), took, maximumInitTime)
 		}
 
 		if err != nil {


### PR DESCRIPTION
after:

[foundation] 2022/04/12 12:20:23.240665 [init] namespacelabs.dev/internal/aws/s3/server.s3Demo took 5.009976857s (log thresh is 10ms)
