### PR TITLE
WIP: Implement Windows support for buildx

### DIFF
--- a/framework/ulimit/ulimit_unix.go
+++ b/framework/ulimit/ulimit_unix.go
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 
+//go:build unix
+// +build unix
+
 package ulimit
 
 import (

--- a/framework/ulimit/ulimit_windows.go
+++ b/framework/ulimit/ulimit_windows.go
@@ -1,0 +1,13 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package ulimit
+
+func SetFileLimit(n uint64) error {
+	// noop, on windows there is no open file limit.
+	return nil
+}

--- a/internal/cli/cmd/cluster/attachdocker.go
+++ b/internal/cli/cmd/cluster/attachdocker.go
@@ -120,7 +120,7 @@ func newDockerAttachCmd() *cobra.Command {
 			md := store.Metadata{
 				Endpoints: map[string]interface{}{
 					docker.DockerEndpoint: docker.EndpointMeta{
-						Host: "unix://" + sockPath,
+						Host: toDockerUrl(sockPath),
 					},
 				},
 				Metadata: command.DockerContext{

--- a/internal/cli/cmd/cluster/buildkit.go
+++ b/internal/cli/cmd/cluster/buildkit.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	builderv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/builder/v1beta"
@@ -238,9 +237,7 @@ func startBackgroundProxy(ctx context.Context, md buildxInstanceMetadata, connec
 		}
 	}
 
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid: true,
-	}
+	cmd.SysProcAttr = startBackgroundProxySysProcAttr
 
 	fmt.Fprintf(console.Debug(ctx), "Running background command %q\n", strings.Join(cmd.Args, " "))
 	if err := cmd.Start(); err != nil {
@@ -257,7 +254,7 @@ func startBackgroundProxy(ctx context.Context, md buildxInstanceMetadata, connec
 }
 
 func runBuildctl(ctx context.Context, buildctlBin buildctl.Buildctl, p *buildProxyWithRegistry, args ...string) error {
-	cmdLine := []string{"--addr", "unix://" + p.BuildkitAddr}
+	cmdLine := []string{"--addr", toDockerUrl(p.BuildkitAddr)}
 	cmdLine = append(cmdLine, args...)
 
 	fmt.Fprintf(console.Debug(ctx), "buildctl %s\n", strings.Join(cmdLine, " "))

--- a/internal/cli/cmd/cluster/buildkit_unix.go
+++ b/internal/cli/cmd/cluster/buildkit_unix.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build unix
+// +build unix
+
+package cluster
+
+import (
+	"syscall"
+)
+
+var startBackgroundProxySysProcAttr = &syscall.SysProcAttr{
+	Setsid: true,
+}

--- a/internal/cli/cmd/cluster/buildkit_windows.go
+++ b/internal/cli/cmd/cluster/buildkit_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package cluster
+
+import (
+	"syscall"
+)
+
+// TODO: do we need to set anything here?
+var startBackgroundProxySysProcAttr = &syscall.SysProcAttr{}

--- a/internal/cli/cmd/cluster/buildproxy_unix.go
+++ b/internal/cli/cmd/cluster/buildproxy_unix.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build unix
+// +build unix
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+	"namespacelabs.dev/foundation/internal/workspace/dirs"
+)
+
+func toDockerUrl(path string) string {
+	return "unix://" + path
+}
+
+func crossPlatformListen(path string) (net.Listener, error) {
+	if err := unix.Unlink(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+func internalListenProxy(ctx context.Context, socketPath *string, platform string) (net.Listener, func() error, error) {
+	var cleanup func() error
+	if *socketPath == "" {
+		sockDir, err := dirs.CreateUserTempDir("", fmt.Sprintf("buildkit.%v", platform))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		*socketPath = filepath.Join(sockDir, "buildkit.sock")
+		cleanup = func() error {
+			return os.RemoveAll(sockDir)
+		}
+	} else {
+		if err := unix.Unlink(*socketPath); err != nil && !os.IsNotExist(err) {
+			return nil, nil, err
+		}
+	}
+
+	var d net.ListenConfig
+	listener, err := d.Listen(ctx, "unix", *socketPath)
+	if err != nil {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+
+		return nil, nil, err
+	}
+
+	return listener, cleanup, nil
+}

--- a/internal/cli/cmd/cluster/buildproxy_windows.go
+++ b/internal/cli/cmd/cluster/buildproxy_windows.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/google/uuid"
+)
+
+func toDockerUrl(path string) string {
+	return "npipe://" + strings.ReplaceAll(path, "\\", "/")
+}
+
+func crossPlatformListen(path string) (net.Listener, error) {
+	// From Microsoft docs: An instance of a named pipe is always deleted when the last handle to the instance of the named pipe is closed.
+	// https://learn.microsoft.com/en-gb/windows/win32/api/winbase/nf-winbase-createnamedpipea
+	return winio.ListenPipe(path, &winio.PipeConfig{})
+}
+
+func internalListenProxy(ctx context.Context, socketPath *string, platform string) (net.Listener, func() error, error) {
+	if *socketPath == "" {
+		*socketPath = filepath.Join("\\\\.\\pipe\\", fmt.Sprintf("nsc-%v-buildkit.%v", uuid.New().String(), platform))
+	}
+
+	// As named pipes can't be removed on windows, no need to check for existence prior to listening.
+	// If the named pipe already exists, and another process listens it will fail then.
+	listener, err := crossPlatformListen(*socketPath)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return listener, func() error { return nil }, nil
+}

--- a/internal/cli/cmd/cluster/docker.go
+++ b/internal/cli/cmd/cluster/docker.go
@@ -132,7 +132,7 @@ func connectToDocker(ctx context.Context, token fnapi.Token, cluster *api.Kubern
 }
 
 func runDocker(ctx context.Context, socketPath string, args ...string) error {
-	cmdLine := []string{"-H", "unix://" + socketPath}
+	cmdLine := []string{"-H", toDockerUrl(socketPath)}
 	cmdLine = append(cmdLine, args...)
 
 	docker := exec.CommandContext(ctx, "docker", cmdLine...)

--- a/internal/cli/cmd/cluster/execscoped.go
+++ b/internal/cli/cmd/cluster/execscoped.go
@@ -103,7 +103,7 @@ var constructors = map[string]func(context.Context, *api.KubernetesCluster) (inj
 
 		return injected{
 			Env: []string{
-				"DOCKER_HOST=unix://" + p.SocketAddr,
+				"DOCKER_HOST=" + toDockerUrl(p.SocketAddr),
 			},
 			Cleanup: p.Cleanup,
 		}, nil

--- a/internal/cli/cmd/cluster/proxy.go
+++ b/internal/cli/cmd/cluster/proxy.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -67,10 +66,8 @@ func NewProxyCmd() *cobra.Command {
 
 func setupBackgroundProxy(ctx context.Context, clusterId, kind, sockPath, pidFile string) error {
 	cmd := exec.Command(os.Args[0], "cluster", "proxy", "--kind", kind, "--sock_path", sockPath, "--cluster", clusterId, "--region", endpoint.RegionName)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Foreground: false,
-		Setsid:     true,
-	}
+
+	cmd.SysProcAttr = setupBackgroundProxySysProcAttr
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/internal/cli/cmd/cluster/proxy_unix.go
+++ b/internal/cli/cmd/cluster/proxy_unix.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build unix
+// +build unix
+
+package cluster
+
+import (
+	"syscall"
+)
+
+var setupBackgroundProxySysProcAttr = &syscall.SysProcAttr{
+	Foreground: false,
+	Setsid:     true,
+}

--- a/internal/cli/cmd/cluster/proxy_windows.go
+++ b/internal/cli/cmd/cluster/proxy_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package cluster
+
+import (
+	"syscall"
+)
+
+// TODO: do we need to set anything here?
+var setupBackgroundProxySysProcAttr = &syscall.SysProcAttr{}

--- a/internal/cli/cmd/cluster/ssh.go
+++ b/internal/cli/cmd/cluster/ssh.go
@@ -10,9 +10,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	c "github.com/containerd/console"
 	"github.com/mattn/go-isatty"
@@ -221,26 +219,4 @@ func InlineSsh(ctx context.Context, cluster *api.KubernetesCluster, sshAgent boo
 			return g.Wait()
 		}
 	})
-}
-
-func listenForResize(ctx context.Context, stdin c.Console, session *ssh.Session) {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGWINCH)
-
-	defer func() {
-		signal.Stop(sig)
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-sig:
-		}
-
-		w, h, err := term.GetSize(int(stdin.Fd()))
-		if err == nil {
-			session.WindowChange(h, w)
-		}
-	}
 }

--- a/internal/cli/cmd/cluster/ssh_unix.go
+++ b/internal/cli/cmd/cluster/ssh_unix.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build unix
+// +build unix
+
+package cluster
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	c "github.com/containerd/console"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+)
+
+func listenForResize(ctx context.Context, stdin c.Console, session *ssh.Session) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGWINCH)
+
+	defer func() {
+		signal.Stop(sig)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sig:
+		}
+
+		w, h, err := term.GetSize(int(stdin.Fd()))
+		if err == nil {
+			session.WindowChange(h, w)
+		}
+	}
+}

