### PR TITLE
Gateway envoy controller: robust SIGTERM/SIGINT handling

### DIFF
--- a/std/networking/gateway/controller/xdsserver.go
+++ b/std/networking/gateway/controller/xdsserver.go
@@ -7,12 +7,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"namespacelabs.dev/foundation/internal/fnerrors"
 
 	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -21,7 +21,9 @@ import (
 	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
 	runtimeservice "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
 	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/test/v3"
 )
 
 const (
@@ -31,19 +33,12 @@ const (
 	grpcMaxConcurrentStreams = 1000000
 )
 
-func registerServer(grpcServer *grpc.Server, server server.Server) {
-	// register services
-	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
-	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
-	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
-	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
-	secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, server)
-	runtimeservice.RegisterRuntimeDiscoveryServiceServer(grpcServer, server)
+type XdsServer struct {
+	grpcServer *grpc.Server
+	xdsServer  server.Server
 }
 
-// RunXdsServer starts an xDS server at the given port.
-func RunXdsServer(ctx context.Context, srv server.Server, port uint) error {
+func NewXdsServer(ctx context.Context, snapshotCache cache.SnapshotCache, logger Logger) *XdsServer {
 	// gRPC golang library sets a very small upper bound for the number gRPC/h2
 	// streams over a single TCP connection. If a proxy multiplexes requests over
 	// a single connection to the management server, then it might lead to
@@ -60,18 +55,59 @@ func RunXdsServer(ctx context.Context, srv server.Server, port uint) error {
 			PermitWithoutStream: true,
 		}),
 	)
-	grpcServer := grpc.NewServer(grpcOptions...)
+	cb := &test.Callbacks{Debug: logger.Debug}
 
+	return &XdsServer{
+		grpcServer: grpc.NewServer(grpcOptions...),
+		xdsServer:  server.NewServer(ctx, snapshotCache, cb),
+	}
+}
+
+func (x *XdsServer) RegisterServices() {
+	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+	endpointservice.RegisterEndpointDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+	clusterservice.RegisterClusterDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+	routeservice.RegisterRouteDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+	listenerservice.RegisterListenerDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+	secretservice.RegisterSecretDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+	runtimeservice.RegisterRuntimeDiscoveryServiceServer(x.grpcServer, x.xdsServer)
+}
+
+// Serve serves the GRPC endpoint on the given port, returning only when it fails or is stopped.
+func (x *XdsServer) Serve(port uint) error {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		return err
+		return fnerrors.InternalError("xDS server failed to listen on %d: %w", port, err)
 	}
 
-	registerServer(grpcServer, srv)
-
-	log.Printf("xDS envoy control plane server listening on %d\n", port)
-	if err = grpcServer.Serve(lis); err != nil {
-		return err
+	if err = x.grpcServer.Serve(lis); err != nil {
+		return fnerrors.InternalError("failed to run the xDS server control loop on %d: %w", port, err)
 	}
+
 	return nil
+}
+
+// Stop requests a graceful stop of the xDS GRPC server.
+func (x *XdsServer) Stop() {
+	x.grpcServer.GracefulStop()
+}
+
+// Start runs the xDRS GRPC server on the given port, returning
+// only when the server is stopped by the context closing, or when
+// it fails.
+func (x *XdsServer) Start(ctx context.Context, port uint) error {
+	errChan := make(chan error)
+
+	go func() {
+		errChan <- x.Serve(port)
+	}()
+
+	select {
+	case <-ctx.Done():
+		<-errChan // Wait for Serve to return.
+		x.Stop()
+		return ctx.Err()
+	case err := <-errChan:
+		return err
+	}
 }


### PR DESCRIPTION
-  Use a context which is canceled on SIGTERM or SIGINT for the controller flow
- Introduce `XdsServer` that wraps the xDS grpc server as well as the envoy control planer server with lifecycle management APIs in addition to respecting context cancelation.
- Run the `XdsServer` and the `ControllerManager` as go-routines that respect context cancelation. 
- Improve logging of the sidecar handler 

part of #85 

**Improved sidecar logging**

![sidecar-container-logging](https://user-images.githubusercontent.com/102962107/173194706-4673adc9-da62-442a-a408-7595012eefa1.png)

**Verified envoy**

![envoy-logging](https://user-images.githubusercontent.com/102962107/173194704-8531658b-4b30-46ec-957b-c0bfc334a806.png)

Signal handling code for reference:

```go
func SetupSignalHandler() context.Context {
	close(onlyOneSignalHandler) // panics when called twice

	ctx, cancel := context.WithCancel(context.Background())

	c := make(chan os.Signal, 2)
	signal.Notify(c, shutdownSignals...)
	go func() {
		<-c
		cancel()
		<-c
		os.Exit(1) // second signal. Exit directly.
	}()

	return ctx
}
```