### PR TITLE
Fix console's cursor state

### DIFF
--- a/internal/cli/cmd/tools/kubectl.go
+++ b/internal/cli/cmd/tools/kubectl.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
-	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/provision"
 	"namespacelabs.dev/foundation/runtime/kubernetes"
 	"namespacelabs.dev/foundation/runtime/rtypes"
@@ -42,8 +41,8 @@ func newKubeCtlCmd() *cobra.Command {
 
 			return k8s.Kubectl(ctx, rtypes.IO{
 				Stdin:  os.Stdin,
-				Stdout: console.Stdout(ctx),
-				Stderr: console.Stderr(ctx),
+				Stdout: os.Stdout,
+				Stderr: os.Stderr,
 			}, args...)
 		}),
 	}


### PR DESCRIPTION
I simplified tracking of the `c.rendering` state (as changing it in multiple places led to problems)
