### PR TITLE
internal/providers/nscloud: use tenant tokens for image registry authN

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,9 +144,8 @@ jobs:
       - name: Make ns executable
         run: chmod +x ns && mv ns /tmp/ns
 
-      - name: Login
-        # Consider using secrets.GITHUB_TOKEN
-        run: echo ${{ secrets.NSL_GH_SERVICE }} | /tmp/ns login robot github.com/namespacelabs/foundation
+      - name: Exchange Github token
+        run: /tmp/ns auth exchange-github-token
 
       - name: Run tests
         # Consider removing --also_report_start_events
@@ -200,9 +199,8 @@ jobs:
       - name: Make ns executable
         run: chmod +x ns && mv ns /tmp/ns
 
-      - name: Login
-        # Consider using secrets.GITHUB_TOKEN
-        run: echo ${{ secrets.NSL_GH_SERVICE }} | /tmp/ns login robot github.com/namespacelabs/foundation
+      - name: Exchange Github token
+        run: /tmp/ns auth exchange-github-token
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -280,9 +278,8 @@ jobs:
       - name: Make ns executable
         run: chmod +x ns && mv ns /tmp/ns
 
-      - name: Login
-        # Consider using secrets.GITHUB_TOKEN
-        run: echo ${{ secrets.NSL_GH_SERVICE }} | /tmp/ns login robot github.com/namespacelabs/${{ matrix.repo }}
+      - name: Exchange Github token
+        run: /tmp/ns auth exchange-github-token
 
       - name: Run tests
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -199,8 +199,9 @@ jobs:
       - name: Make ns executable
         run: chmod +x ns && mv ns /tmp/ns
 
-      - name: Exchange Github token
-        run: /tmp/ns auth exchange-github-token
+      - name: Login
+        # Consider using secrets.GITHUB_TOKEN
+        run: echo ${{ secrets.NSL_GH_SERVICE }} | /tmp/ns login robot github.com/namespacelabs/foundation
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/internal/fnapi/tenants.go
+++ b/internal/fnapi/tenants.go
@@ -27,3 +27,43 @@ func ExchangeGithubToken(ctx context.Context, jwt string) (ExchangeGithubTokenRe
 
 	return res, nil
 }
+
+type ExchangeUserTokenRequest struct {
+	Token  string   `json:"token,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+type ExchangeUserTokenResponse struct {
+	TenantToken string `json:"tenant_token,omitempty"`
+}
+
+func ExchangeUserToken(ctx context.Context, token string, scopes []string) (ExchangeUserTokenResponse, error) {
+	req := ExchangeUserTokenRequest{Token: token, Scopes: scopes}
+
+	var res ExchangeUserTokenResponse
+	if err := AnonymousCall(ctx, EndpointAddress, "nsl.tenants.TenantsService/ExchangeUserToken", req, DecodeJSONResponse(&res)); err != nil {
+		return ExchangeUserTokenResponse{}, err
+	}
+
+	return res, nil
+}
+
+type ExchangeTenantTokenRequest struct {
+	TenantToken string   `json:"tenant_token,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
+}
+
+type ExchangeTenantTokenResponse struct {
+	TenantToken string `json:"tenant_token,omitempty"`
+}
+
+func ExchangeTenantToken(ctx context.Context, token string, scopes []string) (ExchangeTenantTokenResponse, error) {
+	req := ExchangeTenantTokenRequest{TenantToken: token, Scopes: scopes}
+
+	var res ExchangeTenantTokenResponse
+	if err := AnonymousCall(ctx, EndpointAddress, "nsl.tenants.TenantsService/ExchangeTenantToken", req, DecodeJSONResponse(&res)); err != nil {
+		return ExchangeTenantTokenResponse{}, err
+	}
+
+	return res, nil
+}

--- a/internal/prepare/nscloud.go
+++ b/internal/prepare/nscloud.go
@@ -56,6 +56,7 @@ func PrepareNewNamespaceCluster(ctx context.Context, env cfg.Context, machineTyp
 		if err != nil {
 			return err
 		}
+
 		mainMessages = append(mainMessages, &configuration.Cluster{ClusterId: cfg.ClusterId})
 		return nil
 	})

--- a/internal/providers/nscloud/api/rpc.go
+++ b/internal/providers/nscloud/api/rpc.go
@@ -275,6 +275,34 @@ func ListClusters(ctx context.Context, api API) (*KubernetesClusterList, error) 
 	})
 }
 
