### PR TITLE
cluster/buildx: cleanup background proxy with state management

### DIFF
--- a/internal/cli/cmd/cluster/attachdocker.go
+++ b/internal/cli/cmd/cluster/attachdocker.go
@@ -63,7 +63,7 @@ func newDockerAttachCmd() *cobra.Command {
 			}
 		}
 
-		state, err := ensureStateDir(*stateDir, "docker", "proxy")
+		state, err := ensureStateDir(*stateDir, "docker/proxy")
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/cluster/build.go
+++ b/internal/cli/cmd/cluster/build.go
@@ -300,13 +300,21 @@ func NewBuildCmd() *cobra.Command {
 
 		if !*push {
 			// On push, we already report what was built. Add a hint for other builds, too.
-			fmt.Fprintf(console.Stdout(ctx), "\nBuilt %d images (platforms %s).\n", len(fragments), strings.Join(*platforms, ","))
+			fmt.Fprintf(console.Stdout(ctx), "\nBuilt %d %s (platforms %s).\n", len(fragments), plural(len(fragments), "image", "images"), strings.Join(*platforms, ","))
 		}
 
 		return nil
 	})
 
 	return cmd
+}
+
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+
+	return plural
 }
 
 type buildFragment struct {

--- a/std/networking/gateway/controller/transcodersnapshot.go
+++ b/std/networking/gateway/controller/transcodersnapshot.go
@@ -412,8 +412,9 @@ func makeRoute(clusterName string, transcoderSpec HttpGrpcTranscoderSpec) *route
 					Cluster: clusterName,
 				},
 				// Explicitly override the default upstream route timeout of 15s.
+				// We set HttpConnectionManager.RequestTimeout to 5m below for unary requests.
 				// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routeaction
-				Timeout: durationpb.New(5 * time.Minute),
+				Timeout: durationpb.New(30 * time.Minute),
 			},
 		},
 	}
@@ -495,6 +496,7 @@ func makeHTTPListener(httpConfig httpListenerConfig, transcoders []transcoderWit
 			},
 		}},
 		StreamIdleTimeout: durationpb.New(30 * time.Minute),
+		RequestTimeout:    durationpb.New(5 * time.Minute), // Does not apply to streaming requests.
 		RouteSpecifier: &hcm.HttpConnectionManager_RouteConfig{
 			RouteConfig: &route.RouteConfiguration{
 				Name: LocalRouteName,

--- a/std/networking/gateway/controller/transcodersnapshot.go
+++ b/std/networking/gateway/controller/transcodersnapshot.go
@@ -494,6 +494,7 @@ func makeHTTPListener(httpConfig httpListenerConfig, transcoders []transcoderWit
 				TypedConfig: fileAccessLog,
 			},
 		}},
+		StreamIdleTimeout: durationpb.New(30 * time.Minute),
 		RouteSpecifier: &hcm.HttpConnectionManager_RouteConfig{
 			RouteConfig: &route.RouteConfiguration{
 				Name: LocalRouteName,


### PR DESCRIPTION
* State file to stable location
* Add node group name to metadata.json, so cleanup command can read it and avoid asking user for `--name` input
* Add background process ID to metadata.json, so cleanup command can read it and seng SIGTERM signal
* Implement SIGTERM handler to buildx proxy
* Print informative message even when buildx proxy is run in background
* Delete state folder when cleanup command is called
* Print error message if state metadata.json file is found

Fixes: NSL-1137