### PR TITLE
UnwrapSink to get consolesink.

### DIFF
--- a/internal/console/err_context.go
+++ b/internal/console/err_context.go
@@ -37,7 +37,7 @@ func newErrContext() *errContext {
 // WithLogs adds additional context to the error message, but only if a given message
 // hasn't been output in the most recent log lines.
 func WithLogs(ctx context.Context, err error) error {
-	sink := tasks.SinkFrom(ctx)
+	sink := UnwrapSink(tasks.SinkFrom(ctx))
 	if sink == nil {
 		return err
 	}


### PR DESCRIPTION
before:

```
  go build namespacelabs.dev/foundation/universe/storage/s3
  go build # namespacelabs.dev/foundation/universe/storage/s3
  go build universe/storage/s3/deps.fn.go:20:29: undefined: ProvideBucket
Failed: Captured logs: 
namespacelabs.dev/foundation/universe/storage/s3
# namespacelabs.dev/foundation/universe/storage/s3
universe/storage/s3/deps.fn.go:20:29: undefined: ProvideBucket
```


after:

```
➜  foundation git:(main) ✗ fn dev 
  go build namespacelabs.dev/foundation/universe/storage/s3
  go build # namespacelabs.dev/foundation/universe/storage/s3
  go build universe/storage/s3/deps.fn.go:20:29: undefined: ProvideBucket
Failed: xxx go build: local execution failed: exit status 2
  
   Foundation: web ui running at: http://127.0.0.1:4003
  
   Key bindings (l): stream logs (q): quit
 
```
