### PR TITLE
nsc/gcp: trim leading slashes from gcp identity provider input

### DIFF
--- a/internal/cli/cmd/gcp/federation.go
+++ b/internal/cli/cmd/gcp/federation.go
@@ -49,6 +49,11 @@ func newImpersonateCmd() *cobra.Command {
 			ip = strings.TrimPrefix(ip, gcpIamUrl)
 		}
 
+		// Trim leading slashes
+		for strings.HasPrefix(ip, "/") {
+			ip = strings.TrimPrefix(ip, "/")
+		}
+
 		resp, err := fnapi.IssueIdToken(ctx, fmt.Sprintf("%s/%s", gcpIamUrl, ip), idTokenVersion)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### nsc/gcp: trim leading slashes from gcp identity provider input

This fixes support for identity providers in the formats:
 - `https://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/providers/<PROVIDER_ID>`
 - `/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/providers/<PROVIDER_ID>`
<!-- pr-cli body end -->