### PR TITLE
buildkitknob

### DIFF
--- a/std/go/grpc/servercore/configurations.go
+++ b/std/go/grpc/servercore/configurations.go
@@ -16,6 +16,7 @@ import (
 var configConfigs = map[string]ListenerConfiguration{}
 
 type DefaultConfiguration struct{}
+type DefaultConfigurationWithSharedMtls struct{}
 
 type ListenerConfiguration interface {
 	CreateListener(context.Context, string, ListenOpts) (net.Listener, error)
@@ -24,6 +25,13 @@ type ListenerConfiguration interface {
 type GrpcListenerConfiguration interface {
 	ListenerConfiguration
 	TransportCredentials(string) credentials.TransportCredentials
+	ServerOpts(string) []grpc.ServerOption
+}
+
+type SharedMtlsGrpcListenerConfiguration interface {
+	ListenerConfiguration
+
+	UseFoundationMTLSConfiguration()
 	ServerOpts(string) []grpc.ServerOption
 }
 
@@ -48,3 +56,5 @@ func listenerConfiguration(name string) ListenerConfiguration {
 func (DefaultConfiguration) CreateListener(ctx context.Context, name string, opts ListenOpts) (net.Listener, error) {
 	return opts.CreateNamedListener(ctx, name)
 }
+
+func (DefaultConfigurationWithSharedMtls) UseFoundationMTLSConfiguration() {}

--- a/std/go/grpc/servercore/listener.go
+++ b/std/go/grpc/servercore/listener.go
@@ -158,6 +158,13 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 				}
 
 				serversByConfiguration[cfg.Name] = append(serversByConfiguration[cfg.Name], grpc.NewServer(x...))
+			} else if cgrp, ok := c.(SharedMtlsGrpcListenerConfiguration); ok {
+				x := append(slices.Clone(grpcopts), cgrp.ServerOpts(cfg.Name)...)
+				if tlsConfig != nil {
+					x = append(x, grpc.Creds(credentials.NewTLS(tlsConfig)))
+				}
+
+				serversByConfiguration[cfg.Name] = append(serversByConfiguration[cfg.Name], grpc.NewServer(x...))
 			} else {
 				return fnerrors.New("listener configuration for %q does not support grpc", cfg.Name)
 			}


### PR DESCRIPTION
- buildkit: add ability to pass a flag to connect to an existing buildkit: --buildkit_addr
- servercore: introduced SharedMtlsGrpcListenerConfiguration that allows creating separate listeners that share the same mtls configuration.
