### PR TITLE
Opaque: parsing tests.

### DIFF
--- a/integrations/testdata/dockerfile/server.cue
+++ b/integrations/testdata/dockerfile/server.cue
@@ -19,3 +19,10 @@ server: {
 		}
 	}
 }
+
+tests: {
+	// TODO: fix a k8s error when a test name is too long.
+	hello: {
+		build: docker: dockerfile: "test/Dockerfile"
+	}
+}

--- a/integrations/testdata/dockerfile/test/Dockerfile
+++ b/integrations/testdata/dockerfile/test/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.16.1
+
+RUN apk add --no-cache bash
+
+COPY test/test.sh .
+
+RUN chmod 755 test.sh
+
+CMD [ "./test.sh" ]

--- a/integrations/testdata/dockerfile/test/test.sh
+++ b/integrations/testdata/dockerfile/test/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Hello, world!"

--- a/internal/frontend/cuefrontendopaque/phase0.go
+++ b/internal/frontend/cuefrontendopaque/phase0.go
@@ -121,6 +121,15 @@ func (ft Frontend) ParsePackage(ctx context.Context, partial *fncue.Partial, loc
 		}
 	}
 
+	if tests := v.LookupPath("tests"); tests.Exists() {
+		parsedTests, err := parseTests(ctx, ft.loader, loc, tests)
+		if err != nil {
+			return nil, err
+		}
+
+		parsedPkg.Tests = append(parsedPkg.Tests, parsedTests...)
+	}
+
 	if integration := server.LookupPath("integration"); integration.Exists() {
 		if err := parseIntegration(ctx, loc, integration, parsedPkg); err != nil {
 			return nil, err

--- a/internal/frontend/cuefrontendopaque/tests.go
+++ b/internal/frontend/cuefrontendopaque/tests.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the EARLY ACCESS SOFTWARE LICENSE AGREEMENT
+// available at http://github.com/namespacelabs/foundation
+
+package cuefrontendopaque
+
+import (
+	"context"
+
+	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/foundation/internal/frontend/fncue"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/pkggraph"
+	"namespacelabs.dev/foundation/workspace"
+)
+
+type cueTest struct {
+	Servers []string `json:"serversUnderTest"`
+}
+
+func parseTests(ctx context.Context, pl workspace.EarlyPackageLoader, loc pkggraph.Location, v *fncue.CueV) ([]*schema.Test, error) {
+	it, err := v.Val.Fields()
+	if err != nil {
+		return nil, err
+	}
+
+	out := []*schema.Test{}
+
+	for it.Next() {
+		parsedTest, err := parseTest(ctx, pl, loc, it.Label(), (&fncue.CueV{Val: it.Value()}))
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, parsedTest)
+	}
+
+	return out, nil
+}
+
+func parseTest(ctx context.Context, pl workspace.EarlyPackageLoader, loc pkggraph.Location, name string, v *fncue.CueV) (*schema.Test, error) {
+	var bits cueTest
+	if err := v.Val.Decode(&bits); err != nil {
+		return nil, err
+	}
+
+	out := &schema.Test{
+		Name:             name,
+		ServersUnderTest: bits.Servers,
+	}
+
+	if build := v.LookupPath("build"); build.Exists() {
+		cueBuild, err := parseCueBuild(ctx, name, loc, build)
+		if err != nil {
+			return nil, err
+		}
+
+		out.Driver = cueBuild.inlineBinary
+	} else {
+		return nil, fnerrors.UserError(loc, "missing build definition")
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
 - Moving the default Binary.Config.Command generation to the old CUE frontend: for dockerfile/image builds the binary command may be omitted.

Tests are running but don't fully work yet: the Namespace config JSON is not mounted so they can't access the server under test.