### PR TITLE
providers/vault: use URI like CN if base_domain is provided

### DIFF
--- a/internal/providers/vault/certificate.go
+++ b/internal/providers/vault/certificate.go
@@ -49,7 +49,7 @@ func certificateProvider(ctx context.Context, conf cfg.Configuration, secretId s
 	}
 
 	if certConfig, ok := GetCertificateConfig(conf); ok && certConfig.GetBaseDomain() != "" {
-		req.commonName = fmt.Sprintf("%s.%s", req.commonName, certConfig.GetBaseDomain())
+		req.commonName = fmt.Sprintf("%s/%s", certConfig.GetBaseDomain(), req.commonName)
 	}
 
 	return issueCertificate(ctx, vaultClient, cfg.GetMount(), cfg.GetRole(), req)

--- a/internal/providers/vault/certificate.go
+++ b/internal/providers/vault/certificate.go
@@ -24,8 +24,9 @@ const (
 )
 
 type certificateRequest struct {
-	commonName string
-	sans       []string
+	commonName        string
+	sans              []string
+	excludeCnFromSans bool
 }
 
 func certificateProvider(ctx context.Context, conf cfg.Configuration, secretId secrets.SecretIdentifier, cfg *vault.Certificate) ([]byte, error) {
@@ -50,6 +51,7 @@ func certificateProvider(ctx context.Context, conf cfg.Configuration, secretId s
 
 	if certConfig, ok := GetCertificateConfig(conf); ok && certConfig.GetBaseDomain() != "" {
 		req.commonName = fmt.Sprintf("%s/%s", certConfig.GetBaseDomain(), req.commonName)
+		req.excludeCnFromSans = true
 	}
 
 	return issueCertificate(ctx, vaultClient, cfg.GetMount(), cfg.GetRole(), req)
@@ -60,8 +62,9 @@ func issueCertificate(ctx context.Context, vaultClient *vaultclient.Client, pkiM
 		func(ctx context.Context) ([]byte, error) {
 			issueResp, err := vaultClient.Secrets.PkiIssueWithRole(ctx, pkiRole,
 				schema.PkiIssueWithRoleRequest{
-					CommonName: req.commonName,
-					AltNames:   strings.Join(req.sans, ","),
+					CommonName:        req.commonName,
+					AltNames:          strings.Join(req.sans, ","),
+					ExcludeCnFromSans: req.excludeCnFromSans,
 				},
 				vaultclient.WithMountPath(pkiMount),
 			)

--- a/internal/versions/versions.json
+++ b/internal/versions/versions.json
@@ -1,5 +1,5 @@
 {
-	"api_version": 126,
+	"api_version": 127,
 	"minimum_api_version": 40,
 	"cache_version": 1
 }


### PR DESCRIPTION
If `common_name` is defined as `svc/foo`, then certificate CN would be `example.com/svc/foo`.