### PR TITLE
nsc/cred-helper: docker-login installs docker-credential-nsc helper

### DIFF
--- a/cmd/nsc/main.go
+++ b/cmd/nsc/main.go
@@ -18,56 +18,67 @@ import (
 	"namespacelabs.dev/foundation/internal/providers/nscloud/api"
 )
 
+const (
+	dockerCredHelperBinary = "docker-credential-nsc"
+	nscBinary              = "nsc"
+)
+
 func main() {
-	if os.Args[0] == "docker-credential-nsc" {
-		fncobra.DoMain("docker-credential-nsc", false, func(root *cobra.Command) {
-			api.SetupFlags("", root.PersistentFlags(), false)
-			ia.SetupFlags(root.PersistentFlags())
-
-			root.AddCommand(cluster.NewDockerCredHelperStoreCmd(false))
-			root.AddCommand(cluster.NewDockerCredHelperGetCmd(false))
-			root.AddCommand(cluster.NewDockerCredHelperListCmd(false))
-			root.AddCommand(cluster.NewDockerCredHelperEraseCmd(false))
-
-			fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
-				api.Register()
-				return nil
-			})
-		})
-
+	if os.Args[0] == dockerCredHelperBinary {
+		dockerCredHelperMain()
 	} else {
-
-		// Consider adding auto updates if we frequently change nsc.
-		fncobra.DoMain("nsc", true, func(root *cobra.Command) {
-			api.SetupFlags("", root.PersistentFlags(), false)
-			ia.SetupFlags(root.PersistentFlags())
-
-			root.AddCommand(auth.NewAuthCmd())
-			root.AddCommand(auth.NewLoginCmd()) // register `nsc login` as an alias for `nsc auth login`
-
-			root.AddCommand(version.NewVersionCmd())
-
-			root.AddCommand(cluster.NewBareClusterCmd(false))
-			root.AddCommand(cluster.NewKubectlCmd())          // nsc kubectl
-			root.AddCommand(cluster.NewKubeconfigCmd())       // nsc kubeconfig write
-			root.AddCommand(cluster.NewBuildkitCmd())         // nsc buildkit builctl
-			root.AddCommand(cluster.NewBuildCmd())            // nsc build
-			root.AddCommand(cluster.NewDockerLoginCmd(false)) // nsc docker-login
-			root.AddCommand(cluster.NewMetadataCmd())         // nsc metadata
-			root.AddCommand(cluster.NewCreateCmd(false))      // nsc create
-			root.AddCommand(cluster.NewListCmd())             // nsc list
-			root.AddCommand(cluster.NewLogsCmd())             // nsc logs
-			root.AddCommand(cluster.NewExposeCmd())           // nsc expose
-			root.AddCommand(cluster.NewRunCmd())              // nsc run
-			root.AddCommand(cluster.NewRunComposeCmd())       // nsc run-compose
-			root.AddCommand(cluster.NewSshCmd())              // nsc ssh
-
-			root.AddCommand(sdk.NewSdkCmd(true))
-
-			fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
-				api.Register()
-				return nil
-			})
-		})
+		nscMain()
 	}
+}
+
+func nscMain() {
+	// Consider adding auto updates if we frequently change nsc.
+	fncobra.DoMain(nscBinary, true, func(root *cobra.Command) {
+		api.SetupFlags("", root.PersistentFlags(), false)
+		ia.SetupFlags(root.PersistentFlags())
+
+		root.AddCommand(auth.NewAuthCmd())
+		root.AddCommand(auth.NewLoginCmd()) // register `nsc login` as an alias for `nsc auth login`
+
+		root.AddCommand(version.NewVersionCmd())
+
+		root.AddCommand(cluster.NewBareClusterCmd(false))
+		root.AddCommand(cluster.NewKubectlCmd())          // nsc kubectl
+		root.AddCommand(cluster.NewKubeconfigCmd())       // nsc kubeconfig write
+		root.AddCommand(cluster.NewBuildkitCmd())         // nsc buildkit builctl
+		root.AddCommand(cluster.NewBuildCmd())            // nsc build
+		root.AddCommand(cluster.NewDockerLoginCmd(false)) // nsc docker-login
+		root.AddCommand(cluster.NewMetadataCmd())         // nsc metadata
+		root.AddCommand(cluster.NewCreateCmd(false))      // nsc create
+		root.AddCommand(cluster.NewListCmd())             // nsc list
+		root.AddCommand(cluster.NewLogsCmd())             // nsc logs
+		root.AddCommand(cluster.NewExposeCmd())           // nsc expose
+		root.AddCommand(cluster.NewRunCmd())              // nsc run
+		root.AddCommand(cluster.NewRunComposeCmd())       // nsc run-compose
+		root.AddCommand(cluster.NewSshCmd())              // nsc ssh
+
+		root.AddCommand(sdk.NewSdkCmd(true))
+
+		fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
+			api.Register()
+			return nil
+		})
+	})
+}
+
+func dockerCredHelperMain() {
+	fncobra.DoMain(dockerCredHelperBinary, false, func(root *cobra.Command) {
+		api.SetupFlags("", root.PersistentFlags(), false)
+		ia.SetupFlags(root.PersistentFlags())
+
+		root.AddCommand(cluster.NewDockerCredHelperStoreCmd(false))
+		root.AddCommand(cluster.NewDockerCredHelperGetCmd(false))
+		root.AddCommand(cluster.NewDockerCredHelperListCmd(false))
+		root.AddCommand(cluster.NewDockerCredHelperEraseCmd(false))
+
+		fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
+			api.Register()
+			return nil
+		})
+	})
 }

