### PR TITLE
Cloud build support

### DIFF
--- a/internal/runtime/docker/invoke.go
+++ b/internal/runtime/docker/invoke.go
@@ -179,6 +179,10 @@ func runImpl(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) error
 	}
 
 	networkConfig := &network.NetworkingConfig{}
+	if opts.Network != "" {
+		networkConfig.EndpointsConfig = make(map[string]*network.EndpointSettings)
+		networkConfig.EndpointsConfig[opts.Network] = &network.EndpointSettings{}
+	}
 
 	name := ""
 	if len(opts.Command) > 0 {

--- a/internal/runtime/rtypes/rtypes.go
+++ b/internal/runtime/rtypes/rtypes.go
@@ -30,6 +30,7 @@ type RunToolOpts struct {
 	MountAbsRoot string
 	Mounts       []*LocalMapping
 	AllocateTTY  bool
+	Network      string
 	NoNetworking bool // XXX remove, too specific.
 }
 


### PR DESCRIPTION
On cloud build, mounting the $HOME/.config/gcloud does not work. Instead, one should attach `cloudbuild` network to the container to make the config-helper work (see:  https://cloud.google.com/build/docs/build-config-file-schema#network )