### PR TITLE
grpc: specify loopback address in one place only

### DIFF
--- a/std/grpc/wire.go
+++ b/std/grpc/wire.go
@@ -29,7 +29,7 @@ func ProvideConn(ctx context.Context, req *Backend) (*grpc.ClientConn, error) {
 	endpoint := connMapFromArgs()[key]
 	if endpoint == "" {
 		// If there's no endpoint configured, assume we're doing a loopback.
-		endpoint = fmt.Sprintf("127.0.0.1:%d", server.ListenPort())
+		return Loopback(ctx)
 	}
 
 	// XXX ServerResource wrapping is missing.


### PR DESCRIPTION
This is a no-op change but the idea is to have a single function provide the loopback client.