### PR TITLE
ns dev: stop swallowing errors from "setWorkspace"

### DIFF
--- a/devworkflow/session.go
+++ b/devworkflow/session.go
@@ -159,7 +159,7 @@ func (s *Session) handleSetWorkspace(parentCtx context.Context, absRoot, envName
 				fnerrors.Format(console.Stderr(parentCtx), err, fnerrors.WithStyle(colors.WithColors))
 			}
 
-			return nil
+			return err
 		})
 	}
 


### PR DESCRIPTION
Error examples:
 - No registry configured in the environment "dev".
 - dev: no kubernetes runtime configuration available.

Closes #38
