### PR TITLE
WIP: Import gloo and install directly

### DIFF
--- a/internal/cli/cmd/prepare.go
+++ b/internal/cli/cmd/prepare.go
@@ -31,7 +31,7 @@ var deprecatedConfigs = []string{
 }
 
 func NewPrepareCmd() *cobra.Command {
-	var dontUpdateDevhost, force bool
+	var dontUpdateDevhost, force, enableGloo bool
 	var contextName string
 	var awsProfile string
 
@@ -45,6 +45,7 @@ func NewPrepareCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&force, "force", "f", force, "Skip checking if the configuration is changing.")
 	cmd.Flags().StringVar(&contextName, "context", "", "If set, configures Foundation to use the specific context.")
 	cmd.Flags().StringVar(&awsProfile, "aws_profile", awsProfile, "Configures the specified AWS configuration profile.")
+	cmd.Flags().BoolVarP(&enableGloo, "enable_gloo", "", enableGloo, "Installs the gloo gateway if true.")
 
 	return fncobra.CmdWithEnv(cmd, func(ctx context.Context, env provision.Env, args []string) error {
 		var prepares []compute.Computable[[]*schema.DevHost_ConfigureEnvironment]
@@ -99,6 +100,10 @@ func NewPrepareCmd() *cobra.Command {
 			}
 
 			prepares = append(prepares, prepare.PrepareAWSRegistry(env)) // XXX make provider configurable.
+		}
+
+		if enableGloo {
+			prepares = append(prepares, prepare.PrepareGloo(env))
 		}
 
 		prepares = append(prepares, prepare.PrepareIngress(env, k8sconfig))

--- a/internal/prepare/gloo.go
+++ b/internal/prepare/gloo.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the EARLY ACCESS SOFTWARE LICENSE AGREEMENT
+// available at http://github.com/namespacelabs/foundation
+
+package prepare
+
+import (
+	"context"
+
+	"namespacelabs.dev/foundation/internal/engine/ops"
+	"namespacelabs.dev/foundation/runtime/gloo"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/workspace/compute"
+	"namespacelabs.dev/foundation/workspace/tasks"
+)
+
+func PrepareGloo(env ops.Environment) compute.Computable[[]*schema.DevHost_ConfigureEnvironment] {
+	return compute.Map(
+		tasks.Action("prepare.gloo").HumanReadablef("Preparing the gloo gateway"),
+		compute.Inputs().Proto("env", env.Proto()),
+		compute.Output{NotCacheable: true},
+		func(ctx context.Context, _ compute.Resolved) ([]*schema.DevHost_ConfigureEnvironment, error) {
+			if err := gloo.Install(ctx); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		})
+}

--- a/runtime/gloo/install.go
+++ b/runtime/gloo/install.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the EARLY ACCESS SOFTWARE LICENSE AGREEMENT
+// available at http://github.com/namespacelabs/foundation
+
+package gloo
+
+import (
+	"context"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+)
+
+// Install sets up the gloo gateway on Kubernetes.
+func Install(ctx context.Context) error {
+	helmClient := install.DefaultHelmClient()
+	installer := install.NewInstaller(helmClient)
+	mode := install.Gloo
+	if err := installer.Install(&install.InstallerConfig{
+		Mode: mode,
+		Ctx:  ctx,
+	}); err != nil {
+		return fnerrors.InternalError("failed to install gloo: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
See conflicting k8s imports:

```
go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install imports
  go mod tidy   helm.sh/helm/v3/pkg/action imports
  go mod tidy   helm.sh/helm/v3/pkg/kube imports
  go mod tidy   k8s.io/kubectl/pkg/cmd/util imports
  go mod tidy   k8s.io/client-go/scale tested by
  go mod tidy   k8s.io/client-go/scale.test imports
  go mod tidy   k8s.io/apimachinery/pkg/api/testing/roundtrip: module k8s.io/apimachinery@latest found (v0.24.1), but does not contain package k8s.io/apimachinery/pkg/api/testing/roundtrip
  go mod tidy namespacelabs.dev/foundation/runtime/gloo imports
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install tested by
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install.test imports
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils imports
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd imports
  go mod tidy   k8s.io/kubectl/pkg/cmd imports
  go mod tidy   k8s.io/kubectl/pkg/cmd/create imports
  go mod tidy   k8s.io/client-go/kubernetes/typed/policy/v1: package k8s.io/client-go/kubernetes/typed/policy/v1 provided by k8s.io/client-go at latest version v0.24.1 but not at required version v8.0.0+incompatible
  go mod tidy namespacelabs.dev/foundation/runtime/gloo imports
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install tested by
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install.test imports
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils imports
  go mod tidy   github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd imports
  go mod tidy   k8s.io/kubectl/pkg/cmd imports
  go mod tidy   k8s.io/kubectl/pkg/cmd/create imports
  go mod tidy   k8s.io/client-go/kubernetes/typed/scheduling/v1: package k8s.io/client-go/kubernetes/typed/scheduling/v1 provided by k8s.io/client-go at latest version v0.24.1 but not at required version v8.0.0+incompatible
```