### PR TITLE
Migrating "build", "deploy", "dev" and "logs" commands to the unified parsing of servers from args.

### DIFF
--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -31,6 +31,8 @@ func NewBuildCmd() *cobra.Command {
 		explain      = false
 		continuously = false
 		env          provision.Env
+		locs         fncobra.Locations
+		servers      fncobra.Servers
 	)
 
 	return fncobra.
@@ -45,19 +47,12 @@ func NewBuildCmd() *cobra.Command {
 			cmd.Flags().Var(build.BuildPlatformsVar{}, "build_platforms", "Allows the runtime to be instructed to build for a different set of platforms; by default we only build for the development host.")
 			cmd.Flags().BoolVarP(&continuously, "continuously", "c", continuously, "If set to true, builds continuously, listening to changes to the workspace.")
 		}).
-		With(fncobra.ParseEnv(&env)).
+		With(
+			fncobra.ParseEnv(&env),
+			fncobra.ParseLocations(&locs, &fncobra.ParseLocationsOpts{DefaultToAllWhenEmpty: true}),
+			fncobra.ParseServers(&servers, &env, &locs)).
 		DoWithArgs(func(ctx context.Context, args []string) error {
-			serverLocs, specified, err := allServersOrFromArgs(ctx, env, false, args)
-			if err != nil {
-				return err
-			}
-
-			_, servers, err := loadServers(ctx, env, serverLocs, specified)
-			if err != nil {
-				return err
-			}
-
-			_, images, err := deploy.ComputeStackAndImages(ctx, env, servers)
+			_, images, err := deploy.ComputeStackAndImages(ctx, env, servers.Servers)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
#758
