### PR TITLE
Split CodegenMultiError into a thread-safe error collector and an immutable CodegenMultiError

### DIFF
--- a/internal/cli/cmd/source/create/extension.go
+++ b/internal/cli/cmd/source/create/extension.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
-	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/fnfs"
@@ -50,15 +49,20 @@ func newExtensionCmd() *cobra.Command {
 				return err
 			}
 
-			codegenMultiErr := fnerrors.NewCodegenMultiError()
 			// Aggregates and prints all accumulated codegen errors on return.
-			defer fnerrors.Format(console.Stderr(ctx), codegenMultiErr, fnerrors.WithColors(true))
+			errorCollector := fnerrors.ErrorCollector{}
 
 			// Generate protos before generating code for this extension as code (our generated code may depend on the protos).
-			if err := codegen.ForLocationsGenProto(ctx, root, []fnfs.Location{loc}, codegenMultiErr.Append); err != nil {
+			if err := codegen.ForLocationsGenProto(ctx, root, []fnfs.Location{loc}, errorCollector.Append); err != nil {
 				return err
 			}
-			return codegen.ForLocationsGenCode(ctx, root, []fnfs.Location{loc}, codegenMultiErr.Append)
+			if err := codegen.ForLocationsGenCode(ctx, root, []fnfs.Location{loc}, errorCollector.Append); err != nil {
+				return err
+			}
+			if !errorCollector.IsEmpty() {
+				return errorCollector.Build()
+			}
+			return nil
 		}),
 	}
 

--- a/internal/fnerrors/errors.go
+++ b/internal/fnerrors/errors.go
@@ -413,11 +413,6 @@ func formatCodegenError(w io.Writer, err *CodegenError, opts *FormatOptions) {
 }
 
 func formatCodegenMultiError(w io.Writer, err *CodegenMultiError, opts *FormatOptions) {
-	err.mu.Lock()
-	defer err.mu.Unlock()
-
-	err.aggregateErrors()
-
 	// Print aggregated errors.
 	for commonErr, whatpkgs := range err.commonerrs {
 		for what, pkgs := range whatpkgs {
@@ -436,15 +431,7 @@ func formatCodegenMultiError(w io.Writer, err *CodegenMultiError, opts *FormatOp
 			fmt.Fprintf(w, "%s at phase [%s] for package(s) %s\n", commonErr.Error(), phase, pkgnamesdisplay)
 		}
 	}
-	// Print all unique CodegenErrors that don't have a common root.
-	var uniqgenerrs []CodegenError
-	for _, generr := range err.errs {
-		_, duplicate := err.duplicateerrs[generr.fingerprint()]
-		if !duplicate {
-			uniqgenerrs = append(uniqgenerrs, generr)
-		}
-	}
-	for _, generr := range uniqgenerrs {
+	for _, generr := range err.uniqgenerrs {
 		formatCodegenError(w, &generr, opts)
 	}
 }


### PR DESCRIPTION
This separates the concerns and avoids reclassifying the errors in CodegenMultiError at every read.