### PR TITLE
std/grpc/httptranscoding: introduce package which represents the http/grpc transcoding.

### DIFF
--- a/languages/golang/golang.go
+++ b/languages/golang/golang.go
@@ -232,8 +232,12 @@ func (impl) PostParseServer(ctx context.Context, sealed *workspace.Sealed) error
 		}
 	}
 
-	if runtime.UseGoInternalGrpcGateway && needGatewayCount > 0 && !sealed.HasDep(gatewayNode) {
-		return fnerrors.UserError(sealed.Location, "server exposes gRPC services as HTTP, it must depend on %s", gatewayNode)
+	if needGatewayCount > 0 {
+		if !sealed.HasDep(runtime.GrpcHttpTranscodeNode) {
+			if runtime.UseGoInternalGrpcGateway && !sealed.HasDep(gatewayNode) {
+				return fnerrors.UserError(sealed.Location, "server exposes gRPC services as HTTP, it must depend on %s", gatewayNode)
+			}
+		}
 	}
 
 	if len(sealed.Proto.Server.UrlMap) > 0 && !sealed.HasDep(httpNode) {

--- a/runtime/grpcgateway.go
+++ b/runtime/grpcgateway.go
@@ -12,6 +12,8 @@ import (
 	"namespacelabs.dev/foundation/schema"
 )
 
+const GrpcHttpTranscodeNode schema.PackageName = "namespacelabs.dev/foundation/std/grpc/httptranscoding"
+
 var (
 	UseGoInternalGrpcGateway = true
 )

--- a/std/grpc/httptranscoding/extension.cue
+++ b/std/grpc/httptranscoding/extension.cue
@@ -1,0 +1,15 @@
+import (
+	"namespacelabs.dev/foundation/std/fn"
+	"namespacelabs.dev/foundation/std/fn:inputs"
+)
+
+// This extension represents a std/networking/gateway-based transcoding setup.
+extension: fn.#Extension & {}
+
+$gateway: inputs.#Server & {
+	packageName: "namespacelabs.dev/foundation/std/networking/gateway/server"
+}
+
+configure: fn.#Configure & {
+	stack: append: [$gateway]
+}

--- a/std/testdata/server/gogrpc/server.cue
+++ b/std/testdata/server/gogrpc/server.cue
@@ -10,6 +10,8 @@ server: fn.#Server & {
 
 	import: [
 		"namespacelabs.dev/foundation/std/go/grpc/gateway",
+		// Work in progress: replace std/go/grpc/gateway with package below.
+		// "namespacelabs.dev/foundation/std/grpc/httptranscoding",
 		"namespacelabs.dev/foundation/std/testdata/service/post",
 		"namespacelabs.dev/foundation/std/grpc/logging",
 		"namespacelabs.dev/foundation/std/monitoring/tracing/jaeger",


### PR DESCRIPTION
This is a step towards replacing the builtin gateway support within Go servers.
Depending on std/grpc/httptranscoding disables that builtin support. Although
this new package still does not yet configure the gateway.
