### PR TITLE
Direct log output to Stderr instead of Stdout.

### DIFF
--- a/internal/cli/fncobra/main.go
+++ b/internal/cli/fncobra/main.go
@@ -444,7 +444,7 @@ func ensureFnConfig() {
 }
 
 func consoleFromFile() (*os.File, bool) {
-	out := os.Stdout
+	out := os.Stderr
 	return out, termios.IsTerm(out.Fd())
 }
 


### PR DESCRIPTION
This allows commands to produce machine-parseable output on Stdout if needed. This is used to implement Language Server Protocol on Stdio for `fn lsp` command.