### PR TITLE
cluster/build: Skip adding NSCR prefix if user already specified it

### DIFF
--- a/internal/cli/cmd/cluster/build.go
+++ b/internal/cli/cmd/cluster/build.go
@@ -143,8 +143,13 @@ func NewBuildCmd() *cobra.Command {
 				return fmt.Errorf("Could not fetch nscr.io repository")
 			}
 
+			registryEpPrefix := fmt.Sprintf("%s/%s/", resp.NSCR.EndpointAddress, resp.NSCR.Repository)
 			for _, name := range *names {
-				*tags = append(*tags, fmt.Sprintf("%s/%s/%s", resp.NSCR.EndpointAddress, resp.NSCR.Repository, name))
+				if !strings.HasPrefix(name, registryEpPrefix) {
+					name = registryEpPrefix + name
+				}
+
+				*tags = append(*tags, name)
 			}
 		}
 


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### cluster/build: Skip adding NSCR prefix if user already specified it

Fixes NSL-5950
<!-- pr-cli body end -->