--- a/internal/cli/cmd/cluster/ssh_windows.go
+++ b/internal/cli/cmd/cluster/ssh_windows.go
@@ -1,0 +1,19 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package cluster
+
+import (
+	"context"
+
+	c "github.com/containerd/console"
+	"golang.org/x/crypto/ssh"
+)
+
+func listenForResize(ctx context.Context, stdin c.Console, session *ssh.Session) {
+	// listen for resize is not available on windows.
+}

--- a/internal/cli/cmd/cluster/unixsockproxy_unix.go
+++ b/internal/cli/cmd/cluster/unixsockproxy_unix.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build unix
+// +build unix
+
+package cluster
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+	"namespacelabs.dev/foundation/internal/workspace/dirs"
+)
+
+func crossPlatformUnixSocketProxyListen(ctx context.Context, socketPath *string, clusterId string, kind string) (net.Listener, func(), error) {
+	var cleanup func()
+
+	if *socketPath == "" {
+		sockDir, err := dirs.CreateUserTempDir("", clusterId)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		*socketPath = filepath.Join(sockDir, kind+".sock")
+		cleanup = func() {
+			os.RemoveAll(sockDir)
+		}
+	} else {
+		cleanup = func() {}
+	}
+
+	if err := unix.Unlink(*socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+
+	var d net.ListenConfig
+	listener, err := d.Listen(ctx, "unix", *socketPath)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	return listener, cleanup, err
+}

--- a/internal/cli/cmd/cluster/unixsockproxy_windows.go
+++ b/internal/cli/cmd/cluster/unixsockproxy_windows.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+func crossPlatformUnixSocketProxyListen(ctx context.Context, socketPath *string, clusterId string, kind string) (net.Listener, func(), error) {
+	if *socketPath == "" {
+		*socketPath = filepath.Join("\\\\.\\pipe\\", fmt.Sprintf("nsc-%v-%v-%v", uuid.New().String(), clusterId, kind))
+	}
+
+	// As named pipes can't be removed on windows, no need to check for existence prior to listening.
+	// If the named pipe already exists, and another process listens it will fail then.
+	listener, err := crossPlatformListen(*socketPath)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return listener, func() {}, nil
+}

--- a/internal/console/termios/termios_unix.go
+++ b/internal/console/termios/termios_unix.go
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 
+//go:build unix
+// +build unix
+
 package termios
 
 import (

--- a/internal/console/termios/termios_windows.go
+++ b/internal/console/termios/termios_windows.go
@@ -1,0 +1,47 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build windows
+// +build windows
+
+package termios
+
+import "golang.org/x/sys/windows"
+
+func IsTerm(fd uintptr) bool {
+	var st uint32
+	err := windows.GetConsoleMode(windows.Handle(fd), &st)
+	return err == nil
+}
+
+func TermSize(fd uintptr) (WinSize, error) {
+	var info windows.ConsoleScreenBufferInfo
+	if err := windows.GetConsoleScreenBufferInfo(windows.Handle(fd), &info); err != nil {
+		return WinSize{}, err
+	}
+	var ts WinSize
+	ts.Height = uint16(info.Window.Bottom - info.Window.Top + 1)
+	ts.Width = uint16(info.Window.Right - info.Window.Left + 1)
+
+	return ts, nil
+}
+
+func MakeRaw(fd uintptr) (func() error, error) {
+	var oldState uint32
+	if err := windows.GetConsoleMode(windows.Handle(fd), &oldState); err != nil {
+		return nil, err
+	}
+
+	raw := oldState &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT)
+	if err := windows.SetConsoleMode(windows.Handle(fd), raw); err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		return windows.SetConsoleMode(windows.Handle(oldState), raw)
+	}, nil
+}

