### PR TITLE
implements ability to create new environment with prepare

### DIFF
--- a/std/pkggraph/workspacedata.go
+++ b/std/pkggraph/workspacedata.go
@@ -16,6 +16,7 @@ type EditableWorkspaceData interface {
 
 	WithSetDependency(...*schema.Workspace_Dependency) WorkspaceData
 	WithReplacedDependencies([]*schema.Workspace_Dependency) WorkspaceData
+	WithSetEnvironment(...*schema.Workspace_EnvironmentSpec) WorkspaceData
 }
 
 type WorkspaceData interface {


### PR DESCRIPTION
The implementation supports environment purpose, runtime, and labels:
For example:
```
ns prepare local --env=foobar --create-env \
      --create-env-args='purpose=development,runtime=kubernetes,"labels=a=b,c=d"'
```
