### PR TITLE
Ensure `fnerrors.Wrapf` preserves the root cause

### DIFF
--- a/internal/fnerrors/errors.go
+++ b/internal/fnerrors/errors.go
@@ -420,11 +420,11 @@ func formatDependencyFailedError(w io.Writer, err *DependencyFailedError, opts *
 func formatUserError(w io.Writer, err *userError, opts *FormatOptions) {
 	what := err.What
 	if len(what) > 0 {
-		what = ": " + what
+		what = what + ": "
 	}
 	if err.Location != nil {
 		loc := formatLabel(err.Location.ErrorLocation(), opts.colors)
-		fmt.Fprintf(w, "%s%s: %s\n", loc, what, err.Err.Error())
+		fmt.Fprintf(w, "%s%s at %s\n", what, err.Err.Error(), loc)
 	} else {
 		fmt.Fprintf(w, "%s%s\n", what, err.Err.Error())
 	}


### PR DESCRIPTION
This preserves the original cause of the error as in the screenshot below

```go
return fnerrors.UsageError("Run `fn tidy`.", "%s: missing entry in %s: run:\n  fn tidy", packageName, pl.workspaceData.DefinitionFile())
```
**With the change**

![usage-error](https://user-images.githubusercontent.com/102962107/173428865-75f0670d-b6b1-4883-924e-fdf907dbd56d.png)

**Current behavior**

![current-behavior](https://user-images.githubusercontent.com/102962107/173429201-7ba1affa-c4be-4bb5-8e8f-0677d8eccef0.png)

Part of #599 

*Existing call sites of wrapf*

![wrapf](https://user-images.githubusercontent.com/102962107/173433946-9976bcb3-49bf-4274-978f-050813e3aa27.png)



