### PR TITLE
Envoy: shared memory conflict prevention

### DIFF
--- a/std/networking/gateway/server/configure/main.go
+++ b/std/networking/gateway/server/configure/main.go
@@ -135,7 +135,7 @@ func (configuration) Apply(ctx context.Context, req configure.StackRequest, out 
 	envoyArgs := []string{"-c", filepath.Join("/config/", filename)}
 	// Envoy uses shared memory regions during hot restarts and this flag guarantees that
 	// shared memory regions do not conflict when there are multiple running Envoy instances
-	// on the same machine.
+	// on the same machine. See https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-use-dynamic-base-id.
 	envoyArgs = append(envoyArgs, "--use-dynamic-base-id")
 
 	out.Extensions = append(out.Extensions, kubedef.ExtendContainer{


### PR DESCRIPTION
Envoy uses shared memory regions during hot restarts and this guarantees that they do not conflict when there are multiple envoys on the same machine.

https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-base-id