### PR TITLE
add MutatingWebhookConfiguration type

### DIFF
--- a/framework/kubernetes/kubeparser/from_reader.go
+++ b/framework/kubernetes/kubeparser/from_reader.go
@@ -165,6 +165,8 @@ func messageTypeFromKind(kind string) runtime.Object {
 		return &batchv1.Job{}
 	case "Pod":
 		return &corev1.Pod{}
+	case "MutatingWebhookConfiguration":
+		return &admissionregistrationv1.MutatingWebhookConfiguration{}
 	}
 
 	return nil


### PR DESCRIPTION
I'm experimenting with complex Kubernetes manifests like the cert manager. It uses these Kubernetes kind that is missing from the `messageTypeFromKind` function.