### PR TITLE
nsc/gcp: allow configuring token duration for nsc gcp impersonate

### DIFF
--- a/internal/cli/cmd/auth/oidc.go
+++ b/internal/cli/cmd/auth/oidc.go
@@ -30,13 +30,14 @@ func NewIssueIdTokenCmd() *cobra.Command {
 
 	audience := cmd.Flags().String("audience", "", "The audience of an ID token.")
 	output := cmd.Flags().StringP("output", "o", "plain", "One of plain or json.")
+	duration := cmd.Flags().Duration("duration", 0, "How long the token should last")
 
 	return fncobra.Cmd(cmd).Do(func(ctx context.Context) error {
 		if *audience == "" {
 			return fmt.Errorf("ID token audience is not provided")
 		}
 
-		resp, err := fnapi.IssueIdToken(ctx, *audience, idTokenVersion)
+		resp, err := fnapi.IssueIdToken(ctx, *audience, idTokenVersion, *duration)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/aws/ecr.go
+++ b/internal/cli/cmd/aws/ecr.go
@@ -65,7 +65,7 @@ func newEcrDockerLoginCmd() *cobra.Command {
 		}
 
 		t := time.Now()
-		resp, err := fnapi.IssueIdToken(ctx, "sts.amazonaws.com", idTokenVersion)
+		resp, err := fnapi.IssueIdToken(ctx, "sts.amazonaws.com", idTokenVersion, *duration)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/aws/federation.go
+++ b/internal/cli/cmd/aws/federation.go
@@ -63,7 +63,7 @@ func newAssumeRoleCmd() *cobra.Command {
 		}
 
 		t := time.Now()
-		resp, err := fnapi.IssueIdToken(ctx, "sts.amazonaws.com", idTokenVersion)
+		resp, err := fnapi.IssueIdToken(ctx, "sts.amazonaws.com", idTokenVersion, *duration)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/aws/setupwebidentity.go
+++ b/internal/cli/cmd/aws/setupwebidentity.go
@@ -28,6 +28,7 @@ func newSetupWebIdentity() *cobra.Command {
 	roleArn := cmd.Flags().String("role_arn", "", "The ARN of the role to assume.")
 	envFile := cmd.Flags().String("write_env", "", "Instead of outputting, write the environment variables to the specified file.")
 	tokenDir := cmd.Flags().String("token_dir", "", "If specified, stores any obtained tokens here.")
+	duration := cmd.Flags().Duration("duration", 0, "How long the token should last.")
 
 	return fncobra.Cmd(cmd).Do(func(ctx context.Context) error {
 		if *roleArn == "" {
@@ -63,7 +64,7 @@ func newSetupWebIdentity() *cobra.Command {
 		defer tokenFile.Close()
 
 		t := time.Now()
-		resp, err := fnapi.IssueIdToken(ctx, "sts.amazonaws.com", idTokenVersion)
+		resp, err := fnapi.IssueIdToken(ctx, "sts.amazonaws.com", idTokenVersion, *duration)
 		if err != nil {
 			return err
 		}

--- a/internal/fnapi/tenants.go
+++ b/internal/fnapi/tenants.go
@@ -60,8 +60,9 @@ type TrustAWSCognitoIdentityPoolRequest struct {
 }
 
 type IssueIdTokenRequest struct {
-	Audience string `json:"audience,omitempty"`
-	Version  int    `json:"version,omitempty"`
+	Audience     string `json:"audience,omitempty"`
+	Version      int    `json:"version,omitempty"`
+	DurationSecs int64  `json:"duration_secs,omitempty"`
 }
 
 type IssueIdTokenResponse struct {
@@ -144,10 +145,11 @@ func ExchangeAWSCognitoJWT(ctx context.Context, tenantID, token string) (Exchang
 	return res, nil
 }
 
-func IssueIdToken(ctx context.Context, aud string, version int) (IssueIdTokenResponse, error) {
+func IssueIdToken(ctx context.Context, aud string, version int, duration time.Duration) (IssueIdTokenResponse, error) {
 	req := IssueIdTokenRequest{
-		Audience: aud,
-		Version:  version,
+		Audience:     aud,
+		Version:      version,
+		DurationSecs: int64(duration.Seconds()),
 	}
 
 	var res IssueIdTokenResponse

--- a/universe/vault/credentials.go
+++ b/universe/vault/credentials.go
@@ -320,7 +320,7 @@ func JwtLogin(ctx context.Context, client *vault.Client, authMount, audience str
 		aud = VaultJwtAudience
 	}
 
-	idTokenResp, err := fnapi.IssueIdToken(ctx, audience, 1)
+	idTokenResp, err := fnapi.IssueIdToken(ctx, audience, 1, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### nsc/gcp: allow configuring token duration for nsc gcp impersonate

- Add --duration flag to change the namespace token validity duration
- Add --gcp_token_lifetime flag to change configured gcp token duration
- Use existing duration flag for token in aws, ecr, oidc federation cmds
<!-- pr-cli body end -->