### PR TITLE
std/networking/gateway/controller: additionally log events to the console in debug mode

### DIFF
--- a/fn-workspace.cue
+++ b/fn-workspace.cue
@@ -13,7 +13,7 @@ prebuilts: {
 		"namespacelabs.dev/foundation/std/grpc/httptranscoding/configure":                             "sha256:9fcefb7e686ebb9f442dec5bdf65f352c2d5a004fc5408578aebfc9ad06e8bdf"
 		"namespacelabs.dev/foundation/std/monitoring/grafana/tool":                                    "sha256:9e4fbae952218b45c004012b070a56075c2ac52adfd915a962e34a945f3fd78b"
 		"namespacelabs.dev/foundation/std/monitoring/prometheus/tool":                                 "sha256:6fd4b1b41b8fc4e5f51bc111312beaab9fef9bfddb08090c41df1c50aa532e36"
-		"namespacelabs.dev/foundation/std/networking/gateway/controller":                              "sha256:c5cf7f1dc809c8b4c6d498ae3ec4af294172baba1aa45945c7389e9239ff708e"
+		"namespacelabs.dev/foundation/std/networking/gateway/controller":                              "sha256:3e455a18e9dfbdae09a69b319edfb9de1e31b7b2a6a94689f7f3046c89f5e945"
 		"namespacelabs.dev/foundation/std/networking/gateway/server/configure":                        "sha256:65e4e0072a252cdfb915409cd393cbad52a9bc3555e6bd2d93ab57c1c23ddda3"
 		"namespacelabs.dev/foundation/std/runtime/kubernetes/controller/img":                          "sha256:623154594a9edc30038330bef123354dc9c6ef6f74e6470609506d7f78a1f2cf"
 		"namespacelabs.dev/foundation/std/runtime/kubernetes/controller/tool":                         "sha256:93cf715829c24bebdf0876cac64a9d8b3112d13b236d68af88069d1003b32e3f"

--- a/std/networking/gateway/controller/main.go
+++ b/std/networking/gateway/controller/main.go
@@ -183,6 +183,9 @@ func main() {
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
+	if *debug {
+		eventBroadcaster.StartLogging(zapLogger.Sugar().Debugf)
+	}
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events(controllerNamespace)})
 	recorder := eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "http-grpc-transcoder-controller"})
 


### PR DESCRIPTION
Since we use unified zap logging, we bind `Debugf` to the `func` argument of the broadcaster. 

```go
// StartLogging starts sending events received from this EventBroadcaster to the given logging
// function. The return value can be ignored or used to stop recording, if desired.
StartLogging(logf func(format string, args ...interface{})) watch.Interface

if *debug {
    eventBroadcaster.StartLogging(zapLogger.Sugar().Debugf)
}
```

**Verified**

![envoy-debug-events](https://user-images.githubusercontent.com/102962107/178251463-d54d994c-f5d7-45e1-a4d3-f8c28a757f32.png)
