### PR TITLE
gitcheckout: Fix workers exiting when a work item is done

### DIFF
--- a/internal/cli/cmd/cluster/gitcheckout.go
+++ b/internal/cli/cmd/cluster/gitcheckout.go
@@ -453,7 +453,9 @@ func (p *processor) workerForDoEnsureMirror(ctx context.Context) error {
 	for {
 		select {
 		case work := <-p.doEnsureMirrorJobQueue:
-			return p.doEnsureMirror(ctx, work)
+			if err := p.doEnsureMirror(ctx, work); err != nil {
+				return err
+			}
 
 		case <-p.doneSignal:
 			return nil


### PR DESCRIPTION
Workers should only exit when the full process is done (doneSignal) or
when canceled.
They should not exit when a single work item finished without error.
