### PR TITLE
Excluding files that start with "." in buildkit.

### DIFF
--- a/build/buildkit/build.go
+++ b/build/buildkit/build.go
@@ -88,7 +88,8 @@ type frontendReq struct {
 }
 
 func MakeLocalState(src LocalContents) llb.State {
-	var excludePatterns []string
+	// Exlcluding files starting with ".". Consistent with dirs.IsExcluded
+	excludePatterns := []string{"**/.*/"}
 	for _, dir := range dirs.DirsToExclude {
 		excludePatterns = append(excludePatterns, "**/"+dir+"/")
 	}

--- a/workspace/dirs/constants.go
+++ b/workspace/dirs/constants.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Any sub-directory.
-var DirsToExclude = []string{".git", ".parcel-cache", "node_modules"}
+var DirsToExclude = []string{"node_modules"}
 
 // Relative to the workspace.
 var FilesToExclude = []string{}


### PR DESCRIPTION
For example, ".yarn".