### PR TITLE
Don't digest local inputs in buildkit builds by default

### DIFF
--- a/internal/build/buildkit/base.go
+++ b/internal/build/buildkit/base.go
@@ -54,7 +54,7 @@ func (l *baseRequest[V]) Inputs() *compute.In {
 		for k, local := range l.localDirs {
 			in = in.
 				Computable(fmt.Sprintf("local%d:contents", k), memfs.DeferSnapshot(local.Module.ReadOnlyFS(local.Path), memfs.SnapshotOpts{
-					ExcludePatterns: local.ExcludePatterns,
+					ExcludePatterns: MakeLocalExcludes(local),
 				})).
 				Str(fmt.Sprintf("local%d:path", k), local.Path)
 		}

--- a/internal/build/buildkit/computable.go
+++ b/internal/build/buildkit/computable.go
@@ -27,7 +27,7 @@ const (
 var SkipExpectedMaxWorkspaceSizeCheck = false
 
 // XXX make this a flag instead. The assumption here is that in CI the filesystem is readonly.
-var PreDigestLocalInputs = environment.IsRunningInCI()
+var PreDigestLocalInputs = environment.IsRunningInCI() || !environment.DigestLocalInputs()
 
 type LocalContents struct {
 	Module build.Workspace

--- a/internal/environment/ci.go
+++ b/internal/environment/ci.go
@@ -9,3 +9,7 @@ import "os"
 func IsRunningInCI() bool {
 	return os.Getenv("CI") != ""
 }
+
+func DigestLocalInputs() bool {
+	return os.Getenv("DIGEST_LOCAL_INPUTS") == "true"
+}


### PR DESCRIPTION
This is a quick workaround for https://linear.app/namespacelabs/issue/NSL-4847/ns-build-binary-consumes-all-memory