### PR TITLE
`ns` installation script for Linux, mac OS X, WSL

### DIFF
--- a/install/install_ns.sh
+++ b/install/install_ns.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-VERSION="0.0.43"
+VERSION="0.0.44"
 
 is_wsl() {
 	case "$(uname -r)" in
@@ -41,10 +41,10 @@ do_install() {
         ;;    
 		  
       --*)
-	    echo "Illegal option $1"
-		;;
-  	esac
-	  shift $(( $# > 0 ? 1 : 0 ))
+        echo "Illegal option $1"
+        ;;
+    esac
+    shift $(( $# > 0 ? 1 : 0 ))
   done
 
   if [ -z "$version" ]; then


### PR DESCRIPTION
Supports `--dry_run` and overriding the version with `-v/--version`:

![nscli](https://user-images.githubusercontent.com/102962107/176964800-230b7dd9-023a-4ffc-ad19-762fdf9305b9.gif)

Closes https://github.com/namespacelabs/foundation/issues/648 

**References**

https://github.com/docker/docker-install/blob/master/install.sh 

