### PR TITLE
Fix race condition or accessing LogActions flag

### DIFF
--- a/internal/cli/fncobra/main.go
+++ b/internal/cli/fncobra/main.go
@@ -192,8 +192,6 @@ func DoMain(name string, registerCommands func(*cobra.Command)) {
 		return nil
 	})
 
-	registerCommands(rootCmd)
-
 	rootCmd.PersistentFlags().BoolVar(&binary.UsePrebuilts, "use_prebuilts", binary.UsePrebuilts,
 		"If set to false, binaries are built from source rather than a corresponding prebuilt being used.")
 	rootCmd.PersistentFlags().BoolVar(&consolesink.LogActions, "log_actions", consolesink.LogActions,
@@ -232,6 +230,8 @@ func DoMain(name string, registerCommands func(*cobra.Command)) {
 	} {
 		_ = rootCmd.PersistentFlags().MarkHidden(noisy)
 	}
+
+	registerCommands(rootCmd)
 
 	err := rootCmd.ExecuteContext(ctxWithSink)
 


### PR DESCRIPTION
```
=================
WARNING: DATA RACE
Read at 0x00000530204c by goroutine 30:
  namespacelabs.dev/foundation/internal/console/consolesink.(*ConsoleSink).drawFrame()
      /home/kamil/namespacelabs/foundation/internal/console/consolesink/console.go:690 +0x570
  namespacelabs.dev/foundation/internal/console/consolesink.(*ConsoleSink).redraw()
      /home/kamil/namespacelabs/foundation/internal/console/consolesink/console.go:593 +0x55d
  namespacelabs.dev/foundation/internal/console/consolesink.(*ConsoleSink).run()
      /home/kamil/namespacelabs/foundation/internal/console/consolesink/console.go:279 +0x6a4
  namespacelabs.dev/foundation/internal/console/consolesink.(*ConsoleSink).Start.func2()
      /home/kamil/namespacelabs/foundation/internal/console/consolesink/console.go:194 +0x47

Previous write at 0x00000530204c by main goroutine:
  [failed to restore the stack]

```