### PR TITLE
internal/auth: cache tenant token on login

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -19,17 +19,25 @@ func GenerateToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	if userAuth.Clerk != nil {
+	return GenerateTokenFromUserAuth(ctx, userAuth)
+}
+
+func GenerateTokenFromUserAuth(ctx context.Context, userAuth *UserAuth) (string, error) {
+	switch {
+	case userAuth.Clerk != nil:
 		jwt, err := clerk.JWT(ctx, userAuth.Clerk)
 		if err != nil {
 			if errors.Is(err, clerk.ErrUnauthorized) {
 				return "", ErrRelogin
 			}
+
 			return "", err
 		}
 
 		return fmt.Sprintf("jwt:%s", jwt), nil
+	case len(userAuth.InternalOpaque) > 0:
+		return base64.RawStdEncoding.EncodeToString(userAuth.InternalOpaque), nil
+	default:
+		return "", ErrRelogin
 	}
-
-	return base64.RawStdEncoding.EncodeToString(userAuth.InternalOpaque), nil
 }

--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -7,7 +7,9 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,4 +88,17 @@ func LoadTenantToken(ctx context.Context) (*Token, error) {
 	}
 
 	return token, nil
+}
+
+func RemoveTenantToken(ctx context.Context) error {
+	dir, err := dirs.Config()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(filepath.Join(dir, tokenTxt)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	return nil
 }

--- a/internal/auth/userauth.go
+++ b/internal/auth/userauth.go
@@ -7,6 +7,8 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -70,4 +72,17 @@ func LoadUser() (*UserAuth, error) {
 	}
 
 	return userAuth, nil
+}
+
+func RemoveUser(ctx context.Context) error {
+	dir, err := dirs.Config()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(filepath.Join(dir, userAuthJson)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	return nil
 }

--- a/internal/build/buildkit/client.go
+++ b/internal/build/buildkit/client.go
@@ -123,7 +123,7 @@ func (c *clientInstance) Compute(ctx context.Context, _ compute.Resolved) (*Gate
 		}
 
 		// We must fetch a token with our parent context, so we get a task sink etc.
-		token, err := api.ExchangeToken(ctx)
+		token, err := api.FetchTenantToken(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/cmd/auth/login.go
+++ b/internal/cli/cmd/auth/login.go
@@ -60,7 +60,7 @@ func NewLoginCmd() *cobra.Command {
 				return err
 			}
 
-			tt, err := fnapi.ExchangeUserToken(ctx, userToken, nil)
+			tt, err := fnapi.ExchangeUserToken(ctx, userToken)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/auth/login.go
+++ b/internal/cli/cmd/auth/login.go
@@ -55,6 +55,20 @@ func NewLoginCmd() *cobra.Command {
 				return err
 			}
 
+			userToken, err := auth.GenerateTokenFromUserAuth(ctx, userAuth)
+			if err != nil {
+				return err
+			}
+
+			tt, err := fnapi.ExchangeUserToken(ctx, userToken, nil)
+			if err != nil {
+				return err
+			}
+
+			if err := auth.StoreTenantToken(tt.TenantToken); err != nil {
+				return err
+			}
+
 			fmt.Fprintf(stdout, "\nHi %s, you are now logged in, have a nice day.\n", username)
 
 			return nil

--- a/internal/cli/cmd/auth/login.go
+++ b/internal/cli/cmd/auth/login.go
@@ -31,6 +31,14 @@ func NewLoginCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
+			if err := auth.RemoveUser(ctx); err != nil {
+				return err
+			}
+
+			if err := auth.RemoveTenantToken(ctx); err != nil {
+				return err
+			}
+
 			res, err := fnapi.StartLogin(ctx, kind)
 			if err != nil {
 				return nil

--- a/internal/fnapi/tenants.go
+++ b/internal/fnapi/tenants.go
@@ -37,7 +37,7 @@ type ExchangeUserTokenResponse struct {
 	TenantToken string `json:"tenant_token,omitempty"`
 }
 
-func ExchangeUserToken(ctx context.Context, token string, scopes []string) (ExchangeUserTokenResponse, error) {
+func ExchangeUserToken(ctx context.Context, token string, scopes ...string) (ExchangeUserTokenResponse, error) {
 	req := ExchangeUserTokenRequest{Token: token, Scopes: scopes}
 
 	var res ExchangeUserTokenResponse

--- a/internal/providers/nscloud/api/dial.go
+++ b/internal/providers/nscloud/api/dial.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/jpillora/chisel/share/cnet"
+	"namespacelabs.dev/foundation/internal/auth"
 )
 
 func DialPort(ctx context.Context, cluster *KubernetesCluster, targetPort int) (net.Conn, error) {
-	token, err := ExchangeToken(ctx)
+	token, err := FetchTenantToken(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +25,7 @@ func DialPort(ctx context.Context, cluster *KubernetesCluster, targetPort int) (
 	return DialPortWithToken(ctx, token, cluster, targetPort)
 }
 
-func DialPortWithToken(ctx context.Context, token *TenantToken, cluster *KubernetesCluster, targetPort int) (net.Conn, error) {
+func DialPortWithToken(ctx context.Context, token *auth.Token, cluster *KubernetesCluster, targetPort int) (net.Conn, error) {
 	d := websocket.Dialer{
 		HandshakeTimeout: 15 * time.Second,
 	}

--- a/internal/providers/nscloud/api/rpc.go
+++ b/internal/providers/nscloud/api/rpc.go
@@ -25,6 +25,8 @@ import (
 	"namespacelabs.dev/foundation/std/tasks"
 )
 
+const AdminScope = "admin"
+
 type API struct {
 	StartCreateKubernetesCluster fnapi.Call[CreateKubernetesClusterRequest]
 	GetKubernetesCluster         fnapi.Call[GetKubernetesClusterRequest]
@@ -104,11 +106,7 @@ func MakeAPI(endpoint string) API {
 func FetchTenantToken(ctx context.Context) (*auth.Token, error) {
 	return tasks.Return(ctx, tasks.Action("nscloud.fetch-tenant-token"), func(ctx context.Context) (*auth.Token, error) {
 		if !fnapi.AdminMode {
-			t, err := auth.LoadTenantToken(ctx)
-			if err != nil {
-				return nil, err
-			}
-			return t, nil
+			return auth.LoadTenantToken(ctx)
 		}
 
 		// In admin mode we exchange user token to a tenant token with `admin` scope.
@@ -117,7 +115,7 @@ func FetchTenantToken(ctx context.Context) (*auth.Token, error) {
 			return nil, err
 		}
 
-		t, err := fnapi.ExchangeUserToken(ctx, userToken, []string{"admin"})
+		t, err := fnapi.ExchangeUserToken(ctx, userToken, AdminScope)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/nscloud/registry.go
+++ b/internal/providers/nscloud/registry.go
@@ -94,7 +94,7 @@ func (dk defaultKeychain) Resolve(ctx context.Context, r authn.Resource) (authn.
 		return authn.Anonymous, nil
 	}
 
-	token, err := api.ExchangeToken(ctx, "image-registry-access")
+	token, err := api.FetchTenantToken(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also in this change:
- In admin mode we exchange user token to a tenant token with an admin scope.
- Changed registry to use the cached tenant token without exchanged to a scoped token.