### PR TITLE
internal/wscontents: ignore changes to files which are not valid paths for example includes '..'

### DIFF
--- a/internal/wscontents/wscontents.go
+++ b/internal/wscontents/wscontents.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -427,8 +428,8 @@ func handleEvents(ctx context.Context, debugLogger, userVisible io.Writer, absPa
 			return nil, false, fnerrors.InternalError("rel failed: %v", err)
 		}
 
-		// Ignore changes to files which are not valid paths for example includes ..
-		if !fs.ValidPath(rel) {
+		// Observed a change that is not within the destination we're observing. We'll ignore it.
+		if strings.HasPrefix(rel, "../") {
 			fmt.Fprintf(debugLogger, "ignored change: %s\n", rel)
 			continue
 		}

--- a/internal/wscontents/wscontents.go
+++ b/internal/wscontents/wscontents.go
@@ -427,6 +427,12 @@ func handleEvents(ctx context.Context, debugLogger, userVisible io.Writer, absPa
 			return nil, false, fnerrors.InternalError("rel failed: %v", err)
 		}
 
+		// Ignore changes to files which are not valid paths for example includes ..
+		if !fs.ValidPath(rel) {
+			fmt.Fprintf(debugLogger, "ignored change: %s\n", rel)
+			continue
+		}
+
 		action, err := checkChanges(ctx, snapshot, os.DirFS(absPath), rel)
 		if err != nil {
 			return nil, false, fnerrors.InternalError("failed to check changes: %v", err)


### PR DESCRIPTION
It prevents calling `checkChanges` on file paths that are invalid relative paths. For example, if the NS workspace is on $HOME and changes are made with vim, the `checkChanges` are called with ../.viminfo relative path which is an invalid path for the `fs.FS.Open` and it returns EINVAL that causes a fatal internal error. This is an attempt to fix these cases.  