--- a/cmd/nsc/main.go
+++ b/cmd/nsc/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	ia "namespacelabs.dev/foundation/internal/auth"
@@ -18,36 +19,55 @@ import (
 )
 
 func main() {
-	// Consider adding auto updates if we frequently change nsc.
-	fncobra.DoMain("nsc", true, func(root *cobra.Command) {
-		api.SetupFlags("", root.PersistentFlags(), false)
-		ia.SetupFlags(root.PersistentFlags())
+	if os.Args[0] == "docker-credential-nsc" {
+		fncobra.DoMain("docker-credential-nsc", false, func(root *cobra.Command) {
+			api.SetupFlags("", root.PersistentFlags(), false)
+			ia.SetupFlags(root.PersistentFlags())
 
-		root.AddCommand(auth.NewAuthCmd())
-		root.AddCommand(auth.NewLoginCmd()) // register `nsc login` as an alias for `nsc auth login`
+			root.AddCommand(cluster.NewDockerCredHelperStoreCmd(false))
+			root.AddCommand(cluster.NewDockerCredHelperGetCmd(false))
+			root.AddCommand(cluster.NewDockerCredHelperListCmd(false))
+			root.AddCommand(cluster.NewDockerCredHelperEraseCmd(false))
 
-		root.AddCommand(version.NewVersionCmd())
-
-		root.AddCommand(cluster.NewBareClusterCmd(false))
-		root.AddCommand(cluster.NewKubectlCmd())          // nsc kubectl
-		root.AddCommand(cluster.NewKubeconfigCmd())       // nsc kubeconfig write
-		root.AddCommand(cluster.NewBuildkitCmd())         // nsc buildkit builctl
-		root.AddCommand(cluster.NewBuildCmd())            // nsc build
-		root.AddCommand(cluster.NewDockerLoginCmd(false)) // nsc docker-login
-		root.AddCommand(cluster.NewMetadataCmd())         // nsc metadata
-		root.AddCommand(cluster.NewCreateCmd(false))      // nsc create
-		root.AddCommand(cluster.NewListCmd())             // nsc list
-		root.AddCommand(cluster.NewLogsCmd())             // nsc logs
-		root.AddCommand(cluster.NewExposeCmd())           // nsc expose
-		root.AddCommand(cluster.NewRunCmd())              // nsc run
-		root.AddCommand(cluster.NewRunComposeCmd())       // nsc run-compose
-		root.AddCommand(cluster.NewSshCmd())              // nsc ssh
-
-		root.AddCommand(sdk.NewSdkCmd(true))
-
-		fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
-			api.Register()
-			return nil
+			fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
+				api.Register()
+				return nil
+			})
 		})
-	})
+
+	} else {
+
+		// Consider adding auto updates if we frequently change nsc.
+		fncobra.DoMain("nsc", true, func(root *cobra.Command) {
+			api.SetupFlags("", root.PersistentFlags(), false)
+			ia.SetupFlags(root.PersistentFlags())
+
+			root.AddCommand(auth.NewAuthCmd())
+			root.AddCommand(auth.NewLoginCmd()) // register `nsc login` as an alias for `nsc auth login`
+
+			root.AddCommand(version.NewVersionCmd())
+
+			root.AddCommand(cluster.NewBareClusterCmd(false))
+			root.AddCommand(cluster.NewKubectlCmd())          // nsc kubectl
+			root.AddCommand(cluster.NewKubeconfigCmd())       // nsc kubeconfig write
+			root.AddCommand(cluster.NewBuildkitCmd())         // nsc buildkit builctl
+			root.AddCommand(cluster.NewBuildCmd())            // nsc build
+			root.AddCommand(cluster.NewDockerLoginCmd(false)) // nsc docker-login
+			root.AddCommand(cluster.NewMetadataCmd())         // nsc metadata
+			root.AddCommand(cluster.NewCreateCmd(false))      // nsc create
+			root.AddCommand(cluster.NewListCmd())             // nsc list
+			root.AddCommand(cluster.NewLogsCmd())             // nsc logs
+			root.AddCommand(cluster.NewExposeCmd())           // nsc expose
+			root.AddCommand(cluster.NewRunCmd())              // nsc run
+			root.AddCommand(cluster.NewRunComposeCmd())       // nsc run-compose
+			root.AddCommand(cluster.NewSshCmd())              // nsc ssh
+
+			root.AddCommand(sdk.NewSdkCmd(true))
+
+			fncobra.PushPreParse(root, func(ctx context.Context, args []string) error {
+				api.Register()
+				return nil
+			})
+		})
+	}
 }

