### PR TITLE
Introduce `--disable_command_bundle` for `fn lsp`

### DIFF
--- a/internal/cli/fncobra/cmdbundle.go
+++ b/internal/cli/fncobra/cmdbundle.go
@@ -34,12 +34,8 @@ func (c *CommandBundle) RemoveStaleCommands() error {
 }
 
 // RegisterCommand writes invocation information about the command to the bundle.
-func (c *CommandBundle) RegisterCommand(ctx context.Context, cmd *cobra.Command, args []string) error {
-	err := c.bundle.WriteInvocationInfo(cmd.Context(), cmd, args)
-	if err != nil {
-		return err
-	}
-	return nil
+func (c *CommandBundle) RegisterCommand(cmd *cobra.Command, args []string) error {
+	return c.bundle.WriteInvocationInfo(cmd.Context(), cmd, args)
 }
 
 func (c *CommandBundle) CreateActionStorer(ctx context.Context, flushLogs func()) *tasks.Storer {

--- a/internal/cli/fncobra/main.go
+++ b/internal/cli/fncobra/main.go
@@ -128,7 +128,7 @@ func DoMain(name string, registerCommands func(*cobra.Command)) {
 
 	rootCmd := newRoot(name, func(cmd *cobra.Command, args []string) error {
 		if cmdBundle != nil {
-			if err := cmdBundle.RegisterCommand(ctx, cmd, args); err != nil {
+			if err := cmdBundle.RegisterCommand(cmd, args); err != nil {
 				return err
 			}
 			tasks.ActionStorer = cmdBundle.CreateActionStorer(cmd.Context(), flushLogs)


### PR DESCRIPTION
Simplified main.go by extracting out this facade. 

![verified](https://user-images.githubusercontent.com/102962107/174829484-b068351f-0ebf-42f4-9d54-2ee3fe7038d7.png)
