### PR TITLE
Idle label race condition fix.

### DIFF
--- a/devworkflow/step.go
+++ b/devworkflow/step.go
@@ -27,9 +27,6 @@ import (
 func setWorkspace(ctx context.Context, env provision.Env, packageName string, additional []string, obs *Session, pfw *endpointfwd.PortForward) error {
 	for {
 		if err := compute.Do(ctx, func(ctx context.Context) error {
-			done := console.SetIdleLabel(ctx, "waiting for workspace changes")
-			defer done()
-
 			serverPackages := []schema.PackageName{schema.Name(packageName)}
 			for _, pkg := range additional {
 				serverPackages = append(serverPackages, schema.Name(pkg))

--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -70,8 +70,7 @@ func NewBuildCmd() *cobra.Command {
 			}
 
 			if continuously {
-				done := console.SetIdleLabel(ctx, "waiting for workspace changes")
-				defer done()
+				console.SetIdleLabel(ctx, "waiting for workspace changes")
 				return compute.Continuously(ctx, continuousBuild{allImages: buildAll})
 			}
 

--- a/internal/cli/cmd/dev.go
+++ b/internal/cli/cmd/dev.go
@@ -20,6 +20,7 @@ import (
 	"namespacelabs.dev/foundation/devworkflow"
 	"namespacelabs.dev/foundation/devworkflow/keyboard"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/reverseproxy"
 	"namespacelabs.dev/foundation/languages/web"
@@ -90,6 +91,7 @@ func NewDevCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				console.SetIdleLabel(ctx, "waiting for workspace changes")
 				defer stackState.Close()
 
 				go func() {

--- a/internal/cli/cmd/logs.go
+++ b/internal/cli/cmd/logs.go
@@ -40,8 +40,7 @@ func NewLogsCmd() *cobra.Command {
 				return err
 			}
 
-			cancel := console.SetIdleLabel(ctx, "listening for deployment changes")
-			defer cancel()
+			console.SetIdleLabel(ctx, "listening for deployment changes")
 
 			return logtail.NewLogTail(ctx, env, server.Proto())
 		}),

--- a/internal/console/consolesink/console.go
+++ b/internal/console/consolesink/console.go
@@ -1040,11 +1040,9 @@ func (c *ConsoleSink) AllocateConsoleId() uint64 {
 	return uint64(rand.Int63())
 }
 
-func (c *ConsoleSink) SetIdleLabel(label string) func() {
+func (c *ConsoleSink) SetIdleLabel(label string) {
 	// XXX locking
-	was := c.idleLabel
 	c.idleLabel = label
-	return func() { c.idleLabel = was }
 }
 
 func (c *ConsoleSink) SetStickyContent(name string, content []byte) {

--- a/internal/console/sticky.go
+++ b/internal/console/sticky.go
@@ -10,13 +10,11 @@ import (
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
-func SetIdleLabel(ctx context.Context, label string) func() {
+func SetIdleLabel(ctx context.Context, label string) {
 	unwrapped := UnwrapSink(tasks.SinkFrom(ctx))
 	if t, ok := unwrapped.(consoleLike); ok {
-		return t.SetIdleLabel(label)
+		t.SetIdleLabel(label)
 	}
-
-	return func() {}
 }
 
 func SetStickyContent(ctx context.Context, name string, content []byte) {
@@ -43,7 +41,7 @@ func IsConsoleLike(ctx context.Context) bool {
 }
 
 type consoleLike interface {
-	SetIdleLabel(string) func()
+	SetIdleLabel(string)
 	SetStickyContent(string, []byte)
 	EnterInputMode(context.Context, ...string) func()
 }


### PR DESCRIPTION
motivation:
- the `defer done()` code was racing with us checking the value of `idleLabel`

- as we didn't use "stacking" feature of SetIdleLabel (i.e. allowing later-running code to overwrite the label and reset it back when done) removing this, but we may get back to it later.

fixes #463