### PR TITLE
build/binary: Stamp built images with build provenance.

### DIFF
--- a/internal/artifacts/oci/annotate.go
+++ b/internal/artifacts/oci/annotate.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package oci
+
+import (
+	"context"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/std/tasks"
+)
+
+func AnnotateImage(src NamedImage, anns map[string]string) compute.Computable[Image] {
+	return &annotateImage{src: src, anns: anns}
+}
+
+type annotateImage struct {
+	src  NamedImage
+	anns map[string]string
+	compute.LocalScoped[Image]
+}
+
+func (al *annotateImage) Action() *tasks.ActionEvent {
+	return tasks.Action("oci.annotate-image").Arg("src", al.src.Description())
+}
+
+func (al *annotateImage) Inputs() *compute.In {
+	return compute.Inputs().Computable("src", al.src.Image()).StrMap("anns", al.anns)
+}
+
+func (al *annotateImage) Compute(ctx context.Context, deps compute.Resolved) (Image, error) {
+	image, _ := compute.GetDep(deps, al.src.Image(), "src")
+	return mutate.Annotations(image.Value, al.anns).(v1.Image), nil
+}

--- a/internal/build/binary/binary.go
+++ b/internal/build/binary/binary.go
@@ -161,10 +161,11 @@ func PrebuiltImageID(ctx context.Context, loc pkggraph.Location, cfg cfg.Configu
 func planImage(ctx context.Context, pl pkggraph.PackageLoader, env cfg.Context, loc pkggraph.Location, bin *schema.Binary, assets assets.AvailableBuildAssets, opts BuildImageOpts) (build.Spec, error) {
 	// We prepare the build spec, as we need information, e.g. whether it's platform independent,
 	// if a prebuilt is specified.
-	spec, err := buildLayeredSpec(ctx, pl, env, loc, bin, assets, opts)
+	layered, err := buildLayeredSpec(ctx, pl, env, loc, bin, assets, opts)
 	if err != nil {
 		return nil, err
 	}
+	spec := StampImage{layered}
 
 	if opts.UsePrebuilts {
 		imgid, err := PrebuiltImageID(ctx, loc, env.Configuration())

--- a/internal/build/binary/stamp.go
+++ b/internal/build/binary/stamp.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package binary
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"namespacelabs.dev/foundation/internal/artifacts/oci"
+	"namespacelabs.dev/foundation/internal/build"
+	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/std/pkggraph"
+)
+
+type StampImage struct {
+	Src build.Spec
+}
+
+func (m StampImage) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
+	anns := map[string]string{}
+
+	if bkBuildURL := os.Getenv("BUILDKITE_BUILD_URL"); bkBuildURL != "" {
+		bkJobID := os.Getenv("BUILDKITE_JOB_ID")
+		anns["org.opencontainers.image.url"] = fmt.Sprintf("%s#%s", bkBuildURL, bkJobID)
+	}
+
+	if bkCommit := os.Getenv("BUILDKITE_COMMIT"); bkCommit != "" {
+		anns["org.opencontainers.image.revision"] = bkCommit
+	}
+
+	im, err := m.Src.BuildImage(ctx, env, conf)
+	if err != nil {
+		return nil, err
+	}
+
+	named := oci.MakeNamedImage(m.Src.Description(), im)
+	return oci.AnnotateImage(named, anns), nil
+}
+
+func (m StampImage) PlatformIndependent() bool { return m.Src.PlatformIndependent() }
+
+func (m StampImage) Description() string { return fmt.Sprintf("Stamp(%s)", m.Src.Description()) }


### PR DESCRIPTION
Set ns.build-workflow-url and ns.source-commit annotations.

ref NSL-5715