--- a/internal/console/tui/asksecret.go
+++ b/internal/console/tui/asksecret.go
@@ -15,7 +15,7 @@ import (
 )
 
 func AskSecret(ctx context.Context, title, desc, placeholder string) ([]byte, error) {
-	if !term.IsTerminal(syscall.Stdin) {
+	if !term.IsTerminal(int(syscall.Stdin)) {
 		reader := bufio.NewReader(os.Stdin)
 		// Read until (required) newline.
 		s, err := reader.ReadString('\n')

--- a/internal/disk/disk_windows.go
+++ b/internal/disk/disk_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+// +build windows
+
+package disk
+
+// We don't require filesystem information in Windows. Filesystem information
+// is used temporarily as part of #121, which doesn't affect Windows. This
+// package is expected to be removed afterwards.
+func FSType(path string) (string, error) {
+	return "unknown", nil
+}


### PR DESCRIPTION
WIP: There are still a lot of issues, like errors when stopping the server, and cleanup fails.

But using remote builder already succeeds.

We are using named pipes on Windows, with a `net.Listener` implementation from Microsoft.

Docker buildx ls output:
```
PS C:\Users\gordon> docker buildx ls
NAME/NODE           DRIVER/ENDPOINT                              STATUS    BUILDKIT            PLATFORMS
nsc-remote          remote
 \_ amd64            \_ npipe:////./pipe/nsc-buildx/amd64.sock   running   v0.13.0-namespace   linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
 \_ arm64            \_ npipe:////./pipe/nsc-buildx/arm64.sock   running   v0.13.0-namespace   linux/arm64*, linux/arm64/v6, linux/arm64/v7
```