### PR TITLE
Set GRPC_ENFORCE_ALPN_ENABLED false for go-grpc servers

### DIFF
--- a/std/go/grpc/extension.cue
+++ b/std/go/grpc/extension.cue
@@ -22,5 +22,13 @@ configure: fn.#Configure & {
 			listen_hostname: "0.0.0.0"
 			grpcserver_port: "\($inputs.serverPort.port)"
 		}
+
+		env: {
+			// go-grpc started requiring ALPN in TLS handshakes with go-grpc 1.67.0
+			// (https://github.com/grpc/grpc-go/pull/7535), but not all external
+			// clients send it (notably many buildkit clients don't).
+			// This instructs go-grpc to not enforce it for now.
+			GRPC_ENFORCE_ALPN_ENABLED: "false"
+		}
 	}
 }


### PR DESCRIPTION
This is necessary to support some clients with the go-grpc 1.67+ uprev.

See also NSL-4866 and NSL-4857.