### PR TITLE
Implementing filesync for opaque dockerfiles.

### DIFF
--- a/internal/build/binary/binary.go
+++ b/internal/build/binary/binary.go
@@ -202,7 +202,7 @@ func buildLayeredSpec(ctx context.Context, pl pkggraph.PackageLoader, env cfg.Co
 		}
 	}
 
-	return mergeSpecs{specs: specs, descriptions: descriptions, platformIndependent: platformIndependent}, nil
+	return MergeSpecs{Specs: specs, Descriptions: descriptions, platformIndependent: platformIndependent}, nil
 }
 
 func buildSpec(ctx context.Context, pl pkggraph.PackageLoader, env cfg.Context, loc pkggraph.Location, bin *schema.Binary, src *schema.ImageBuildPlan, assets assets.AvailableBuildAssets, opts BuildImageOpts) (build.Spec, error) {

--- a/internal/build/binary/merge.go
+++ b/internal/build/binary/merge.go
@@ -13,17 +13,17 @@ import (
 	"namespacelabs.dev/foundation/std/pkggraph"
 )
 
-type mergeSpecs struct {
-	specs               []build.Spec
-	descriptions        []string // Same indexing as specs.
+type MergeSpecs struct {
+	Specs               []build.Spec
+	Descriptions        []string // Same indexing as specs.
 	platformIndependent bool
 }
 
-func (m mergeSpecs) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
-	images := make([]oci.NamedImage, len(m.specs))
+func (m MergeSpecs) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
+	images := make([]oci.NamedImage, len(m.Specs))
 
-	for k, spec := range m.specs {
-		xconf := build.CopyConfiguration(conf).WithSourceLabel(m.descriptions[k])
+	for k, spec := range m.Specs {
+		xconf := build.CopyConfiguration(conf).WithSourceLabel(m.Descriptions[k])
 
 		// XXX we ignore whether the request is platform-specific.
 		image, err := spec.BuildImage(ctx, env, xconf)
@@ -31,10 +31,10 @@ func (m mergeSpecs) BuildImage(ctx context.Context, env pkggraph.SealedContext, 
 			return nil, err
 		}
 
-		images[k] = oci.MakeNamedImage(m.descriptions[k], image)
+		images[k] = oci.MakeNamedImage(m.Descriptions[k], image)
 	}
 
 	return oci.MergeImageLayers(images...), nil
 }
 
-func (m mergeSpecs) PlatformIndependent() bool { return m.platformIndependent }
+func (m MergeSpecs) PlatformIndependent() bool { return m.platformIndependent }

--- a/internal/hotreload/constants.go
+++ b/internal/hotreload/constants.go
@@ -11,5 +11,6 @@ var (
 )
 
 const (
-	FileSyncPort = 50000
+	FileSyncPort      = 50000
+	ControllerCommand = "/filesync-controller"
 )

--- a/internal/languages/nodejs/opaqueintegration/opaquenodejs.go
+++ b/internal/languages/nodejs/opaqueintegration/opaquenodejs.go
@@ -15,6 +15,7 @@ import (
 	"namespacelabs.dev/foundation/internal/languages/opaque"
 	"namespacelabs.dev/foundation/internal/planning"
 	"namespacelabs.dev/foundation/internal/runtime"
+	"namespacelabs.dev/foundation/internal/wscontents"
 	"namespacelabs.dev/foundation/schema"
 )
 
@@ -40,13 +41,13 @@ func (impl) PrepareHotReload(ctx context.Context, remote *wsremote.SinkRegistrar
 			// "ModuleName" and "Rel" are empty because we have only one module in the image and
 			// we put the package content directly under the root "/app" directory.
 			Sink: remote.For(&wsremote.Signature{ModuleName: "", Rel: ""}),
-			TriggerFullRebuiltPredicate: func(filepath string) bool {
+			EventProcessor: func(ev *wscontents.FileEvent) *wscontents.FileEvent {
 				for _, p := range binary.PackageManagerSources {
-					if strings.HasPrefix(filepath, p) {
-						return true
+					if strings.HasPrefix(ev.Path, p) {
+						return nil
 					}
 				}
-				return false
+				return ev
 			},
 		}
 	}

--- a/internal/languages/types.go
+++ b/internal/languages/types.go
@@ -14,6 +14,7 @@ import (
 	"namespacelabs.dev/foundation/internal/parsing"
 	"namespacelabs.dev/foundation/internal/planning"
 	"namespacelabs.dev/foundation/internal/runtime"
+	"namespacelabs.dev/foundation/internal/wscontents"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/cfg"
 	"namespacelabs.dev/foundation/std/pkggraph"
@@ -46,8 +47,11 @@ type DevObserver interface {
 }
 
 type HotReloadOpts struct {
-	Sink                        wsremote.Sink
-	TriggerFullRebuiltPredicate func(filepath string) bool
+	Sink wsremote.Sink
+	// If "eventProcessor" is set:
+	//   - If it returns nil, a full rebuild will be triggered instead of a hot reload.
+	//   - If it returns a non-nil event, that event will be used instead of the original event.
+	EventProcessor func(*wscontents.FileEvent) *wscontents.FileEvent
 }
 
 var (

--- a/internal/languages/web/web.go
+++ b/internal/languages/web/web.go
@@ -29,6 +29,7 @@ import (
 	"namespacelabs.dev/foundation/internal/parsing"
 	"namespacelabs.dev/foundation/internal/planning"
 	"namespacelabs.dev/foundation/internal/runtime"
+	"namespacelabs.dev/foundation/internal/wscontents"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/cfg"
 	"namespacelabs.dev/foundation/std/development/controller/admin"
@@ -211,8 +212,14 @@ func (impl) PrepareDev(ctx context.Context, cluster runtime.ClusterNamespace, sr
 
 func (impl) PrepareHotReload(ctx context.Context, remote *wsremote.SinkRegistrar, srv planning.Server) *languages.HotReloadOpts {
 	return &languages.HotReloadOpts{
-		Sink:                        remote.For(&wsremote.Signature{ModuleName: srv.Module().ModuleName(), Rel: "."}),
-		TriggerFullRebuiltPredicate: func(filepath string) bool { return filepath == yarnLockFn },
+		Sink: remote.For(&wsremote.Signature{ModuleName: srv.Module().ModuleName(), Rel: "."}),
+		EventProcessor: func(ev *wscontents.FileEvent) *wscontents.FileEvent {
+			if ev.Path == yarnLockFn {
+				return nil
+			} else {
+				return ev
+			}
+		},
 	}
 }
 

--- a/internal/parsing/integration/nodejs/nodejs.go
+++ b/internal/parsing/integration/nodejs/nodejs.go
@@ -89,7 +89,7 @@ func CreateNodejsBinary(ctx context.Context, env *schema.Environment, pl pkggrap
 			Binary:      hotreload.ControllerPkg,
 		})
 
-		config.Command = []string{"/filesync-controller"}
+		config.Command = []string{hotreload.ControllerCommand}
 		// Existence of the "dev" script is not checked, because this code is executed during package loading,
 		// and for "ns test" it happens initially with the "DEV" environment.
 		config.Args = []string{binary.AppRootPath, fmt.Sprint(hotreload.FileSyncPort), packageManager.CLI, "run", data.RunScript}

--- a/internal/testdata/integrations/dockerfile/simple/README.md
+++ b/internal/testdata/integrations/dockerfile/simple/README.md
@@ -1,0 +1,1 @@
+Using Namespace in a simple case with a dockerfile integration and filesync (for hot reload).

--- a/internal/testdata/integrations/dockerfile/simple/server.cue
+++ b/internal/testdata/integrations/dockerfile/simple/server.cue
@@ -15,4 +15,8 @@ server: {
 			ingress: internetFacing: true
 		}
 	}
+
+	mounts: "/app/src": {
+		syncWorkspace: fromDir: "src"
+	}
 }


### PR DESCRIPTION
Syntax:

```
mounts: "/app/src": {
	syncWorkspace: fromDir: "src"
}
```

Implementation:
If there is a "syncWorkspace" mount:
 - A layer with the "filesync-controller" is added to the built image.
 - `ns dev` uses a custom "hot reload" module that forwards filesync events to the dev observer (same way it works for node.js/web today).
 - The dev observer starts the filesync controller process inside the same container. When `ns dev` exists, it sends `Ctrl-C` to the controller process. As a failsafe, ns kills all controller processes before starting one.


The existing Node.js/Web filesync works the same way as before and not migrated to the new way in this PR.