### PR TITLE
cmd/docker-credential-nsc/binary.cue: Add an ns binary definition.

### DIFF
--- a/cmd/docker-credential-nsc/binary.cue
+++ b/cmd/docker-credential-nsc/binary.cue
@@ -1,0 +1,10 @@
+binary: {
+	name: "docker-credential-nsc"
+
+	build_plan: [
+		{go_build: {
+			binary_name: "docker-credential-nsc"
+			binary_only: true
+		}},
+	]
+}


### PR DESCRIPTION
ref NSL-4059