### PR TITLE
nsc: un-hide --enable_docker flag for nsc run

### DIFF
--- a/internal/cli/cmd/cluster/run.go
+++ b/internal/cli/cmd/cluster/run.go
@@ -57,7 +57,6 @@ func NewRunCmd() *cobra.Command {
 
 	run.Flags().MarkHidden("label")
 	run.Flags().MarkHidden("internal_extra")
-	run.Flags().MarkHidden("enable_docker")
 	run.Flags().MarkHidden("forward_nsc_state")
 	run.Flags().MarkHidden("network")
 	run.Flags().MarkHidden("experimental")


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### nsc: un-hide --enable_docker flag for nsc run
<!-- pr-cli body end -->