--- a/install/install_nsc.sh
+++ b/install/install_nsc.sh
@@ -118,6 +118,9 @@ do_install() {
 
   $sh_c "chmod +x ${bin_dir}/${tool_name}"
 
+  # symlink for Docker's credential helper (requirement for `nsc docker-login`)
+  $sh_c "ln -s ${bin_dir}/${tool_name} ${bin_dir}/docker-credential-${tool_name}"
+
   $sh_c "rm ${temp_tar}"
 
   echo

--- a/internal/cli/cmd/cluster/docker.go
+++ b/internal/cli/cmd/cluster/docker.go
@@ -99,8 +99,8 @@ func NewDockerLoginCmd(hidden bool) *cobra.Command {
 
 		cfg := config.LoadDefaultConfigFile(console.Stderr(ctx))
 
-		for _, x := range []*api.ImageRegistry{response.Registry, response.NSCR} {
-			if x != nil {
+		for _, reg := range []*api.ImageRegistry{response.Registry, response.NSCR} {
+			if reg != nil {
 				if err := cfg.GetCredentialsStore(response.Registry.EndpointAddress).Store(types.AuthConfig{
 					ServerAddress: x.EndpointAddress,
 					Username:      dockerUsername,
@@ -186,7 +186,7 @@ func NewDockerCredHelperGetCmd(hidden bool) *cobra.Command {
 		}
 
 		for _, reg := range []*api.ImageRegistry{resp.Registry, resp.NSCR} {
-			if regURL == reg.EndpointAddress {
+			if reg != nil && regURL == reg.EndpointAddress {
 				token, err := fnapi.FetchTenantToken(ctx)
 				if err != nil {
 					return fnerrors.New("failed to fetch tenant token: %w", err)
@@ -235,7 +235,9 @@ func NewDockerCredHelperListCmd(hidden bool) *cobra.Command {
 		output := map[string]string{}
 
 		for _, reg := range []*api.ImageRegistry{resp.Registry, resp.NSCR} {
-			output[reg.EndpointAddress] = dockerUsername
+			if reg != nil {
+				output[reg.EndpointAddress] = dockerUsername
+			}
 		}
 
 		buf, err := json.Marshal(output)

--- a/internal/cli/cmd/cluster/docker.go
+++ b/internal/cli/cmd/cluster/docker.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	dockerUsername   = "tenant-token"
-	credHelperBinary = "docker-credentials-nsc"
+	credHelperBinary = "docker-credential-nsc"
 	nscBinary        = "nsc"
 )
 
@@ -139,7 +139,7 @@ func NewDockerLoginCmd(hidden bool) *cobra.Command {
 
 		if _, err := exec.LookPath(credHelperBinary); err != nil {
 			if errors.Is(err, exec.ErrNotFound) {
-				fmt.Fprintf(stdout, "\nWe didn't find docker-credentials-nsc in your $PATH.\nIt's usually installed along-side nsc; so if you have nsc to the $PATH, docker-credentials-nsc will also be available.\n")
+				fmt.Fprintf(stdout, "\nWe didn't find docker-credential-nsc in your $PATH.\nIt's usually installed along-side nsc; so if you have nsc to the $PATH, docker-credential-nsc will also be available.\n")
 				fmt.Fprintf(stdout, "\nWhile your $PATH is not updated, accessing nscr.io images from docker-based tools won't work.\nBut you can always use nsc build (as per above) or nsc run.\n")
 			} else {
 				return fnerrors.New("failed to look up nsc in $PATH: %w", err)


### PR DESCRIPTION
Tested:
```
{
	"auths": {
		"ghcr.io": {},
		"https://index.docker.io/v1/": {}
	},
	"credsStore": "desktop",
	"credHelpers": {
    		"nscr.io": "nsc"
  	}
}
```

```
docker pull nscr.io/<workspace-id>/ns-go-app:v0.0.1
```