### PR TITLE
buildx: Fix wrong platform specifier

### DIFF
--- a/internal/cli/cmd/cluster/server_side_buildx.go
+++ b/internal/cli/cmd/cluster/server_side_buildx.go
@@ -77,7 +77,7 @@ func PrepareServerSideBuildxProxy(ctx context.Context, stateDir string, platform
 		}
 
 		builderConfigs = append(builderConfigs, BuilderConfig{
-			Platform:             bc.GetShape().GetMachineArch() + "/" + bc.GetShape().GetOs(),
+			Platform:             bc.GetShape().GetOs() + "/" + bc.GetShape().GetMachineArch(),
 			Arch:                 bc.GetShape().GetMachineArch(),
 			FullBuildkitEndpoint: bc.GetFullBuildkitEndpoint(),
 			ServerCAPath:         serverCAPath,


### PR DESCRIPTION
This fixes a regression introduced in 81c88bf5821607176a17477cc106a695dcd18eae