### PR TITLE
telemetry: respect `api_endpoint` overrides

### DIFF
--- a/internal/cli/fncobra/main.go
+++ b/internal/cli/fncobra/main.go
@@ -456,6 +456,9 @@ func setupViper() {
 	viper.SetDefault("enable_pprof", false)
 	_ = viper.BindEnv("enable_pprof")
 
+	viper.SetDefault("api_endpoint", "https://api.namespacelabs.net")
+	_ = viper.BindEnv("api_endpoint")
+
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			log.Fatal(err)

--- a/internal/fnapi/fnapi.go
+++ b/internal/fnapi/fnapi.go
@@ -18,10 +18,6 @@ import (
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
-func init() {
-	viper.SetDefault("api_endpoint", "https://api.namespacelabs.net")
-}
-
 func callProdAPI(ctx context.Context, method string, req interface{}, handle func(dec *json.Decoder) error) error {
 	endpoint := viper.GetString("api_endpoint")
 	return tasks.Action("fnapi.call").LogLevel(2).Arg("endpoint", endpoint).Arg("method", method).Arg("request", req).Run(ctx, func(ctx context.Context) error {

--- a/internal/fnapi/telemetry.go
+++ b/internal/fnapi/telemetry.go
@@ -47,7 +47,7 @@ func NewTelemetry() *Telemetry {
 	return &Telemetry{
 		UseTelemetry:   true,
 		errorLogging:   false,
-		backendAddress: "https://api.namespacelabs.net",
+		backendAddress: viper.GetString("api_endpoint"),
 		makeClientID:   generateClientIDAndSalt,
 	}
 }


### PR DESCRIPTION
Verified with

`NS_API_ENDPOINT=http://127.0.0.1 nsdev build` against a local internal server hosting telemetry. Without this, there is no way to override it currently. 

![telemetry](https://user-images.githubusercontent.com/102962107/176490993-dcdfd306-b52f-4d5c-ad2a-ff71b38a1b85.png)
