### PR TITLE
Revert "Fix console's cursor state" (missing `[-] idle line`)

### DIFF
--- a/internal/cli/cmd/tools/kubectl.go
+++ b/internal/cli/cmd/tools/kubectl.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/provision"
 	"namespacelabs.dev/foundation/runtime/kubernetes"
 	"namespacelabs.dev/foundation/runtime/rtypes"
@@ -41,8 +42,8 @@ func newKubeCtlCmd() *cobra.Command {
 
 			return k8s.Kubectl(ctx, rtypes.IO{
 				Stdin:  os.Stdin,
-				Stdout: os.Stdout,
-				Stderr: os.Stderr,
+				Stdout: console.Stdout(ctx),
+				Stderr: console.Stderr(ctx),
 			}, args...)
 		}),
 	}

--- a/internal/console/consolesink/console.go
+++ b/internal/console/consolesink/console.go
@@ -110,13 +110,14 @@ type ConsoleSink struct {
 	ch       chan consoleEvent
 	ticker   <-chan time.Time
 
+	rendering       bool
 	idling          bool
 	buffer          []consoleOutput  // Pending regular log output lines.
 	running         []*lineItem      // Computed EventData for waiting/running actions.
 	root            *node            // Root of the tree of displayable events.
 	nodes           map[string]*node // Map of actionID->tree node.
 	startedCounting time.Time        // When did we start counting.
-	waitForIdle     []chan struct{}
+	waitForIdle     []func()
 
 	maxLevel int // Only display actions at this level or below (all actions are still computed).
 
@@ -151,10 +152,11 @@ var _ tasks.ActionSink = &ConsoleSink{}
 
 func NewSink(out *os.File, maxLevel int) *ConsoleSink {
 	return &ConsoleSink{
-		out:      out,
-		outbuf:   bytes.NewBuffer(make([]byte, 4*1024)), // Start with 4k, enough to hold 20 lines of 100 bytes. bytes.Buffer will grow as needed.
-		idling:   true,
-		maxLevel: maxLevel,
+		out:       out,
+		outbuf:    bytes.NewBuffer(make([]byte, 4*1024)), // Start with 4k, enough to hold 20 lines of 100 bytes. bytes.Buffer will grow as needed.
+		rendering: true,
+		idling:    true,
+		maxLevel:  maxLevel,
 	}
 }
 
@@ -205,7 +207,6 @@ func (c *ConsoleSink) Start() func() {
 func (c *ConsoleSink) run(canceled chan struct{}) {
 	defer close(c.waitDone)
 
-	rendering := true
 loop:
 	for {
 		select {
@@ -215,9 +216,15 @@ loop:
 		case msg := <-c.ch:
 			if msg.renderingMode != "" {
 				if msg.renderingMode == "rendering" {
-					rendering = true
+					c.rendering = true
 				} else {
-					c.waitForIdle = append(c.waitForIdle, msg.onInput)
+					ch := msg.onInput
+					c.waitForIdle = append(c.waitForIdle, func() {
+						c.rendering = false
+						if ch != nil {
+							close(ch)
+						}
+					})
 				}
 			}
 
@@ -269,21 +276,7 @@ loop:
 			}
 
 		case t := <-c.ticker:
-			if !rendering {
-				continue
-			}
-			running, waiting, anchored := c.countStates()
-			if running+waiting+anchored == 0 {
-				c.redraw(t, true) // Entering input mode - flush the state.
-				rendering = false
-				for _, waitingForIdle := range c.waitForIdle {
-					// Unblock callers waiting for the input state.
-					close(waitingForIdle)
-				}
-				c.waitForIdle = nil
-			} else {
-				c.redraw(t, false)
-			}
+			c.redraw(t, false)
 		}
 	}
 
@@ -559,6 +552,10 @@ type debugRunning struct {
 }
 
 func (c *ConsoleSink) redraw(t time.Time, flush bool) {
+	if !c.rendering {
+		return
+	}
+
 	var width uint
 	var height uint
 	if w, err := termios.TermSize(c.out.Fd()); err == nil {
@@ -593,7 +590,10 @@ func (c *ConsoleSink) redraw(t time.Time, flush bool) {
 		// If anything is trying to write directly, clear the screen first.
 		fmt.Fprint(c.out, aec.EraseDisplay(aec.EraseModes.Tail))
 	}}
-	c.drawFrame(&rawOut, c.outbuf, t, width, height, flush)
+	if !c.drawFrame(&rawOut, c.outbuf, t, width, height, flush) {
+		// c.drawFrame() entered the `input` state (and may be rendering the prompt now).
+		return
+	}
 
 	newFrame := make([]byte, len(c.outbuf.Bytes()))
 	copy(newFrame, c.outbuf.Bytes())
@@ -658,10 +658,10 @@ func (c *checkDirtyWriter) Write(p []byte) (int, error) {
 	return c.out.Write(p)
 }
 
-func (c *ConsoleSink) countStates() (running, waiting, anchored int) {
-	running = 0
-	waiting = 0
-	anchored = 0
+// drawFrame renders a single frame and returns `false` if further rendering should be stopped.
+func (c *ConsoleSink) drawFrame(raw, out io.Writer, t time.Time, width, height uint, flush bool) bool {
+	var running, anchored, waiting, completed, completedAnchors int
+	var printableCompleted []*lineItem
 	for _, r := range c.running {
 		if r.data.State == tasks.ActionRunning {
 			if !r.data.Indefinite {
@@ -673,18 +673,7 @@ func (c *ConsoleSink) countStates() (running, waiting, anchored int) {
 			}
 		} else if r.data.State == tasks.ActionWaiting {
 			waiting++
-		}
-	}
-	return
-}
-
-// drawFrame renders a single frame and returns `false` if further rendering should be stopped.
-func (c *ConsoleSink) drawFrame(raw, out io.Writer, t time.Time, width, height uint, flush bool) {
-	running, waiting, anchored := c.countStates()
-	var completed, completedAnchors int
-	var printableCompleted []*lineItem
-	for _, r := range c.running {
-		if r.data.State != tasks.ActionWaiting && r.data.State != tasks.ActionRunning {
+		} else {
 			hasError := (r.data.Err != nil && tasks.ErrorType(r.data.Err) == tasks.ErrTypeIsRegular)
 			shouldLog := LogActions && (DisplayWaitingActions || r.data.AnchorID == "")
 
@@ -804,15 +793,21 @@ func (c *ConsoleSink) drawFrame(raw, out io.Writer, t time.Time, width, height u
 	}
 
 	if flush {
-		return
+		return true
 	}
 
 	if (waiting + running + anchored) == 0 {
-		if len(c.waitForIdle) == 0 && c.idleLabel != "" {
+		waitForIdle := c.waitForIdle
+		c.waitForIdle = nil
+		for _, f := range waitForIdle {
+			f()
+		}
+		if len(waitForIdle) == 0 && c.idleLabel != "" {
 			// Show the idle banner.
 			c.writeLineWithMaxW(out, width, fmt.Sprintf("[-] idle, %s.", c.idleLabel), "")
 		}
-		return
+		// We may have entered the input state when calling any of the waitForIdle functions.
+		return c.rendering
 	}
 
 	report := ""
@@ -849,6 +844,7 @@ func (c *ConsoleSink) drawFrame(raw, out io.Writer, t time.Time, width, height u
 
 	// Recurse through the line item tree.
 	c.renderLineRec(out, width, c.root, t, " => ", 0, maxDepth)
+	return true
 }
 
 func plural(count int, singular, plural string) string {


### PR DESCRIPTION
Reverts namespacelabs/foundation#412