### PR TITLE
nsc: exec the latest version if available

### DIFF
--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -80,3 +80,7 @@ func ShouldCheckUpdate(ver *storage.NamespaceBinaryVersion) bool {
 	_, have := os.LookupEnv("NS_DO_NOT_UPDATE")
 	return !have
 }
+
+func ShouldUseCachedUpdate(ver *storage.NamespaceBinaryVersion) bool {
+	return !isDevelopmentBuild(ver)
+}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -14,10 +14,8 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 )
 
-var (
-	//go:embed versions.json
-	lib embed.FS
-)
+//go:embed versions.json
+var lib embed.FS
 
 type InternalVersions struct {
 	// APIVersion represents the overall version of Namespaces's semantics, which
@@ -89,5 +87,7 @@ const IntroducedGrpcTranscodeNode = 35
 // Embedded into provisioning tools.
 const ToolAPIVersion = 4
 
-const ToolsIntroducedCompression = 3
-const ToolsIntroducedInlineInvocation = 4
+const (
+	ToolsIntroducedCompression      = 3
+	ToolsIntroducedInlineInvocation = 4
+)


### PR DESCRIPTION
`exec` into the latest version of `nsc` if there is one in the local cache.

Will not `exec` if using a development version (i.e. one **not** built by `goreleaser`).