### PR TITLE
provision/tool: support passing through prebuilt image ids directly to the runtime.

### DIFF
--- a/internal/frontend/invocation/invocation.go
+++ b/internal/frontend/invocation/invocation.go
@@ -25,14 +25,15 @@ import (
 )
 
 type Invocation struct {
-	ImageName  string
-	Image      compute.Computable[oci.Image]
-	Command    []string
-	Args       []string
-	Snapshots  []Snapshot
-	WorkingDir string
-	NoCache    bool
-	Inject     []*schema.Invocation_ValueInjection
+	ImageName     string
+	Image         compute.Computable[oci.Image]
+	PublicImageID *oci.ImageID
+	Command       []string
+	Args          []string
+	Snapshots     []Snapshot
+	WorkingDir    string
+	NoCache       bool
+	Inject        []*schema.Invocation_ValueInjection
 }
 
 type Snapshot struct {
@@ -61,12 +62,13 @@ func Make(ctx context.Context, env provision.ServerEnv, serverLocRef *workspace.
 	}
 
 	invocation := &Invocation{
-		ImageName:  bin.Name,
-		Command:    bin.Command,
-		Image:      bin.Image,
-		WorkingDir: with.WorkingDir,
-		NoCache:    with.NoCache,
-		Inject:     with.Inject,
+		ImageName:     bin.Name,
+		Command:       bin.Command,
+		Image:         bin.Image,
+		PublicImageID: binary.PrebuiltImageID(binPkg.Location), // The assumption at the moment is that all prebuilts are public.
+		WorkingDir:    with.WorkingDir,
+		NoCache:       with.NoCache,
+		Inject:        with.Inject,
 	}
 
 	invocation.Args = with.Args

--- a/runtime/docker/invoke.go
+++ b/runtime/docker/invoke.go
@@ -34,6 +34,10 @@ type ToolRuntime struct{}
 
 func Impl() ToolRuntime { return ToolRuntime{} }
 
+func (r ToolRuntime) CanConsumePublicImages() bool {
+	return false // This is not quite true but it's a simplification for now. // XXX support docker pull.
+}
+
 func (r ToolRuntime) Run(ctx context.Context, opts rtypes.RunToolOpts) error {
 	return r.RunWithOpts(ctx, opts, nil)
 }

--- a/runtime/rtypes/rtypes.go
+++ b/runtime/rtypes/rtypes.go
@@ -9,14 +9,14 @@ import (
 	"io"
 	"os"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/console"
 	schema "namespacelabs.dev/foundation/schema"
 )
 
 type RunBinaryOpts struct {
 	WorkingDir string
-	Image      v1.Image
+	Image      oci.Image
 	Command    []string
 	Args       []string
 	Env        []*schema.BinaryConfig_EnvEntry
@@ -24,6 +24,7 @@ type RunBinaryOpts struct {
 }
 
 type RunToolOpts struct {
+	PublicImageID *oci.ImageID // If set, and runtime supports public images, `Image` is ignored.
 	RunBinaryOpts
 	IO
 	ImageName    string

--- a/runtime/tools/toolsruntime.go
+++ b/runtime/tools/toolsruntime.go
@@ -17,6 +17,7 @@ var UseKubernetesRuntime = false
 type Runtime interface {
 	RunWithOpts(context.Context, rtypes.RunToolOpts, func()) error
 	HostPlatform(context.Context) (specs.Platform, error)
+	CanConsumePublicImages() bool // Whether this runtime implementation can use an ImageID directly if one is available.
 }
 
 func Run(ctx context.Context, opts rtypes.RunToolOpts) error {
@@ -30,6 +31,8 @@ func RunWithOpts(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) e
 func HostPlatform(ctx context.Context) (specs.Platform, error) {
 	return impl().HostPlatform(ctx)
 }
+
+func CanConsumePublicImages() bool { return impl().CanConsumePublicImages() }
 
 func impl() Runtime {
 	if UseKubernetesRuntime {


### PR DESCRIPTION
This removes a need to pull from the public registry, and push to ECR.
