### PR TITLE
Minor formating fixes.

### DIFF
--- a/provision/deploy/wait.go
+++ b/provision/deploy/wait.go
@@ -100,7 +100,7 @@ func observeContainers(ctx context.Context, env ops.Environment, parent chan ops
 						fmt.Fprintf(out, "For more information, run:\n  %s\n", help)
 					}
 
-					fmt.Fprintf(out, "Diagnostics, retrieved at %v:\n", time.Now())
+					fmt.Fprintf(out, "Diagnostics retrieved at %s:\n", time.Now().Format("2006-01-02 15:04:05.000"))
 
 					// XXX fetching diagnostics should not block forwarding events (above).
 					for _, ws := range all {


### PR DESCRIPTION
Was:
    [✓] namespacelabs.dev/internal/development/localstack took 11.0s
        Diagnostics, retrieved at 2022-04-20 20:31:03.715281059 +0000 UTC m=+21.962395261:
        localstack:
          Waiting: ContainerCreating
