### PR TITLE
envoy: fix the deprecated admin access_log_path warning

### DIFF
--- a/fn-workspace.cue
+++ b/fn-workspace.cue
@@ -14,7 +14,7 @@ prebuilts: {
 		"namespacelabs.dev/foundation/std/monitoring/grafana/tool":                                    "sha256:9e4fbae952218b45c004012b070a56075c2ac52adfd915a962e34a945f3fd78b"
 		"namespacelabs.dev/foundation/std/monitoring/prometheus/tool":                                 "sha256:6fd4b1b41b8fc4e5f51bc111312beaab9fef9bfddb08090c41df1c50aa532e36"
 		"namespacelabs.dev/foundation/std/networking/gateway/controller":                              "sha256:bb2a10edf654472471998c3b4b54210a55b7fb0889946e4d79167ce03a1bcc57"
-		"namespacelabs.dev/foundation/std/networking/gateway/server/configure":                        "sha256:433bf0dc4c080d2a72f154eb940040bb33566434b0a61a0e4ea345534658ccd1"
+		"namespacelabs.dev/foundation/std/networking/gateway/server/configure":                        "sha256:b96970a19e7def5c4bf857ef5437d67dcd99b74e29004fad51541b9efaf2bab7"
 		"namespacelabs.dev/foundation/std/runtime/kubernetes/controller/img":                          "sha256:623154594a9edc30038330bef123354dc9c6ef6f74e6470609506d7f78a1f2cf"
 		"namespacelabs.dev/foundation/std/runtime/kubernetes/controller/tool":                         "sha256:93cf715829c24bebdf0876cac64a9d8b3112d13b236d68af88069d1003b32e3f"
 		"namespacelabs.dev/foundation/std/runtime/kubernetes/kube-state-metrics/configure":            "sha256:d911ccfc7ee483c332ee7838af84aff411aa953b3565e03b23f16fca1df61163"

--- a/std/networking/gateway/server/configure/bootstrap-xds.yaml.tmpl
+++ b/std/networking/gateway/server/configure/bootstrap-xds.yaml.tmpl
@@ -1,6 +1,5 @@
 # Base config for a split xDS management server.
 admin:
-  access_log_path: /dev/null
   address:
     socket_address:
       address: 0.0.0.0


### PR DESCRIPTION
```
Deprecated field: type envoy.config.bootstrap.v3.Admin Using deprecated option 'envoy.config.bootstrap.v3.Admin.access_log_path' from file bootstrap.proto
```

See https://github.com/envoyproxy/envoy/issues/19061 for more context on why removing the field is safe since `/dev/null` is the value. With this change, envoy logs are clean and warning free. 

![envoy-logs](https://user-images.githubusercontent.com/102962107/178495268-28449eff-9ca6-40cb-abdc-dd7e2835c876.png)


