### PR TITLE
Making exclude patterns in MakeLocalState customizable.

### DIFF
--- a/internal/cli/cmd/tidy.go
+++ b/internal/cli/cmd/tidy.go
@@ -358,7 +358,7 @@ func listLocations(ctx context.Context, root *workspace.Root) ([]fnfs.Location, 
 		}
 
 		if d.IsDir() {
-			if dirs.IsExcluded(path, d.Name()) {
+			if dirs.IsExcludedAsSource(d.Name()) {
 				return fs.SkipDir
 			}
 			return nil

--- a/internal/nodejs/build.go
+++ b/internal/nodejs/build.go
@@ -19,6 +19,7 @@ import (
 	"namespacelabs.dev/foundation/internal/fnfs/memfs"
 	"namespacelabs.dev/foundation/internal/llbutil"
 	"namespacelabs.dev/foundation/internal/sdk/yarn"
+	"namespacelabs.dev/foundation/languages/nodejs/binary"
 	"namespacelabs.dev/foundation/languages/nodejs/yarnplugin"
 	"namespacelabs.dev/foundation/schema"
 )
@@ -150,7 +151,10 @@ func AddExternalModules(ctx context.Context, workspace *schema.Workspace, rel st
 
 		moduleLocal := buildkit.LocalContents{Module: m, Path: ".", ObserveChanges: false}
 		locals = append(locals, moduleLocal)
-		buildBase = buildBase.With(llbutil.CopyFrom(buildkit.MakeLocalState(moduleLocal), ".", lfModule.Path))
+		localState := buildkit.MakeCustomLocalState(moduleLocal, buildkit.MakeLocalStateOpts{
+			Exclude: binary.NodejsExclude,
+		})
+		buildBase = buildBase.With(llbutil.CopyFrom(localState, ".", lfModule.Path))
 	}
 
 	return locals, buildBase, nil

--- a/internal/wscontents/wscontents.go
+++ b/internal/wscontents/wscontents.go
@@ -111,7 +111,8 @@ func SnapshotDirectory(absPath string) (*memfs.FS, error) {
 		}
 
 		if de.IsDir() {
-			if dirs.IsExcluded(osPathname, de.Name()) {
+			// TODO: use the exclude/include patterns passed as a config instead.
+			if dirs.IsExcludedAsSource(de.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -287,7 +288,8 @@ func (vp *versioned) Observe(ctx context.Context, onChange func(compute.ResultWi
 			return err
 		}
 
-		if dirs.IsExcluded(path, d.Name()) {
+		// TODO: use the exclude/include patterns passed as a config instead.
+		if dirs.IsExcludedAsSource(d.Name()) {
 			if d.IsDir() {
 				return fs.SkipDir
 			}

--- a/languages/nodejs/binary/binary.go
+++ b/languages/nodejs/binary/binary.go
@@ -23,6 +23,10 @@ const (
 	RunScriptPath = appRootPath + "/ns_run_node.sh"
 )
 
+var (
+	NodejsExclude = []string{"**/.yarn", "**/.pnp.*"}
+)
+
 type nodeJsBinary struct {
 	nodejsEnv string
 }
@@ -40,7 +44,9 @@ func (n nodeJsBinary) LLB(ctx context.Context, bnj buildNodeJS, conf build.Confi
 
 	local := buildkit.LocalContents{Module: bnj.loc.Module, Path: bnj.loc.Rel(), ObserveChanges: bnj.isFocus}
 
-	src := buildkit.MakeLocalState(local)
+	src := buildkit.MakeCustomLocalState(local, buildkit.MakeLocalStateOpts{
+		Exclude: NodejsExclude,
+	})
 
 	buildBase = prepareAndRunInstall(ctx, buildBase, src)
 

--- a/languages/web/buildkit.go
+++ b/languages/web/buildkit.go
@@ -103,7 +103,9 @@ func viteBuildBase(ctx context.Context, conf build.BuildTarget, target string, m
 
 	// Use separate layers for node_modules/package.json/yarn.lock, and sources, as the latter change more often.
 	// Copy all package.json files, not only from the given package, to support resolving ns-managed dependencies within the same module.
-	srcForYarn := buildkit.MakeLocalState(local, "**/package.json", "**/yarn.lock")
+	srcForYarn := buildkit.MakeCustomLocalState(local, buildkit.MakeLocalStateOpts{
+		Include: []string{"**/package.json", "**/yarn.lock"},
+	})
 
 	buildBase, err = runYarn(ctx, rel, target, buildBase, srcForYarn, *conf.TargetPlatform())
 	if err != nil {

--- a/workspace/dirs/constants.go
+++ b/workspace/dirs/constants.go
@@ -8,12 +8,22 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Any sub-directory.
-var DirsToExclude = []string{"node_modules"}
+var (
+	// Directories to exlude from source scanning.
+	// Any sub-directory.
+	dirsToExclude = []string{"node_modules"}
 
-// Relative to the workspace.
-var FilesToExclude = []string{}
+	// Patterns to exclude by default when building images. Integrations
+	// (e.g. nodejs) may add additional patterns.
+	BasePatternsToExclude = []string{
+		"**/node_modules/*",
+		"**/.git/*",
+		"**/.parcel-cache/*",
+	}
+)
 
-func IsExcluded(fullPath string, name string) bool {
-	return (len(name) > 1 && name[0] == '.') || slices.Contains(DirsToExclude, name)
+// Returns false if the directory shouldn't be scanned for Namespace source files (.cue, .proto).
+// This doesn't affect the content that is copied to the build image.
+func IsExcludedAsSource(name string) bool {
+	return (len(name) > 1 && name[0] == '.') || slices.Contains(dirsToExclude, name)
 }

--- a/workspace/list.go
+++ b/workspace/list.go
@@ -37,7 +37,7 @@ func ListSchemas(ctx context.Context, env planning.Context, root *Root) (SchemaL
 		}
 
 		if d.IsDir() {
-			if dirs.IsExcluded(path, d.Name()) {
+			if dirs.IsExcludedAsSource(d.Name()) {
 				return fs.SkipDir
 			}
 			return nil

--- a/workspace/source/protos/parse.go
+++ b/workspace/source/protos/parse.go
@@ -200,7 +200,7 @@ func expandProtoList(fsys fs.FS, paths []string) ([]string, error) {
 
 			var children []string
 			for _, dirent := range dirents {
-				if !dirs.IsExcluded(filepath.Join(path, dirent.Name()), dirent.Name()) && (dirent.IsDir() || filepath.Ext(dirent.Name()) == ".proto") {
+				if !dirs.IsExcludedAsSource(dirent.Name()) && (dirent.IsDir() || filepath.Ext(dirent.Name()) == ".proto") {
 					children = append(children, filepath.Join(path, dirent.Name()))
 				}
 			}


### PR DESCRIPTION
So the language-specific integrations may add their own exclude patterns.
Separating "dirs.IsExcluded" from MakeLocalState as its use-cases and behavior are different. Renaming it to "IsExcludedAsSource".
The file sync functionality should be migrated to the "MakeLocalState" patterns, added a TODO.
