### PR TITLE
builds: flag to use server-side mtls proxy for nsc build command

### DIFF
--- a/internal/cli/cmd/cluster/github/build.go
+++ b/internal/cli/cmd/cluster/github/build.go
@@ -68,7 +68,7 @@ func NewBaseImageBuildCmd() *cobra.Command {
 			fragments = append(fragments, bf)
 		}
 
-		if _, err := cluster.StartBuilds(ctx, fragments, cluster.WireBuilder); err != nil {
+		if _, err := cluster.StartBuilds(ctx, fragments, cluster.MakeWireBuilder(false)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Part of: NSL-6123
