### PR TITLE
gateway: configure the k8s event sink with rbac

### DIFF
--- a/std/networking/gateway/server/configure/main.go
+++ b/std/networking/gateway/server/configure/main.go
@@ -120,6 +120,14 @@ func (configuration) Apply(ctx context.Context, req configure.StackRequest, out 
 		WithResources("httpgrpctranscoders", "httpgrpctranscoders/status").
 		WithVerbs("get", "list", "watch", "create", "update", "delete", "patch"))
 
+	// We leverage `record.EventRecorder` from "k8s.io/client-go/tools/record" which
+	// creates `Event` objects with the API group "". This rule ensures that
+	// the event objects created by the controller are accepted by the k8s API server.
+	grant.Rules = append(grant.Rules, rbacv1.PolicyRule().
+		WithAPIGroups("").
+		WithResources("events").
+		WithVerbs("create"))
+
 	if err := grant.Compile(req, out); err != nil {
 		return err
 	}


### PR DESCRIPTION
Also made the code cleaner with `recorder.Eventf`

```
nsdev tools kubectl get event -- --namespace dev-foundation-7l67u
LAST SEEN   TYPE      REASON                     OBJECT                                                                                 MESSAGE
2m12s       Normal    Created                    pod/gateway-sun4qtee50l61888bdj0-77dcffcfbd-zlnc2                                      Created container sidecar-controller
2m12s       Normal    Started                    pod/gateway-sun4qtee50l61888bdj0-77dcffcfbd-zlnc2                                      Started container sidecar-controller
2m12s       Normal    Pulled                     pod/gateway-sun4qtee50l61888bdj0-77dcffcfbd-zlnc2                                      Container image "index.docker.io/envoyproxy/envoy@sha256:478044b54936608dd3115c89ea9fe5be670f1e78d4436927c096b4bc06eeedeb" already present on machine
2m12s       Normal    Created                    pod/gateway-sun4qtee50l61888bdj0-77dcffcfbd-zlnc2                                      Created container gateway
2m12s       Normal    Started                    pod/gateway-sun4qtee50l61888bdj0-77dcffcfbd-zlnc2                                      Started container gateway
2m12s       Normal    CreateHttpGrpcTranscoder   httpgrpctranscoder/std.testdata.service.proto.postservice-7hzne001dff2rpdxav703bwqwc   successfully generated a new envoy snapshot with version 2 for namespace "dev-foundation-7l67u" and name "std.testdata.service.proto.postservice-7hzne001dff2rpdxav703bwqwc"
2m12s       Normal    CreateHttpGrpcTranscoder   httpgrpctranscoder/std.testdata.service.proto.postservice-7hzne001dff2rpdxav703bwqwc   successfully generated a new envoy snapshot with version 3 for namespace "dev-foundation-7l67u" and name "std.testdata.service.proto.postservice-7hzne001dff2rpdxav703bwqwc"
```