### PR TITLE
`ns prepare eks`: polished k8s integration

### DIFF
--- a/internal/prepare/k8s.go
+++ b/internal/prepare/k8s.go
@@ -10,15 +10,36 @@ import (
 	"namespacelabs.dev/foundation/internal/engine/ops"
 	"namespacelabs.dev/foundation/runtime/kubernetes/client"
 	"namespacelabs.dev/foundation/workspace/compute"
+	"namespacelabs.dev/foundation/workspace/devhost"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
-func PrepareExistingK8s(contextName string, env ops.Environment) compute.Computable[*client.HostConfig] {
+type PrepareK8sOptions struct {
+	contextName string
+}
+
+type PrepareK8sOption func(*PrepareK8sOptions)
+
+func WithK8sContextName(contextName string) PrepareK8sOption {
+	return func(options *PrepareK8sOptions) {
+		options.contextName = contextName
+	}
+}
+
+func PrepareExistingK8s(env ops.Environment, args ...PrepareK8sOption) compute.Computable[*client.HostConfig] {
 	return compute.Map(
 		tasks.Action("prepare.existing-k8s").HumanReadablef("Prepare a host-configured Kubernetes instance"),
-		compute.Inputs().Str("contextName", contextName).Proto("env", env.Proto()),
+		compute.Inputs().Proto("env", env.Proto()),
 		compute.Output{NotCacheable: true},
 		func(ctx context.Context, _ compute.Resolved) (*client.HostConfig, error) {
-			return client.NewHostConfig(contextName, env)
+			opts := &PrepareK8sOptions{}
+			for _, opt := range args {
+				opt(opts)
+			}
+			if opts.contextName != "" {
+				return client.NewHostConfig(opts.contextName, env)
+			} else {
+				return client.ComputeHostConfig(env.DevHost(), devhost.ByEnvironment(env.Proto()))
+			}
 		})
 }


### PR DESCRIPTION
- Avoid `cobra.ExactArgs(1)` in favor of an explicit args function impl with a better error message if the cluster is missing
- Use the options pattern and `WithK8sClusterName`