### PR TITLE
internal/ssh: use SSH_AUTH_SOCK env var when it is set

### DIFF
--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -192,8 +192,14 @@ func Establish(ctx context.Context, endpoint Endpoint) (*Deferred, error) {
 			config.Auth = append(config.Auth, key)
 		}
 
-		if endpoint.AgentSockPath != "" {
-			path, err := dirs.ExpandHome(os.ExpandEnv(endpoint.AgentSockPath))
+		agentSock := endpoint.AgentSockPath
+		if agentSockEnv := os.Getenv("SSH_AUTH_SOCK"); agentSock == "" && agentSockEnv != "" {
+			agentSock = agentSockEnv
+		}
+
+		if agentSock != "" {
+			fmt.Fprintf(console.Debug(ctx), "ssh: using ssh-agent socket: %s\n", agentSock)
+			path, err := dirs.ExpandHome(os.ExpandEnv(agentSock))
 			if err != nil {
 				return nil, fnerrors.New("failed to resolve ssh agent path: %w", err)
 			}


### PR DESCRIPTION
Currently in order to use ssh-agent, necessary to set agent socket path in a remote configuration.
But when you want to use different authentication methods locally and in CI, then different configurations required, which is not convenient as whole workspace configuration needs to be duplicated. With this patch we are closer to a default behaviour of most of SSH tools.