+func ExchangeToken(ctx context.Context, scopes ...string) (string, error) {
+	tenantToken, err := auth.LoadTenantToken()
+	if err == nil {
+		resp, err := fnapi.ExchangeTenantToken(ctx, tenantToken.TenantToken, scopes)
+		if err != nil {
+			return "", err
+		}
+
+		return resp.TenantToken, nil
+	}
+
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	userToken, err := auth.GenerateToken(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := fnapi.ExchangeUserToken(ctx, userToken, scopes)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.TenantToken, nil
+}
+
 type clusterCreateProgress struct {
 	status atomic.String
 }

--- a/internal/providers/nscloud/api/types.go
+++ b/internal/providers/nscloud/api/types.go
@@ -78,6 +78,8 @@ type KubernetesCluster struct {
 
 type ImageRegistry struct {
 	EndpointAddress string `json:"endpoint_address,omitempty"`
+	Username        string `json:"username,omitempty"`
+	Password        string `json:"password,omitempty"`
 }
 
 type ClusterShape struct {

--- a/internal/providers/nscloud/registry.go
+++ b/internal/providers/nscloud/registry.go
@@ -112,7 +112,6 @@ func (dk defaultKeychain) Resolve(ctx context.Context, r authn.Resource) (authn.
 			return "", err
 		}
 
-		// TODO exchange user auth for tenant tokens.
 		userToken, err := auth.GenerateToken(ctx)
 		if err != nil {
 			return "", err

--- a/internal/providers/nscloud/registry.go
+++ b/internal/providers/nscloud/registry.go
@@ -6,19 +6,15 @@ package nscloud
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
+	"os"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/artifacts/registry"
 	"namespacelabs.dev/foundation/internal/auth"
 	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/providers/nscloud/api"
 	"namespacelabs.dev/foundation/std/cfg"
@@ -27,14 +23,10 @@ import (
 
 var DefaultKeychain oci.Keychain = defaultKeychain{}
 
-const loginEndpoint = "login.namespace.so/token"
-
 type nscloudRegistry struct {
 	clusterID string
 	registry  *api.ImageRegistry
 }
-
-const registryAddr = "registry-fgfo23t6gn9jd834s36g.prod-metal.namespacelabs.nscloud.dev"
 
 func RegisterRegistry() {
 	registry.Register("nscloud", func(ctx context.Context, ck cfg.Configuration) (registry.Manager, error) {
@@ -45,8 +37,6 @@ func RegisterRegistry() {
 
 		return nscloudRegistry{clusterID: conf.ClusterId}, nil
 	})
-
-	oci.RegisterDomainKeychain(registryAddr, DefaultKeychain, oci.Keychain_UseAlways)
 }
 
 func (r nscloudRegistry) Access() oci.RegistryAccess {
@@ -107,52 +97,42 @@ func (dk defaultKeychain) Resolve(ctx context.Context, r authn.Resource) (authn.
 		return authn.Anonymous, nil
 	}
 
-	ref, err := name.ParseReference(r.String())
+	exchangeToken := func(ctx context.Context) (string, error) {
+		tenantToken, err := auth.LoadTenantToken()
+		if err == nil {
+			resp, err := fnapi.ExchangeTenantToken(ctx, tenantToken.TenantToken, []string{"image-registry-access"})
+			if err != nil {
+				return "", err
+			}
+
+			return resp.TenantToken, nil
+		}
+
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		// TODO exchange user auth for tenant tokens.
+		userToken, err := auth.GenerateToken(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		resp, err := fnapi.ExchangeUserToken(ctx, userToken, []string{"image-registry-access"})
+		if err != nil {
+			return "", err
+		}
+
+		return resp.TenantToken, nil
+	}
+
+	token, err := exchangeToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	values := url.Values{}
-	values.Add("scope", fmt.Sprintf("repository:%s:push,pull", ref.Context().RepositoryStr()))
-	values.Add("service", "Authentication")
-
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://%s?%s", loginEndpoint, values.Encode()), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	tok, err := auth.GenerateToken(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("X-Namespace-Token", tok)
-	req.Header.Add("Authorization", "Bearer "+tok)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fnerrors.InvocationError("nscloud", "%s: unexpected status when fetching an access token: %d", r, resp.StatusCode)
-	}
-
-	tokenData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fnerrors.InvocationError("nscloud", "%s: unexpected error when fetching an access token: %w", r, err)
-	}
-
-	var t Token
-	if err := json.Unmarshal(tokenData, &t); err != nil {
-		return nil, fnerrors.InvocationError("nscloud", "%s: unexpected error when unmarshalling an access token: %w", r, err)
-	}
-
-	return &authn.Bearer{Token: t.Token}, nil
-}
-
-type Token struct {
-	Token string `json:"token"`
+	return &authn.Basic{
+		Username: "tenant-token", // XXX: hardcoded as image-registry expects static username.
+		Password: token,
+	}, nil
 }


### PR DESCRIPTION
Fixes NSL-537