### PR TITLE
Propagating languages.AvailableBuildAssets to "buildSpec" in "build/binary/binary.go".

### DIFF
--- a/build/assets/buildassets.go
+++ b/build/assets/buildassets.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the EARLY ACCESS SOFTWARE LICENSE AGREEMENT
+// available at http://github.com/namespacelabs/foundation
+
+package assets
+
+import (
+	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/schema"
+)
+
+type AvailableBuildAssets struct {
+	IngressFragments compute.Computable[[]*schema.IngressFragment]
+}

--- a/internal/cli/cmd/buildbinary.go
+++ b/internal/cli/cmd/buildbinary.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/artifacts/registry"
@@ -111,7 +112,7 @@ func buildLocations(ctx context.Context, env cfg.Context, locs fncobra.Locations
 
 		// TODO: allow to choose what binary to build within a package.
 		for _, b := range pkg.Binaries {
-			bin, err := binary.Plan(ctx, pkg, b.Name, sealedCtx, imgOpts)
+			bin, err := binary.Plan(ctx, pkg, b.Name, sealedCtx, assets.AvailableBuildAssets{}, imgOpts)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/debugshell.go
+++ b/internal/cli/cmd/debugshell.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/artifacts/registry"
@@ -70,7 +71,7 @@ func NewDebugShellCmd() *cobra.Command {
 
 			sealedCtx := pkggraph.MakeSealedContext(env, pl.Seal())
 
-			prepared, err := binary.Plan(ctx, pkg, binaryRef.Name, sealedCtx, binary.BuildImageOpts{Platforms: platforms, UsePrebuilts: true})
+			prepared, err := binary.Plan(ctx, pkg, binaryRef.Name, sealedCtx, assets.AvailableBuildAssets{}, binary.BuildImageOpts{Platforms: platforms, UsePrebuilts: true})
 			if err != nil {
 				return err
 			}

--- a/internal/planning/deploy/definitions.go
+++ b/internal/planning/deploy/definitions.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/compute"
 	"namespacelabs.dev/foundation/internal/console"
@@ -487,7 +488,7 @@ func makeInvocation(ctx context.Context, env pkggraph.SealedContext, inv *types.
 		return nil, nil, err
 	}
 
-	prepared, err := binary.Plan(ctx, pkg, ref.Name, env, binary.BuildImageOpts{UsePrebuilts: true, Platforms: []specs.Platform{platform}})
+	prepared, err := binary.Plan(ctx, pkg, ref.Name, env, assets.AvailableBuildAssets{}, binary.BuildImageOpts{UsePrebuilts: true, Platforms: []specs.Platform{platform}})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/planning/deploy/resources.go
+++ b/internal/planning/deploy/resources.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/dynamicpb"
 	"google.golang.org/protobuf/types/known/anypb"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/artifacts/registry"
@@ -72,7 +73,7 @@ func planResources(ctx context.Context, sealedCtx pkggraph.SealedContext, planne
 			return nil, err
 		}
 
-		prepared, err := binary.PlanBinary(ctx, sealedCtx, sealedCtx, pkg.Location, bin, binary.BuildImageOpts{
+		prepared, err := binary.PlanBinary(ctx, sealedCtx, sealedCtx, pkg.Location, bin, assets.AvailableBuildAssets{}, binary.BuildImageOpts{
 			UsePrebuilts: true,
 			Platforms:    platforms,
 		})

--- a/internal/planning/invocation/invocation.go
+++ b/internal/planning/invocation/invocation.go
@@ -14,6 +14,7 @@ import (
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/compute"
@@ -68,7 +69,7 @@ func MakeForPlatforms(ctx context.Context, pl pkggraph.SealedPackageLoader, env 
 		return nil, err
 	}
 
-	prepared, err := binary.PlanBinary(ctx, pl, env, pkg.Location, bin, binary.BuildImageOpts{
+	prepared, err := binary.PlanBinary(ctx, pl, env, pkg.Location, bin, assets.AvailableBuildAssets{}, binary.BuildImageOpts{
 		UsePrebuilts: true,
 		Platforms:    target,
 	})

--- a/internal/prepare/prebuilts.go
+++ b/internal/prepare/prebuilts.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/compute"
@@ -47,7 +48,7 @@ func DownloadPrebuilts(env pkggraph.SealedContext, packages []schema.PackageName
 
 			var images []compute.Computable[oci.ResolvableImage]
 			for k, p := range pkgs {
-				prepared, err := binary.PlanBinary(ctx, pl, env, p.Location, bins[k], binary.BuildImageOpts{
+				prepared, err := binary.PlanBinary(ctx, pl, env, p.Location, bins[k], assets.AvailableBuildAssets{}, binary.BuildImageOpts{
 					UsePrebuilts: true,
 					Platforms:    []specs.Platform{platform},
 				})

--- a/internal/testing/fixture.go
+++ b/internal/testing/fixture.go
@@ -11,6 +11,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/build/multiplatform"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
@@ -92,7 +93,7 @@ func PrepareTest(ctx context.Context, pl *parsing.PackageLoader, env cfg.Context
 	// All packages have been bound to the environment, and sealed.
 	packages := pl.Seal()
 
-	testBin, err := binary.PlanBinary(ctx, packages, env, driverLoc, testDef.Driver, binary.BuildImageOpts{
+	testBin, err := binary.PlanBinary(ctx, packages, env, driverLoc, testDef.Driver, assets.AvailableBuildAssets{}, binary.BuildImageOpts{
 		Platforms: platforms,
 	})
 	if err != nil {

--- a/languages/golang/golang.go
+++ b/languages/golang/golang.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/mod/semver"
 	"google.golang.org/protobuf/types/known/anypb"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	source "namespacelabs.dev/foundation/internal/codegen"
 	"namespacelabs.dev/foundation/internal/codegen/protos"
 	"namespacelabs.dev/foundation/internal/compute"
@@ -78,7 +79,7 @@ type impl struct {
 	languages.NoDev
 }
 
-func (impl) PrepareBuild(ctx context.Context, _ languages.AvailableBuildAssets, server planning.Server, isFocus bool) (build.Spec, error) {
+func (impl) PrepareBuild(ctx context.Context, _ assets.AvailableBuildAssets, server planning.Server, isFocus bool) (build.Spec, error) {
 	ext := &FrameworkExt{}
 	if err := parsing.MustExtension(server.Proto().Ext, ext); err != nil {
 		return nil, fnerrors.Wrap(server.Location, err)

--- a/languages/golang/sources.go
+++ b/languages/golang/sources.go
@@ -14,8 +14,8 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/imports"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/internal/planning"
-	"namespacelabs.dev/foundation/languages"
 	"namespacelabs.dev/foundation/std/tasks"
 )
 
@@ -29,7 +29,7 @@ func ComputeSources(ctx context.Context, root string, srv planning.Server, platf
 }
 
 func computeSources(ctx context.Context, root string, srv planning.Server, platforms []specs.Platform) (*D, error) {
-	spec, err := (impl{}).PrepareBuild(ctx, languages.AvailableBuildAssets{}, srv, false)
+	spec, err := (impl{}).PrepareBuild(ctx, assets.AvailableBuildAssets{}, srv, false)
 	if err != nil {
 		return nil, err
 	}

--- a/languages/nodejs/integration/build.go
+++ b/languages/nodejs/integration/build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/build/buildkit"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
@@ -75,7 +76,7 @@ func (bnj buildNodeJS) BuildImage(ctx context.Context, env pkggraph.SealedContex
 			return nil, err
 		}
 
-		p, err := binary.Plan(ctx, pkg, hotreload.ControllerPkg.Name, env, binary.BuildImageOpts{UsePrebuilts: true})
+		p, err := binary.Plan(ctx, pkg, hotreload.ControllerPkg.Name, env, assets.AvailableBuildAssets{}, binary.BuildImageOpts{UsePrebuilts: true})
 		if err != nil {
 			return nil, err
 		}

--- a/languages/nodejs/integration/nodejs.go
+++ b/languages/nodejs/integration/nodejs.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	source "namespacelabs.dev/foundation/internal/codegen"
 	srcprotos "namespacelabs.dev/foundation/internal/codegen/protos"
 	"namespacelabs.dev/foundation/internal/console"
@@ -174,7 +175,7 @@ func GetExternalModuleForDeps(server planning.Server) []build.Workspace {
 	return modules
 }
 
-func (impl) PrepareBuild(ctx context.Context, _ languages.AvailableBuildAssets, server planning.Server, isFocus bool) (build.Spec, error) {
+func (impl) PrepareBuild(ctx context.Context, _ assets.AvailableBuildAssets, server planning.Server, isFocus bool) (build.Spec, error) {
 	yarnRoot, err := findYarnRoot(server.Location)
 	if err != nil {
 		return nil, err

--- a/languages/opaque/opaque.go
+++ b/languages/opaque/opaque.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/parsing"
@@ -28,7 +29,7 @@ type OpaqueIntegration struct {
 	languages.NoDev
 }
 
-func (OpaqueIntegration) PrepareBuild(ctx context.Context, _ languages.AvailableBuildAssets, server planning.Server, isFocus bool) (build.Spec, error) {
+func (OpaqueIntegration) PrepareBuild(ctx context.Context, assets assets.AvailableBuildAssets, server planning.Server, isFocus bool) (build.Spec, error) {
 	binRef := server.Proto().GetMainContainer().GetBinaryRef()
 
 	if binRef == nil {
@@ -40,7 +41,7 @@ func (OpaqueIntegration) PrepareBuild(ctx context.Context, _ languages.Available
 		return nil, err
 	}
 
-	prep, err := binary.Plan(ctx, pkg, binRef.GetName(), server.SealedContext(),
+	prep, err := binary.Plan(ctx, pkg, binRef.GetName(), server.SealedContext(), assets,
 		binary.BuildImageOpts{UsePrebuilts: true, IsFocus: isFocus})
 	if err != nil {
 		return nil, err

--- a/languages/types.go
+++ b/languages/types.go
@@ -9,7 +9,7 @@ import (
 	"io"
 
 	"namespacelabs.dev/foundation/build"
-	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/internal/parsing"
 	"namespacelabs.dev/foundation/internal/planning"
 	"namespacelabs.dev/foundation/runtime"
@@ -18,15 +18,11 @@ import (
 	"namespacelabs.dev/foundation/std/pkggraph"
 )
 
-type AvailableBuildAssets struct {
-	IngressFragments compute.Computable[[]*schema.IngressFragment]
-}
-
 type Integration interface {
 	parsing.FrameworkHandler
 
 	// Called on `ns build`, `ns deploy`.
-	PrepareBuild(context.Context, AvailableBuildAssets, planning.Server, bool /*isFocus*/) (build.Spec, error)
+	PrepareBuild(context.Context, assets.AvailableBuildAssets, planning.Server, bool /*isFocus*/) (build.Spec, error)
 	PrepareRun(context.Context, planning.Server, *runtime.ContainerRunOpts) error
 
 	// Called on `ns tidy`
@@ -62,7 +58,7 @@ func IntegrationFor(fmwk schema.Framework) Integration {
 
 type MaybePrepare struct{}
 
-func (MaybePrepare) PrepareBuild(context.Context, AvailableBuildAssets, planning.Server, bool) (build.Spec, error) {
+func (MaybePrepare) PrepareBuild(context.Context, assets.AvailableBuildAssets, planning.Server, bool) (build.Spec, error) {
 	return nil, nil
 }
 func (MaybePrepare) PrepareRun(context.Context, planning.Server, *runtime.ContainerRunOpts) error {

--- a/languages/web/web.go
+++ b/languages/web/web.go
@@ -12,6 +12,7 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"namespacelabs.dev/foundation/build"
+	"namespacelabs.dev/foundation/build/assets"
 	"namespacelabs.dev/foundation/build/binary"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/codegen/protos/fnany"
@@ -73,14 +74,14 @@ func (impl) DevelopmentPackages() []schema.PackageName {
 	return []schema.PackageName{controllerPkg.AsPackageName()}
 }
 
-func (impl) PrepareBuild(ctx context.Context, buildAssets languages.AvailableBuildAssets, srv planning.Server, isFocus bool) (build.Spec, error) {
+func (impl) PrepareBuild(ctx context.Context, buildAssets assets.AvailableBuildAssets, srv planning.Server, isFocus bool) (build.Spec, error) {
 	if opaque.UseDevBuild(srv.SealedContext().Environment()) {
 		pkg, err := srv.SealedContext().LoadByName(ctx, controllerPkg.AsPackageName())
 		if err != nil {
 			return nil, err
 		}
 
-		p, err := binary.Plan(ctx, pkg, controllerPkg.Name, srv.SealedContext(), binary.BuildImageOpts{UsePrebuilts: false})
+		p, err := binary.Plan(ctx, pkg, controllerPkg.Name, srv.SealedContext(), buildAssets, binary.BuildImageOpts{UsePrebuilts: false})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Moving "AvailableBuildAssets" to a separate package to avoid a dependency cycle.