### PR TITLE
std/go/grpc: add an option to provide CA cert via ENV var

### DIFF
--- a/std/go/grpc/servercore/mtls.go
+++ b/std/go/grpc/servercore/mtls.go
@@ -34,9 +34,7 @@ func getMtlsConfig() (*tls.Config, error) {
 	}
 
 	pool := x509.NewCertPool()
-	for _, cert := range tb.CaChainPem {
-		pool.AppendCertsFromPEM([]byte(cert))
-	}
+	pool.AppendCertsFromPEM([]byte(os.Getenv("FOUNDATION_GRPCSERVER_CA_CERT")))
 
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},


### PR DESCRIPTION
Fixes NSL-3256