### PR TITLE
internal/auth: Avoid resetting login state before new login succeeds.

### DIFF
--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -89,16 +89,3 @@ func LoadTenantToken(ctx context.Context) (*Token, error) {
 
 	return token, nil
 }
-
-func RemoveTenantToken(ctx context.Context) error {
-	dir, err := dirs.Config()
-	if err != nil {
-		return err
-	}
-
-	if err := os.Remove(filepath.Join(dir, tokenTxt)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-
-	return nil
-}

--- a/internal/auth/userauth.go
+++ b/internal/auth/userauth.go
@@ -7,8 +7,6 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -72,17 +70,4 @@ func LoadUser() (*UserAuth, error) {
 	}
 
 	return userAuth, nil
-}
-
-func RemoveUser(ctx context.Context) error {
-	dir, err := dirs.Config()
-	if err != nil {
-		return err
-	}
-
-	if err := os.Remove(filepath.Join(dir, userAuthJson)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-
-	return nil
 }

--- a/internal/cli/cmd/auth/login.go
+++ b/internal/cli/cmd/auth/login.go
@@ -31,14 +31,6 @@ func NewLoginCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
-			if err := auth.RemoveUser(ctx); err != nil {
-				return err
-			}
-
-			if err := auth.RemoveTenantToken(ctx); err != nil {
-				return err
-			}
-
 			res, err := fnapi.StartLogin(ctx, kind)
 			if err != nil {
 				return nil


### PR DESCRIPTION
I often run into the inconvenience when I run `ns login` by mistake. And it immediately resets the login state, so I cannot just cancel the login process and keep the old auth.