### PR TITLE
std/monitoring/jaeger: limit number of in-memory traces

### DIFF
--- a/std/monitoring/jaeger/server.cue
+++ b/std/monitoring/jaeger/server.cue
@@ -27,6 +27,10 @@ server: fn.#OpaqueServer & {
 
 configure: {
 	startup: {
+		args: {
+			"memory.max-traces": "2500000"
+		}
+
 		env: {
 			COLLECTOR_OTLP_ENABLED: "true"
 		}


### PR DESCRIPTION
Fixes NSL-1165