### PR TITLE
Node.js: exporting "@grpc/grpc-js" from "grpcgen" so the user doesn't…

### DIFF
--- a/languages/nodejs/grpcgen/templates.go
+++ b/languages/nodejs/grpcgen/templates.go
@@ -84,7 +84,7 @@ const wrapped{{.Name}}ClientConstructor = grpc.makeGenericClientConstructor({{.N
 ` +
 			`{{define "File"}}// This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 
 {{- template "Imports" .Imports}}
 {{- if .Opts.GenClients}}

--- a/languages/nodejs/grpcgen/tests/.snapshots/tests-assertCodegen-test1.proto-clients.ts.generated
+++ b/languages/nodejs/grpcgen/tests/.snapshots/tests-assertCodegen-test1.proto-clients.ts.generated
@@ -1,6 +1,6 @@
 // This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 import * as i0 from "./test1_pb";
 import * as i1 from "./nested/test2_pb";
 import {adaptClient, CallOptions} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/client";

--- a/languages/nodejs/grpcgen/tests/.snapshots/tests-assertCodegen-test1.proto-servers-clients.ts.generated
+++ b/languages/nodejs/grpcgen/tests/.snapshots/tests-assertCodegen-test1.proto-servers-clients.ts.generated
@@ -1,6 +1,6 @@
 // This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 import * as i0 from "./test1_pb";
 import * as i1 from "./nested/test2_pb";
 import {adaptClient, CallOptions} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/client";

--- a/languages/nodejs/grpcgen/tests/.snapshots/tests-assertCodegen-test1.proto-servers.ts.generated
+++ b/languages/nodejs/grpcgen/tests/.snapshots/tests-assertCodegen-test1.proto-servers.ts.generated
@@ -1,6 +1,6 @@
 // This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 import * as i0 from "./test1_pb";
 import * as i1 from "./nested/test2_pb";
 import {CallContext} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/server";

--- a/languages/nodejs/testdata/services/numberformatter/service_grpc.fn.ts
+++ b/languages/nodejs/testdata/services/numberformatter/service_grpc.fn.ts
@@ -1,6 +1,6 @@
 // This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 import * as i0 from "./service_pb";
 import {adaptClient, CallOptions} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/client";
 import {CallContext} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/server";

--- a/languages/nodejs/testdata/services/postuser/service_grpc.fn.ts
+++ b/languages/nodejs/testdata/services/postuser/service_grpc.fn.ts
@@ -1,6 +1,6 @@
 // This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 import * as i0 from "./service_pb";
 import {adaptClient, CallOptions} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/client";
 import {CallContext} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/server";

--- a/languages/nodejs/testdata/services/simple/service_grpc.fn.ts
+++ b/languages/nodejs/testdata/services/simple/service_grpc.fn.ts
@@ -1,6 +1,6 @@
 // This file was automatically generated.
 
-import * as grpc from "@grpc/grpc-js";
+import {grpc} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen";
 import * as i0 from "./service_pb";
 import {adaptClient, CallOptions} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/client";
 import {CallContext} from "@namespacelabs.dev-foundation/std-nodejs-grpcgen/server";

--- a/std/nodejs/grpcgen/index.ts
+++ b/std/nodejs/grpcgen/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the EARLY ACCESS SOFTWARE LICENSE AGREEMENT
+// available at http://github.com/namespacelabs/foundation
+
+// Exporting grpc so the user doesn't need to depend on @grpc/grpc-js in addition to this package.
+export * as grpc from "@grpc/grpc-js";


### PR DESCRIPTION
… need to depend on @grpc/grpc-js explicitly.