### PR TITLE
Add trust-relationships management commands to nsc

### DIFF
--- a/cmd/nsc/cmd/register.go
+++ b/cmd/nsc/cmd/register.go
@@ -20,7 +20,7 @@ import (
 )
 
 func RegisterCommands(root *cobra.Command) {
-	root.AddCommand(auth.NewAuthCmd())
+	root.AddCommand(auth.NewAuthCmdWithTrustRelationships())
 	root.AddCommand(auth.NewLoginCmd()) // register `nsc login` as an alias for `nsc auth login`
 	root.AddCommand(auth.NewLogoutCmd())
 	root.AddCommand(aws.NewAwsCmd())

--- a/internal/cli/cmd/auth/cmd.go
+++ b/internal/cli/cmd/auth/cmd.go
@@ -36,6 +36,12 @@ func NewAuthCmd() *cobra.Command {
 	return cmd
 }
 
+func NewAuthCmdWithTrustRelationships() *cobra.Command {
+	cmd := NewAuthCmd()
+	cmd.AddCommand(NewTrustRelationshipsCmd())
+	return cmd
+}
+
 func printLoginInfo(ctx context.Context, tenant *fnapi.Tenant) {
 	if tenant.Name != "" {
 		fmt.Fprintf(console.Stdout(ctx), "You are now logged into workspace %q, have a nice day.\n", tenant.Name)

--- a/internal/cli/cmd/auth/trust.go
+++ b/internal/cli/cmd/auth/trust.go
@@ -1,0 +1,182 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/fnapi"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+)
+
+func NewTrustRelationshipsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trust-relationships",
+		Short: "Manage trust relationships for authentication.",
+	}
+
+	cmd.AddCommand(newTrustAddCmd())
+	cmd.AddCommand(newTrustListCmd())
+	cmd.AddCommand(newTrustRemoveCmd())
+
+	return cmd
+}
+
+func newTrustAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a new trust relationship.",
+		Long:  `Add a new trust relationship by specifying issuer and subject match patterns.`,
+		Args:  cobra.NoArgs,
+	}
+
+	issuer := cmd.Flags().String("issuer", "", "Token issuer (required).")
+	subjectMatch := cmd.Flags().String("subject-match", "", "Subject match pattern (required).")
+
+	return fncobra.Cmd(cmd).Do(func(ctx context.Context) error {
+		if *issuer == "" {
+			return fnerrors.Newf("--issuer is required")
+		}
+
+		if *subjectMatch == "" {
+			return fnerrors.Newf("--subject-match is required")
+		}
+
+		return addTrustRelationship(ctx, *issuer, *subjectMatch)
+	})
+}
+
+func newTrustListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List existing trust relationships.",
+		Long:  "List trust relationships configured for the current tenant.",
+		Args:  cobra.NoArgs,
+	}
+
+	return fncobra.Cmd(cmd).Do(func(ctx context.Context) error {
+		return listTrustRelationships(ctx)
+	})
+}
+
+func newTrustRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a trust relationship.",
+		Long:  "Remove a trust relationship by specifying its ID.",
+		Args:  cobra.NoArgs,
+	}
+
+	id := cmd.Flags().String("id", "", "ID of the trust relationship to remove (required).")
+
+	return fncobra.Cmd(cmd).Do(func(ctx context.Context) error {
+		if *id == "" {
+			return fnerrors.Newf("--id is required")
+		}
+
+		return removeTrustRelationship(ctx, *id)
+	})
+}
+
+func addTrustRelationship(ctx context.Context, issuer, subjectMatch string) error {
+	// Get current trust relationships
+	current, err := fnapi.ListTrustRelationships(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(console.Stderr(ctx), "Adding trust relationship...\n")
+	fmt.Fprintf(console.Stderr(ctx), "Issuer: %s\n", issuer)
+	fmt.Fprintf(console.Stderr(ctx), "Subject Match: %s\n", subjectMatch)
+
+	// Create new trust relationship (ID and CreatorJson will be set server-side)
+	newTrustRelationship := fnapi.StoredTrustRelationship{
+		Issuer:       issuer,
+		SubjectMatch: subjectMatch,
+	}
+
+	// Add to existing trust relationships
+	updatedTrustRelationships := append(current.TrustRelationships, newTrustRelationship)
+
+	// Update trust relationships
+	if err := fnapi.UpdateTrustRelationships(ctx, current.Generation, updatedTrustRelationships); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(console.Stdout(ctx), "Successfully added trust relationship.\n")
+	return nil
+}
+
+func listTrustRelationships(ctx context.Context) error {
+	response, err := fnapi.ListTrustRelationships(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(console.Stdout(ctx), "Trust Relationships (Generation: %s):\n\n", response.Generation)
+
+	if len(response.TrustRelationships) == 0 {
+		fmt.Fprintf(console.Stdout(ctx), "No trust relationships configured.\n")
+		return nil
+	}
+
+	for _, tr := range response.TrustRelationships {
+		fmt.Fprintf(console.Stdout(ctx), "ID: %s\n", tr.Id)
+		fmt.Fprintf(console.Stdout(ctx), "  Issuer: %s\n", tr.Issuer)
+		fmt.Fprintf(console.Stdout(ctx), "  Subject Match: %s\n", tr.SubjectMatch)
+		if tr.CreatedAt != nil {
+			fmt.Fprintf(console.Stdout(ctx), "  Created At: %s\n", tr.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
+		}
+		if tr.CreatorJson != "" {
+			fmt.Fprintf(console.Stdout(ctx), "  Creator: %s\n", tr.CreatorJson)
+		}
+		fmt.Fprintf(console.Stdout(ctx), "\n")
+	}
+
+	return nil
+}
+
+func removeTrustRelationship(ctx context.Context, id string) error {
+	// Get current trust relationships
+	current, err := fnapi.ListTrustRelationships(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Find and remove the trust relationship with the specified ID
+	var updatedTrustRelationships []fnapi.StoredTrustRelationship
+	var found bool
+	var removedTr fnapi.StoredTrustRelationship
+
+	for _, tr := range current.TrustRelationships {
+		if tr.Id == id {
+			found = true
+			removedTr = tr
+		} else {
+			updatedTrustRelationships = append(updatedTrustRelationships, tr)
+		}
+	}
+
+	if !found {
+		return fnerrors.Newf("trust relationship with ID %q not found", id)
+	}
+
+	fmt.Fprintf(console.Stderr(ctx), "Removing trust relationship...\n")
+	fmt.Fprintf(console.Stderr(ctx), "ID: %s\n", removedTr.Id)
+	fmt.Fprintf(console.Stderr(ctx), "Issuer: %s\n", removedTr.Issuer)
+	fmt.Fprintf(console.Stderr(ctx), "Subject Match: %s\n", removedTr.SubjectMatch)
+
+	// Update trust relationships
+	if err := fnapi.UpdateTrustRelationships(ctx, current.Generation, updatedTrustRelationships); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(console.Stdout(ctx), "Successfully removed trust relationship.\n")
+	return nil
+}

--- a/internal/fnapi/tenants.go
+++ b/internal/fnapi/tenants.go
@@ -254,6 +254,24 @@ type GetTenantResponse struct {
 	Tenant *Tenant `json:"tenant,omitempty"`
 }
 
+type StoredTrustRelationship struct {
+	Id           string     `json:"id,omitempty"`
+	CreatorJson  string     `json:"creator_json,omitempty"`
+	CreatedAt    *time.Time `json:"created_at,omitempty"`
+	Issuer       string     `json:"issuer,omitempty"`
+	SubjectMatch string     `json:"subject_match,omitempty"`
+}
+
+type UpdateTrustRelationshipsRequest struct {
+	Generation         string                    `json:"generation"`
+	TrustRelationships []StoredTrustRelationship `json:"trust_relationships,omitempty"`
+}
+
+type ListTrustRelationshipsResponse struct {
+	Generation         string                    `json:"generation"`
+	TrustRelationships []StoredTrustRelationship `json:"trust_relationships,omitempty"`
+}
+
 func GetTenant(ctx context.Context) (GetTenantResponse, error) {
 	req := struct{}{}
 
@@ -264,6 +282,34 @@ func GetTenant(ctx context.Context) (GetTenantResponse, error) {
 		Retryable:        true,
 	}).Do(ctx, req, ResolveIAMEndpoint, DecodeJSONResponse(&res)); err != nil {
 		return GetTenantResponse{}, err
+	}
+
+	return res, nil
+}
+
+func UpdateTrustRelationships(ctx context.Context, generation string, trustRelationships []StoredTrustRelationship) error {
+	req := UpdateTrustRelationshipsRequest{
+		Generation:         generation,
+		TrustRelationships: trustRelationships,
+	}
+
+	return Call[UpdateTrustRelationshipsRequest]{
+		Method:           "nsl.tenants.TenantsService/UpdateTrustRelationships",
+		IssueBearerToken: IssueBearerToken,
+		Retryable:        true,
+	}.Do(ctx, req, ResolveIAMEndpoint, nil)
+}
+
+func ListTrustRelationships(ctx context.Context) (ListTrustRelationshipsResponse, error) {
+	req := struct{}{}
+
+	var res ListTrustRelationshipsResponse
+	if err := (Call[any]{
+		Method:           "nsl.tenants.TenantsService/ListTrustRelationships",
+		IssueBearerToken: IssueBearerToken,
+		Retryable:        true,
+	}).Do(ctx, req, ResolveIAMEndpoint, DecodeJSONResponse(&res)); err != nil {
+		return ListTrustRelationshipsResponse{}, err
 	}
 
 	return res, nil


### PR DESCRIPTION
- Add new fnapi types: StoredTrustRelationship, UpdateTrustRelationshipsRequest, ListTrustRelationshipsResponse
- Add UpdateTrustRelationships() and ListTrustRelationships() fnapi functions
- Add nsc auth trust-relationships command with subcommands:
  - add: Add new trust relationships by specifying issuer and subject-match
  - list: List all existing trust relationships with details
  - remove: Remove trust relationships by ID

Amp-Thread-ID: https://ampcode.com/threads/T-dbd70638-4c8f-41b5-8975-fca4f85ddcbb
Co-authored-by: Amp <amp@ampcode.com>
