### PR TITLE
Web: copying the whole module to the build image.

### DIFF
--- a/build/buildkit/computable.go
+++ b/build/buildkit/computable.go
@@ -54,6 +54,8 @@ type LocalContents struct {
 	Module         build.Workspace
 	Path           string
 	ObserveChanges bool
+	// For Web we apply special handling temporarily: not including the root tsconfig.json as it belongs to Node.js
+	TemporaryIsWeb bool
 }
 
 func (l LocalContents) Name() string {

--- a/devworkflow/web/vite.config.ts
+++ b/devworkflow/web/vite.config.ts
@@ -2,13 +2,17 @@
 // Licensed under the EARLY ACCESS SOFTWARE LICENSE AGREEMENT
 // available at http://github.com/namespacelabs/foundation
 
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
-  build: {
-    sourcemap: true,
-  },
+	plugins: [react()],
+	resolve: {
+		// Important to correctly handle ns-managed dependencies.
+		preserveSymlinks: true,
+	},
+	build: {
+		sourcemap: true,
+	},
 });

--- a/internal/nodejs/lockfile.go
+++ b/internal/nodejs/lockfile.go
@@ -87,7 +87,7 @@ func generateLockFileStruct(workspace *schema.Workspace, moduleAbsPath string, r
 	return lock, nil
 }
 
-func generateLockFileStructForBuild(workspace *schema.Workspace) lockFile {
+func generateLockFileStructForBuild(relPath string, workspace *schema.Workspace) (lockFile, error) {
 	lock := lockFile{
 		Modules: map[string]LockFileModule{},
 	}
@@ -99,11 +99,16 @@ func generateLockFileStructForBuild(workspace *schema.Workspace) lockFile {
 		}
 	}
 
-	lock.Modules[workspace.ModuleName] = LockFileModule{
-		Path: ".",
+	moduleRelPath, err := filepath.Rel(relPath, ".")
+	if err != nil {
+		return lockFile{}, err
 	}
 
-	return lock
+	lock.Modules[workspace.ModuleName] = LockFileModule{
+		Path: moduleRelPath,
+	}
+
+	return lock, nil
 }
 
 // Returns the filename

--- a/languages/nodejs/integration/build.go
+++ b/languages/nodejs/integration/build.go
@@ -116,10 +116,13 @@ func (n NodeJsBinary) LLB(ctx context.Context, bnj buildNodeJS, conf build.Confi
 		return llb.State{}, nil, err
 	}
 
-	locals, buildBase, err := nodejs.AddExternalModules(ctx, bnj.workspace, bnj.module, ".", bnj.isFocus, buildBase, bnj.externalModules)
+	local := buildkit.LocalContents{Module: bnj.module, Path: ".", ObserveChanges: bnj.isFocus}
+
+	locals, buildBase, err := nodejs.AddExternalModules(ctx, bnj.workspace, ".", buildBase, bnj.externalModules)
 	if err != nil {
 		return llb.State{}, nil, err
 	}
+	locals = append(locals, local)
 
 	yarnRoot := filepath.Join(appRootPath, bnj.yarnRoot)
 
@@ -133,8 +136,7 @@ func (n NodeJsBinary) LLB(ctx context.Context, bnj buildNodeJS, conf build.Confi
 		return llb.State{}, nil, err
 	}
 
-	// locals[0] represents the module of the package being compiled.
-	src := buildkit.MakeLocalState(locals[0])
+	src := buildkit.MakeLocalState(local)
 	buildBase = buildBase.With(
 		llbutil.CopyFrom(src, bnj.yarnRoot, yarnRoot),
 		yarnInstallAndBuild(*conf.TargetPlatform(), yarnRoot, bnj.isDevBuild))

--- a/languages/web/web.go
+++ b/languages/web/web.go
@@ -152,6 +152,11 @@ func prepareBuild(ctx context.Context, loc workspace.Location, env ops.Environme
 		  return defineConfig({
 			base: process.env.CMD_DEV_BASE || "/",
 
+			resolve: {
+				// Important to correctly handle ns-managed dependencies.
+				preserveSymlinks: true,
+			},
+
 			server: {
 			  watch: {
 				usePolling: true,
@@ -167,7 +172,7 @@ func prepareBuild(ctx context.Context, loc workspace.Location, env ops.Environme
 
 	extra = append(extra, &devwebConfig)
 
-	return viteDevBuild(ctx, env, filepath.Join("/packages", entry.PackageName), loc, isFocus, targetConf, externalModules, extra...)
+	return viteDevBuild(ctx, env, filepath.Join("/packages", loc.Module.ModuleName()), loc, isFocus, targetConf, externalModules, extra...)
 }
 
 func (impl) PrepareDev(ctx context.Context, srv provision.Server) (context.Context, languages.DevObserver, error) {


### PR DESCRIPTION
To support importing files outside of the package.
Fixes `ns build-binary devworkflow/web`.
