### PR TITLE
Use session client cert for buildx outside of ns instances

### DIFF
--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -171,6 +171,16 @@ func (t *Token) IssueToken(ctx context.Context, minDur time.Duration, issueShort
 	return t.BearerToken, nil
 }
 
+type IssueCertFunc func(context.Context, string, string) (string, error)
+
+func (t *Token) ExchangeForSessionClientCert(ctx context.Context, publicKeyPem string, issueFromSession IssueCertFunc) (string, error) {
+	if t.SessionToken == "" {
+		return "", fnerrors.New("ExchangeForSessionClientCert called on a token which is not a session token")
+	}
+
+	return issueFromSession(ctx, t.SessionToken, publicKeyPem)
+}
+
 func StoreTenantToken(token string) error {
 	return StoreToken(Token{BearerToken: token})
 }

--- a/internal/cli/cmd/auth/login.go
+++ b/internal/cli/cmd/auth/login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"namespacelabs.dev/foundation/internal/auth"
+	"namespacelabs.dev/foundation/internal/cli/cmd/cluster"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnapi"
@@ -67,6 +68,16 @@ func NewLoginCmd() *cobra.Command {
 				if err := auth.StoreTenantToken(c.TenantToken); err != nil {
 					return err
 				}
+			}
+
+			// Buildx with the server-side proxy could be authenticating using a session client certificate.
+			// Trigger a refresh of that certificate too.
+			refreshed, err := cluster.RefreshSessionClientCert(ctx)
+			if err != nil {
+				fmt.Fprintf(stdout, "\nRefreshing session client cert for buildx failed: %v.\n", err)
+			}
+			if refreshed {
+				fmt.Fprintf(stdout, "\nSuccessfully refreshed session client cert for buildx.\n")
 			}
 
 			if c.TenantName != "" {

--- a/internal/cli/cmd/cluster/buildx.go
+++ b/internal/cli/cmd/cluster/buildx.go
@@ -354,6 +354,27 @@ func ensureStateDir(specified, dir string) (string, error) {
 	return dirs.Ensure(filepath.Join(s, proxyDir), nil)
 }
 
+// Returns the default state directory for nsc buildkit state.
+// Otherwise returns "".
+func getDefaultStateDirIfExists(dir string) (string, error) {
+	// Mimic the logic of ensureStateDir but don't create directories.
+	oldStateDirPath, err := dirs.Subdir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	if proxyAlreadyExists(oldStateDirPath) {
+		return oldStateDirPath, nil
+	}
+
+	newStateDirPath, err := dirs.ConfigSubdir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	return newStateDirPath, nil
+}
+
 func ensureLogDir(dir string) (string, error) {
 	return dirs.Ensure(dirs.Logs(dir))
 }

--- a/internal/fnapi/fnapi.go
+++ b/internal/fnapi/fnapi.go
@@ -103,6 +103,25 @@ func IssueTenantTokenFromSession(ctx context.Context, sessionToken string, durat
 	return resp.TenantToken, nil
 }
 
+func IssueSessionClientCertFromSession(ctx context.Context, sessionToken string, publicKeyPem string) (string, error) {
+	req := IssueSessionClientCertFromSessionRequest{
+		PublicKeyPem: publicKeyPem,
+	}
+
+	var resp IssueSessionClientCertFromSessionResponse
+
+	if err := (Call[IssueSessionClientCertFromSessionRequest]{
+		Method: "nsl.signin.SigninService/IssueSessionClientCertFromSession",
+		IssueBearerToken: func(ctx context.Context) (ResolvedToken, error) {
+			return ResolvedToken{BearerToken: sessionToken}, nil
+		},
+	}).Do(ctx, req, ResolveIAMEndpoint, DecodeJSONResponse(&resp)); err != nil {
+		return "", err
+	}
+
+	return resp.ClientCertificatePem, nil
+}
+
 type Call[RequestT any] struct {
 	Method           string
 	IssueBearerToken func(context.Context) (ResolvedToken, error)

--- a/internal/fnapi/signin.go
+++ b/internal/fnapi/signin.go
@@ -37,6 +37,14 @@ type IssueTenantTokenFromSessionResponse struct {
 	TenantToken string `json:"tenant_token,omitempty"`
 }
 
+type IssueSessionClientCertFromSessionRequest struct {
+	PublicKeyPem string `json:"public_key_pem,omitempty"`
+}
+
+type IssueSessionClientCertFromSessionResponse struct {
+	ClientCertificatePem string `json:"client_certificate_pem,omitempty"`
+}
+
 // Returns the URL which the user should open.
 func StartLogin(ctx context.Context, tenantId string, sessionDuration time.Duration) (*StartLoginResponse, error) {
 	req := StartLoginRequest{

--- a/internal/fnapi/tokens.go
+++ b/internal/fnapi/tokens.go
@@ -21,6 +21,9 @@ type Token interface {
 	Claims(context.Context) (*auth.TokenClaims, error)
 	PrimaryRegion(context.Context) (string, error)
 	IssueToken(context.Context, time.Duration, func(context.Context, string, time.Duration) (string, error), bool) (string, error)
+
+	// This fails if it is not a session token.
+	ExchangeForSessionClientCert(ctx context.Context, publicKeyPem string, issueFromSession auth.IssueCertFunc) (string, error)
 }
 
 func BearerToken(ctx context.Context, t Token, skipCache bool) (string, error) {


### PR DESCRIPTION
If not running on a ns instance and a session token is available, use a session client cert for auth to the buildx proxy.

Also refresh it if it existed and then nsc login was performed.