### PR TITLE
legal: require signing of CLA by external contributors

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,26 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_GITHUB_TOKEN }}
+        with:
+          remote-organization-name: 'namespacelabs'
+          remote-repository-name: 'cla'
+          path-to-signatures: 'v2023-06-06/signatures.json'
+          path-to-document: 'https://github.com/namespacelabs/cla/blob/main/README.md'
+          # branch should not be protected
+          branch: 'main'
+          allowlist: dependabot*


### PR DESCRIPTION
Opening a proposal that external contributors are required to sign a CLA (contents undefined) which is enforced via GitHub Actions.

Next steps:
- Discuss implementation of a CLA
- Create https://github.com/namespacelabs/cla repo
- Create CLA document at https://github.com/namespacelabs/cla/README.md
- Create `CLA_GITHUB_TOKEN` token which has write access to `namespacelabs/cla`

See https://github.com/coder/cla/tree/main as an example of this running in the wild

Each time `https://github.com/namespacelabs/cla/README.md` is updated then the workflow should bump the vYYYY-MM-DD` field in the GitHub Actions yaml to ensure folks read/review/sign with the updated terms.