### PR TITLE
Make `fn.generate` return non-zero status code when it encounters generation errors

### DIFF
--- a/internal/cli/cmd/generate.go
+++ b/internal/cli/cmd/generate.go
@@ -48,7 +48,14 @@ func NewGenerateCmd() *cobra.Command {
 				return err
 			}
 			// Generate code.
-			return codegen.ForLocationsGenCode(ctx, root, list.Locations, codegenMultiErr.Append)
+			err = codegen.ForLocationsGenCode(ctx, root, list.Locations, codegenMultiErr.Append)
+			if err != nil {
+				return err
+			}
+			if !codegenMultiErr.IsEmpty() {
+				return codegenMultiErr
+			}
+			return nil
 		}),
 	}
 

--- a/internal/fnerrors/codegenerror.go
+++ b/internal/fnerrors/codegenerror.go
@@ -67,6 +67,13 @@ func (c *CodegenMultiError) Append(generr CodegenError) {
 	c.mu.Unlock()
 }
 
+func (c *CodegenMultiError) IsEmpty() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.errs) == 0
+}
+
 func (c *CodegenMultiError) addCommonError(error error, err1 CodegenError, err2 CodegenError) {
 	_, has := c.commonerrs[error]
 	if !has {


### PR DESCRIPTION
Previously major (unexpected) errors were respected, but "expected" generation-level errors were collected separately, reported on the screen and not treated as fatal.