### PR TITLE
Accepting "pkggraph.SealedContext" instead of "planning.Context" in "Spec.BuildImage".

### DIFF
--- a/build/binary/genbinary/llbgen.go
+++ b/build/binary/genbinary/llbgen.go
@@ -21,7 +21,6 @@ import (
 	"namespacelabs.dev/foundation/runtime/tools"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/pkggraph"
-	"namespacelabs.dev/foundation/std/planning"
 	"namespacelabs.dev/foundation/workspace/devhost"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
@@ -36,7 +35,7 @@ type llbBinary struct {
 	bin         build.Spec
 }
 
-func (l llbBinary) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (l llbBinary) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	hostPlatform, err := tools.HostPlatform(ctx, env.Configuration())
 	if err != nil {
 		return nil, err

--- a/build/binary/genbinary/nix.go
+++ b/build/binary/genbinary/nix.go
@@ -30,7 +30,7 @@ type nixImage struct {
 	sources     fs.FS
 }
 
-func (l nixImage) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (l nixImage) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	return NixImage(ctx, env.Configuration(), conf, l.sources)
 
 }

--- a/build/binary/merge.go
+++ b/build/binary/merge.go
@@ -11,7 +11,7 @@ import (
 	"namespacelabs.dev/foundation/build"
 	"namespacelabs.dev/foundation/engine/compute"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 )
 
 type mergeSpecs struct {
@@ -19,7 +19,7 @@ type mergeSpecs struct {
 	platformIndependent bool
 }
 
-func (m mergeSpecs) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (m mergeSpecs) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	images := make([]oci.NamedImage, len(m.specs))
 
 	for k, spec := range m.specs {

--- a/build/binary/snapshotfiles.go
+++ b/build/binary/snapshotfiles.go
@@ -13,7 +13,7 @@ import (
 	"namespacelabs.dev/foundation/engine/compute"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/fnfs/memfs"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
@@ -22,7 +22,7 @@ type snapshotFiles struct {
 	globs []string
 }
 
-func (m snapshotFiles) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (m snapshotFiles) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	w := conf.Workspace().VersionedFS(m.rel, true)
 
 	return compute.Map(tasks.Action("binary.snapshot-files"),

--- a/build/buildkit/dfile.go
+++ b/build/buildkit/dfile.go
@@ -16,7 +16,7 @@ import (
 	"namespacelabs.dev/foundation/engine/compute"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/wscontents"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
@@ -43,7 +43,7 @@ func makeDockerfileState(sourceLabel string, contents []byte) llb.State {
 			llb.WithCustomName(fmt.Sprintf("Dockerfile (%s)", sourceLabel)))
 }
 
-func (df dockerfileBuild) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (df dockerfileBuild) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	generatedRequest := &generateRequest{
 		// Setting observeChanges to true will yield a new solve() on changes to the workspace.
 		// Also importantly we scope observe changes to ContextRel.

--- a/build/multiplatform/multiplatform.go
+++ b/build/multiplatform/multiplatform.go
@@ -18,12 +18,12 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/storedrun"
 	"namespacelabs.dev/foundation/schema/storage"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/workspace/devhost"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
-func PrepareMultiPlatformImage(ctx context.Context, env planning.Context, p build.Plan) (compute.Computable[oci.ResolvableImage], error) {
+func PrepareMultiPlatformImage(ctx context.Context, env pkggraph.SealedContext, p build.Plan) (compute.Computable[oci.ResolvableImage], error) {
 	img, err := prepareImage(ctx, env, p)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func prefix(p, label string) string {
 	return p + " " + label
 }
 
-func prepareImage(ctx context.Context, env planning.Context, p build.Plan) (compute.Computable[oci.ResolvableImage], error) {
+func prepareImage(ctx context.Context, env pkggraph.SealedContext, p build.Plan) (compute.Computable[oci.ResolvableImage], error) {
 	if p.Spec.PlatformIndependent() {
 		img, err := p.Spec.BuildImage(ctx, env, build.NewBuildTarget(nil).
 			WithTargetName(p.PublishName).

--- a/build/prebuilt.go
+++ b/build/prebuilt.go
@@ -10,7 +10,7 @@ import (
 	"namespacelabs.dev/foundation/engine/compute"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/schema"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
@@ -38,7 +38,7 @@ type prebuilt struct {
 	opts                oci.ResolveOpts
 }
 
-func (p prebuilt) BuildImage(ctx context.Context, _ planning.Context, conf Configuration) (compute.Computable[oci.Image], error) {
+func (p prebuilt) BuildImage(ctx context.Context, _ pkggraph.SealedContext, conf Configuration) (compute.Computable[oci.Image], error) {
 	return oci.ImageP(p.imgid.ImageRef(), conf.TargetPlatform(), p.opts), nil
 }
 

--- a/build/types.go
+++ b/build/types.go
@@ -15,7 +15,7 @@ import (
 	"namespacelabs.dev/foundation/internal/wscontents"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/schema/storage"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/workspace/devhost"
 )
 
@@ -25,7 +25,7 @@ var (
 )
 
 type Spec interface {
-	BuildImage(context.Context, planning.Context, Configuration) (compute.Computable[oci.Image], error)
+	BuildImage(context.Context, pkggraph.SealedContext, Configuration) (compute.Computable[oci.Image], error)
 	PlatformIndependent() bool
 }
 

--- a/internal/cli/cmd/buildbinary.go
+++ b/internal/cli/cmd/buildbinary.go
@@ -99,6 +99,8 @@ func buildLocations(ctx context.Context, env planning.Context, locs fncobra.Loca
 		return strings.Compare(pkgs[i].PackageName().String(), pkgs[j].PackageName().String()) < 0
 	})
 
+	sealedCtx := pkggraph.MakeSealedContext(env, pl.Seal())
+
 	var imgOpts binary.BuildImageOpts
 	imgOpts.UsePrebuilts = false
 	imgOpts.Platforms = []specs.Platform{docker.HostPlatform()}
@@ -109,12 +111,12 @@ func buildLocations(ctx context.Context, env planning.Context, locs fncobra.Loca
 
 		// TODO: allow to choose what binary to build within a package.
 		for _, b := range pkg.Binaries {
-			bin, err := binary.Plan(ctx, pkg, b.Name, env, imgOpts)
+			bin, err := binary.Plan(ctx, pkg, b.Name, sealedCtx, imgOpts)
 			if err != nil {
 				return err
 			}
 
-			image, err := bin.Image(ctx, env)
+			image, err := bin.Image(ctx, sealedCtx)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/prepare/cmd.go
+++ b/internal/cli/cmd/prepare/cmd.go
@@ -17,7 +17,7 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/prepare"
 	"namespacelabs.dev/foundation/schema"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/workspace"
 	"namespacelabs.dev/foundation/workspace/devhost"
 	"namespacelabs.dev/foundation/workspace/tasks"
@@ -55,14 +55,14 @@ func NewPrepareCmd() *cobra.Command {
 	return rootCmd
 }
 
-func baseline(env planning.Context) []compute.Computable[[]*schema.DevHost_ConfigureEnvironment] {
+func baseline(env pkggraph.SealedContext) []compute.Computable[[]*schema.DevHost_ConfigureEnvironment] {
 	var prepares []compute.Computable[[]*schema.DevHost_ConfigureEnvironment]
 	prepares = append(prepares, prepare.PrepareBuildkit(env))
 	prepares = append(prepares, prebuilts(env)...)
 	return prepares
 }
 
-func prebuilts(env planning.Context) []compute.Computable[[]*schema.DevHost_ConfigureEnvironment] {
+func prebuilts(env pkggraph.SealedContext) []compute.Computable[[]*schema.DevHost_ConfigureEnvironment] {
 	var prebuilts = []schema.PackageName{
 		"namespacelabs.dev/foundation/devworkflow/web",
 		"namespacelabs.dev/foundation/std/dev/controller",

--- a/internal/cli/cmd/prepare/eks.go
+++ b/internal/cli/cmd/prepare/eks.go
@@ -12,7 +12,9 @@ import (
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/prepare"
 	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/workspace"
 	"namespacelabs.dev/foundation/workspace/module"
 )
 
@@ -37,7 +39,9 @@ func newEksCmd() *cobra.Command {
 				return err
 			}
 
-			prepares := baseline(env)
+			sealedCtx := pkggraph.MakeSealedContext(env, workspace.NewPackageLoader(env).Seal())
+
+			prepares := baseline(sealedCtx)
 
 			var aws []compute.Computable[[]*schema.DevHost_ConfigureEnvironment]
 			aws = append(aws, prepare.PrepareAWSProfile(env, awsProfile))

--- a/internal/cli/cmd/prepare/local.go
+++ b/internal/cli/cmd/prepare/local.go
@@ -13,7 +13,9 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/prepare"
 	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/workspace"
 	"namespacelabs.dev/foundation/workspace/module"
 )
 
@@ -40,7 +42,9 @@ func newLocalCmd() *cobra.Command {
 					"Kubernetes context is required for preparing a production environment.")
 			}
 
-			prepares := baseline(env)
+			sealedCtx := pkggraph.MakeSealedContext(env, workspace.NewPackageLoader(env).Seal())
+
+			prepares := baseline(sealedCtx)
 
 			k8sconfig := prepareK8s(ctx, env, contextName)
 			prepares = append(prepares, prepare.PrepareCluster(env, k8sconfig)...)

--- a/internal/cli/cmd/prepare/newcluster.go
+++ b/internal/cli/cmd/prepare/newcluster.go
@@ -10,7 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/prepare"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/workspace"
 	"namespacelabs.dev/foundation/workspace/module"
 )
 
@@ -35,7 +37,9 @@ func newNewClusterCmd() *cobra.Command {
 			return err
 		}
 
-		prepares := baseline(env)
+		sealedCtx := pkggraph.MakeSealedContext(env, workspace.NewPackageLoader(env).Seal())
+
+		prepares := baseline(sealedCtx)
 		prepares = append(prepares, prepare.PrepareCluster(env, prepare.PrepareNewNamespaceCluster(env, *machineType, *ephemeral))...)
 		return collectPreparesAndUpdateDevhost(ctx, root, prepares)
 	})

--- a/internal/cli/cmd/test.go
+++ b/internal/cli/cmd/test.go
@@ -28,6 +28,7 @@ import (
 	"namespacelabs.dev/foundation/runtime"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/schema/storage"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/std/planning"
 	"namespacelabs.dev/foundation/workspace"
 	"namespacelabs.dev/foundation/workspace/tasks"
@@ -113,10 +114,12 @@ func NewTestCmd() *cobra.Command {
 					eg.Go(func(ctx context.Context) error {
 						buildEnv := testing.PrepareEnv(ctx, env, ephemeral)
 
+						sealedCtx := pkggraph.MakeSealedContext(buildEnv, pl.Seal())
+
 						status := style.Header.Apply("BUILDING")
 						fmt.Fprintf(stderr, "%s: Test %s\n", testRef.Canonical(), status)
 
-						testComp, err := testing.PrepareTest(ctx, pl, buildEnv, testRef, testOpts, func(ctx context.Context, pl *workspace.PackageLoader, test *schema.Test) ([]provision.Server, *stack.Stack, error) {
+						testComp, err := testing.PrepareTest(ctx, pl, sealedCtx, testRef, testOpts, func(ctx context.Context, pl *workspace.PackageLoader, test *schema.Test) ([]provision.Server, *stack.Stack, error) {
 							var suts []provision.Server
 
 							for _, pkg := range test.ServersUnderTest {

--- a/internal/debugshell/image.go
+++ b/internal/debugshell/image.go
@@ -16,12 +16,12 @@ import (
 	"namespacelabs.dev/foundation/engine/compute"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/llbutil"
-	"namespacelabs.dev/foundation/std/planning"
+	"namespacelabs.dev/foundation/std/pkggraph"
 )
 
 func BuildSpec() build.Spec { return debugShellBuild{} }
 
-func Image(ctx context.Context, env planning.Context, platforms []specs.Platform, tag compute.Computable[oci.AllocatedName]) (compute.Computable[oci.ImageID], error) {
+func Image(ctx context.Context, env pkggraph.SealedContext, platforms []specs.Platform, tag compute.Computable[oci.AllocatedName]) (compute.Computable[oci.ImageID], error) {
 	prepared, err := multiplatform.PrepareMultiPlatformImage(ctx, env, build.Plan{
 		SourceLabel: "debugshell.image",
 		Spec:        BuildSpec(),
@@ -39,7 +39,7 @@ type debugShellBuild struct{}
 
 var _ build.Spec = debugShellBuild{}
 
-func (debugShellBuild) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (debugShellBuild) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	image := llbutil.Image("ubuntu:20.04@sha256:8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9", *conf.TargetPlatform())
 
 	base := image.

--- a/internal/prepare/prebuilts.go
+++ b/internal/prepare/prebuilts.go
@@ -13,11 +13,10 @@ import (
 	"namespacelabs.dev/foundation/runtime/tools"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/pkggraph"
-	"namespacelabs.dev/foundation/std/planning"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
-func DownloadPrebuilts(env planning.Context, pl pkggraph.PackageLoader, packages []schema.PackageName) compute.Computable[[]oci.Image] {
+func DownloadPrebuilts(env pkggraph.SealedContext, pl pkggraph.PackageLoader, packages []schema.PackageName) compute.Computable[[]oci.Image] {
 	return compute.Map(
 		tasks.Action("prepare.download-prebuilts").HumanReadablef("Download prebuilt package images"),
 		compute.Inputs().Proto("env", env.Environment()).Strs("packages", schema.Strs(packages...)),

--- a/internal/testing/fixture.go
+++ b/internal/testing/fixture.go
@@ -28,7 +28,6 @@ import (
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/schema/storage"
 	"namespacelabs.dev/foundation/std/pkggraph"
-	"namespacelabs.dev/foundation/std/planning"
 	"namespacelabs.dev/foundation/workspace"
 	"namespacelabs.dev/foundation/workspace/source/protos/resolver"
 	"namespacelabs.dev/foundation/workspace/tasks"
@@ -50,7 +49,7 @@ type TestOpts struct {
 
 type LoadSUTFunc func(context.Context, *workspace.PackageLoader, *schema.Test) ([]provision.Server, *stack.Stack, error)
 
-func PrepareTest(ctx context.Context, pl *workspace.PackageLoader, env planning.Context, testRef *schema.PackageRef, opts TestOpts, loadSUT LoadSUTFunc) (compute.Computable[StoredTestResults], error) {
+func PrepareTest(ctx context.Context, pl *workspace.PackageLoader, env pkggraph.SealedContext, testRef *schema.PackageRef, opts TestOpts, loadSUT LoadSUTFunc) (compute.Computable[StoredTestResults], error) {
 	testPkg, err := pl.LoadByName(ctx, testRef.AsPackageName())
 	if err != nil {
 		return nil, err
@@ -274,7 +273,7 @@ type buildAndAttachDataLayer struct {
 	dataLayer oci.NamedLayer
 }
 
-func (b buildAndAttachDataLayer) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (b buildAndAttachDataLayer) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	base, err := b.spec.BuildImage(ctx, env, conf)
 	if err != nil {
 		return nil, err

--- a/languages/golang/gobinary.go
+++ b/languages/golang/gobinary.go
@@ -15,7 +15,6 @@ import (
 	"namespacelabs.dev/foundation/internal/gosupport"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/pkggraph"
-	"namespacelabs.dev/foundation/std/planning"
 	"namespacelabs.dev/foundation/std/planning/knobs"
 )
 
@@ -36,7 +35,7 @@ type GoBinary struct {
 
 var UseBuildKitForBuilding = knobs.Bool("golang_use_buildkit", "If set to true, buildkit is used for building, instead of a ko-style builder.", false)
 
-func (gb GoBinary) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (gb GoBinary) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	if UseBuildKitForBuilding.Get(env.Configuration()) {
 		return buildUsingBuildkit(ctx, env, gb, conf)
 	}

--- a/languages/nodejs/binary/builder.go
+++ b/languages/nodejs/binary/builder.go
@@ -40,7 +40,7 @@ type buildNodeJS struct {
 
 func (buildNodeJS) PlatformIndependent() bool { return false }
 
-func (bnj buildNodeJS) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (bnj buildNodeJS) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	n := nodeJsBinary{
 		nodejsEnv: nodeEnv(env),
 	}

--- a/languages/nodejs/integration/build.go
+++ b/languages/nodejs/integration/build.go
@@ -45,7 +45,7 @@ type buildNodeJS struct {
 	isFocus         bool
 }
 
-func (bnj buildNodeJS) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (bnj buildNodeJS) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	nodeImage, err := pins.CheckDefault("node")
 	if err != nil {
 		return nil, err

--- a/languages/web/static.go
+++ b/languages/web/static.go
@@ -11,7 +11,6 @@ import (
 	"namespacelabs.dev/foundation/engine/compute"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/std/pkggraph"
-	"namespacelabs.dev/foundation/std/planning"
 )
 
 func WebBuilder(loc pkggraph.Location) build.Spec {
@@ -22,7 +21,7 @@ type staticBuild struct {
 	Location pkggraph.Location
 }
 
-func (w staticBuild) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (w staticBuild) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	img, err := ViteProductionBuild(ctx, w.Location, env, conf.SourceLabel(), ".", "/", nil, generateProdViteConfig())
 	if err != nil {
 		return nil, err

--- a/languages/web/web.go
+++ b/languages/web/web.go
@@ -344,7 +344,7 @@ type buildDevServer struct {
 	ingressFragments compute.Computable[[]*schema.IngressFragment]
 }
 
-func (bws buildDevServer) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (bws buildDevServer) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	builds, err := buildWebApps(ctx, conf, bws.ingressFragments, bws.srv, bws.isFocus)
 	if err != nil {
 		return nil, err
@@ -373,7 +373,7 @@ type buildProdWebServer struct {
 	ingressFragments compute.Computable[[]*schema.IngressFragment]
 }
 
-func (bws buildProdWebServer) BuildImage(ctx context.Context, env planning.Context, conf build.Configuration) (compute.Computable[oci.Image], error) {
+func (bws buildProdWebServer) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	builds, err := buildWebApps(ctx, conf, bws.ingressFragments, bws.srv, bws.isFocus)
 	if err != nil {
 		return nil, err

--- a/runtime/tools/invoke.go
+++ b/runtime/tools/invoke.go
@@ -17,12 +17,13 @@ import (
 	"namespacelabs.dev/foundation/provision/tool/protocol"
 	"namespacelabs.dev/foundation/runtime/rtypes"
 	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/pkggraph"
 	"namespacelabs.dev/foundation/std/planning"
 	"namespacelabs.dev/foundation/std/types"
 	"namespacelabs.dev/foundation/workspace/tasks"
 )
 
-func InvokeWithBinary(ctx context.Context, env planning.Context, inv *types.DeferredInvocation, prepared *binary.Prepared) (compute.Computable[*protocol.InvokeResponse], error) {
+func InvokeWithBinary(ctx context.Context, env pkggraph.SealedContext, inv *types.DeferredInvocation, prepared *binary.Prepared) (compute.Computable[*protocol.InvokeResponse], error) {
 	it := &invokeTool{
 		conf:       env.Configuration(),
 		invocation: inv,


### PR DESCRIPTION
This allows to have access to a sealed package loader in "binary.go:buildSpec" and support building a binary from another package as a layer.
