### PR TITLE
nsc: Fallback to docker auth for pulling in base-image upload command

### DIFF
--- a/internal/cli/cmd/baseimage/upload_base_image.go
+++ b/internal/cli/cmd/baseimage/upload_base_image.go
@@ -51,7 +51,7 @@ func newUploadBaseImageCmd() *cobra.Command {
 		desc, err := oci.FetchRemoteDescriptor(
 			ctx,
 			sourceImage.RepoAndDigest(),
-			oci.RegistryAccess{Keychain: api.DefaultKeychain},
+			oci.RegistryAccess{Keychain: api.DefaultKeychainWithFallback},
 		)
 		if err != nil {
 			return fmt.Errorf("failed to fetch %s: %w", sourceImage, err)

--- a/internal/providers/nscloud/api/creds.go
+++ b/internal/providers/nscloud/api/creds.go
@@ -13,12 +13,21 @@ import (
 )
 
 var DefaultKeychain oci.Keychain = defaultKeychain{}
+var DefaultKeychainWithFallback oci.Keychain = defaultKeychain{
+	fallbackToDefaultKeychain: true,
+}
 
-type defaultKeychain struct{}
+type defaultKeychain struct {
+	fallbackToDefaultKeychain bool
+}
 
 func (dk defaultKeychain) Resolve(ctx context.Context, r authn.Resource) (authn.Authenticator, error) {
 	if strings.HasSuffix(r.RegistryStr(), ".nscluster.cloud") || strings.HasSuffix(r.RegistryStr(), ".namespace.systems") || r.RegistryStr() == "nscr.io" || strings.HasSuffix(r.RegistryStr(), ".nscr.io") {
 		return RegistryCreds(ctx)
+	}
+
+	if dk.fallbackToDefaultKeychain {
+		return authn.DefaultKeychain.Resolve(r)
 	}
 
 	return authn.Anonymous, nil


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### nsc: Fallback to docker auth for pulling in base-image upload command
<!-- pr-cli body end -->