### PR TITLE
Opaque servers: deploy from a Docker file.

### DIFF
--- a/integrations/build.go
+++ b/integrations/build.go
@@ -9,10 +9,12 @@ import (
 
 	"namespacelabs.dev/foundation/build"
 	"namespacelabs.dev/foundation/provision"
+	"namespacelabs.dev/foundation/runtime"
 )
 
 type BuildIntegration interface {
 	PrepareBuild(context.Context, provision.Server) (build.Spec, error)
+	PrepareRun(context.Context, provision.Server, *runtime.ServerRunOpts) error
 }
 
 var (

--- a/integrations/docker/build.go
+++ b/integrations/docker/build.go
@@ -13,6 +13,7 @@ import (
 	"namespacelabs.dev/foundation/integrations"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/provision"
+	"namespacelabs.dev/foundation/runtime"
 	"namespacelabs.dev/foundation/workspace/compute"
 )
 
@@ -45,4 +46,8 @@ func (buildImpl) PrepareBuild(ctx context.Context, server provision.Server) (bui
 	}
 
 	return spec, nil
+}
+
+func (buildImpl) PrepareRun(ctx context.Context, server provision.Server, run *runtime.ServerRunOpts) error {
+	return nil
 }

--- a/internal/cli/cmd/debug/config.go
+++ b/internal/cli/cmd/debug/config.go
@@ -63,7 +63,11 @@ func newComputeConfigCmd() *cobra.Command {
 
 			evald := stack.GetParsed(s.PackageName())
 
-			c, err := startup.ComputeConfig(ctx, s.Env(), evald, sargs)
+			serverStartupPlan, err := s.Startup.EvalStartup(ctx, env, sargs, nil)
+			if err != nil {
+				return err
+			}
+			c, err := startup.ComputeConfig(ctx, s.Env(), serverStartupPlan, evald, sargs)
 			if err != nil {
 				return err
 			}

--- a/provision/server.go
+++ b/provision/server.go
@@ -21,6 +21,7 @@ type Server struct {
 	Package  *workspace.Package
 
 	Provisioning frontend.PreparedProvisionPlan // A provisioning plan that is attached to the server itself.
+	Startup      frontend.PreStartup
 
 	env   ServerEnv            // The environment this server instance is bound to.
 	entry *schema.Stack_Entry  // The stack entry, i.e. all of the server's dependencies.
@@ -92,6 +93,7 @@ func makeServer(ctx context.Context, loader workspace.Packages, env *schema.Envi
 		return Server{}, fnerrors.UserError(t.Location, "servers can't add servers to the stack")
 	}
 
+	t.Startup = pdata.Startup
 	t.Provisioning = pdata.PreparedProvisionPlan
 	t.entry.ServerNaming = pdata.Naming
 

--- a/provision/startup/compute.go
+++ b/provision/startup/compute.go
@@ -14,7 +14,7 @@ import (
 	"namespacelabs.dev/foundation/schema"
 )
 
-func ComputeConfig(ctx context.Context, env ops.Environment, deps []*stack.ParsedNode, info frontend.StartupInputs) (*schema.BinaryConfig, error) {
+func ComputeConfig(ctx context.Context, env ops.Environment, serverStartupPlan *schema.StartupPlan, deps []*stack.ParsedNode, info frontend.StartupInputs) (*schema.BinaryConfig, error) {
 	computed := &schema.BinaryConfig{}
 
 	// For each already loaded configuration, unify the startup args to produce the final startup configuration.
@@ -23,6 +23,8 @@ func ComputeConfig(ctx context.Context, env ops.Environment, deps []*stack.Parse
 			return nil, fnerrors.Wrapf(dep.Package.Location, err, "computing startup config")
 		}
 	}
+
+	mergePlan(serverStartupPlan, computed)
 
 	return computed, nil
 }
@@ -33,15 +35,14 @@ func loadStartupPlan(ctx context.Context, env ops.Environment, dep *stack.Parsed
 		return fnerrors.Wrap(dep.Package.Location, err)
 	}
 
-	return mergePlan(plan, merged)
+	mergePlan(plan, merged)
+	return nil
 }
 
-func mergePlan(plan *schema.StartupPlan, merged *schema.BinaryConfig) error {
+func mergePlan(plan *schema.StartupPlan, merged *schema.BinaryConfig) {
 	merged.Args = append(merged.Args, plan.Args...)
 
 	for k, v := range plan.Env {
 		merged.Env = append(merged.Env, &schema.BinaryConfig_EnvEntry{Name: k, Value: v})
 	}
-
-	return nil
 }


### PR DESCRIPTION
Propagating env vars and args.