### PR TITLE
nsc/log: use include instead of a selector in logs request

### DIFF
--- a/internal/providers/nscloud/api/rpc.go
+++ b/internal/providers/nscloud/api/rpc.go
@@ -359,19 +359,15 @@ type LogsOpts struct {
 	ClusterID string
 	StartTs   *time.Time
 	EndTs     *time.Time
-	Namespace string
-	Pod       string
-	Container string
+	Include   []*LogsSelector
+	Exclude   []*LogsSelector
 }
 
 func TailClusterLogs(ctx context.Context, api API, opts *LogsOpts, w io.Writer) error {
 	return api.TailClusterLogs.Do(ctx, TailLogsRequest{
 		ClusterID: opts.ClusterID,
-		Selector: &LogsSelector{
-			Namespace: opts.Namespace,
-			Pod:       opts.Pod,
-			Container: opts.Container,
-		},
+		Include:   opts.Include,
+		Exclude:   opts.Exclude,
 	}, func(r io.Reader) error {
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
@@ -399,11 +395,8 @@ func GetClusterLogs(ctx context.Context, api API, opts *LogsOpts) (*GetLogsRespo
 			ClusterID: opts.ClusterID,
 			StartTs:   opts.StartTs,
 			EndTs:     opts.EndTs,
-			Selector: &LogsSelector{
-				Namespace: opts.Namespace,
-				Pod:       opts.Pod,
-				Container: opts.Container,
-			},
+			Include:   opts.Include,
+			Exclude:   opts.Exclude,
 		}
 
 		var response GetLogsResponse

--- a/internal/providers/nscloud/api/types.go
+++ b/internal/providers/nscloud/api/types.go
@@ -87,15 +87,17 @@ type KubernetesCluster struct {
 }
 
 type TailLogsRequest struct {
-	ClusterID string        `json:"cluster_id,omitempty"`
-	Selector  *LogsSelector `json:"selector,omitempty"`
+	ClusterID string          `json:"cluster_id,omitempty"`
+	Include   []*LogsSelector `json:"include,omitempty"`
+	Exclude   []*LogsSelector `json:"exclude,omitempty"`
 }
 
 type GetLogsRequest struct {
-	ClusterID string        `json:"cluster_id,omitempty"`
-	StartTs   *time.Time    `json:"start_ts,omitempty"`
-	EndTs     *time.Time    `json:"end_ts,omitempty"`
-	Selector  *LogsSelector `json:"selector,omitempty"`
+	ClusterID string          `json:"cluster_id,omitempty"`
+	StartTs   *time.Time      `json:"start_ts,omitempty"`
+	EndTs     *time.Time      `json:"end_ts,omitempty"`
+	Include   []*LogsSelector `json:"include,omitempty"`
+	Exclude   []*LogsSelector `json:"exclude,omitempty"`
 }
 
 type GetLogsResponse struct {


### PR DESCRIPTION
Contributes-to: NSL-616