### PR TITLE
transcoder: omit proto fields with defaults

### DIFF
--- a/std/networking/gateway/controller/transcodersnapshot.go
+++ b/std/networking/gateway/controller/transcodersnapshot.go
@@ -350,10 +350,18 @@ func makeHTTPListener(httpConfig httpListenerConfig, transcoders []transcoderWit
 			ProtoDescriptorBin: bytes,
 		},
 		PrintOptions: &grpcjsontranscoder.GrpcJsonTranscoder_PrintOptions{
-			AddWhitespace:              true,
-			AlwaysPrintPrimitiveFields: true,
-			AlwaysPrintEnumsAsInts:     false,
-			PreserveProtoFieldNames:    true,
+			// Whether to add spaces, line breaks and indentation to make the JSON
+			// output easy to read. Defaults to false.
+			AddWhitespace: true,
+			// Ensures that primitive fields with default values will be omitted in the JSON output.
+			// For E.g., an int32 set to 0 or a string set to "".
+			AlwaysPrintPrimitiveFields: false,
+			// Ensures that enums are represented as strings in the JSON output.
+			AlwaysPrintEnumsAsInts: false,
+			// Whether to preserve proto field names. By default protobuf will
+			// generate JSON field names using the ``json_name`` option, or lower camel case,
+			// in that order. Setting this flag will preserve the original field names.
+			PreserveProtoFieldNames: true,
 		},
 	}
 	transcoderpbst, err := anypb.New(transcoderPb)


### PR DESCRIPTION
Addresses #748 

**Verified**

Updated the post response to only set the ID and the response is omitted instead of being printed:

![protodefaults](https://user-images.githubusercontent.com/102962107/177789294-a3db33b9-917c-4e93-b280-0b9a464f50a4.png)
