### PR TITLE
Add registry command for managing container images

### DIFF
--- a/cmd/nsc/cmd/register.go
+++ b/cmd/nsc/cmd/register.go
@@ -70,6 +70,8 @@ func RegisterCommands(root *cobra.Command) {
 	root.AddCommand(baseimage.NewBaseImageCmd())
 
 	root.AddCommand(vault.NewVaultCmd()) // nsc vault
+
+	root.AddCommand(cluster.NewRegistryCmd()) // nsc registry
 }
 
 func newGithub() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module namespacelabs.dev/foundation
 go 1.24.4
 
 require (
-	buf.build/gen/go/namespace/cloud/grpc/go v1.5.1-20250918100349-882e2f020c28.2
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.9-20250918100349-882e2f020c28.1
+	buf.build/gen/go/namespace/cloud/grpc/go v1.5.1-20251001125529-1bc0888670a5.2
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.9-20251001125529-1bc0888670a5.1
 	cloud.google.com/go/artifactregistry v1.14.7
 	cloud.google.com/go/container v1.31.0
 	cuelang.org/go v0.10.0
@@ -143,7 +143,7 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	namespacelabs.dev/go-filenotify v0.0.0-20220511192020-53ea11be7eaa
 	namespacelabs.dev/go-ids v0.0.0-20221124082625-9fc72ee06af7
-	namespacelabs.dev/integrations v0.0.9-0.20250918101040-0dbd4703b078
+	namespacelabs.dev/integrations v0.0.9-0.20251001125846-0c2c49d265dd
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-buf.build/gen/go/namespace/cloud/grpc/go v1.5.1-20250918100349-882e2f020c28.2 h1:RbilHWnn7um+RXAur2l2ornTn1QXGwCjPzQDygsqc80=
-buf.build/gen/go/namespace/cloud/grpc/go v1.5.1-20250918100349-882e2f020c28.2/go.mod h1:g5vJqz0il7lnjsaNgTm3vUsKX0V355pz6j90smzTjdM=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.9-20250918100349-882e2f020c28.1 h1:aIeNOkgfUiftbecy2qhvMRp1SHjVmH+N1EVg7beimAU=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.9-20250918100349-882e2f020c28.1/go.mod h1:zLe6Um329KUJqAvDG0uXPD7gZ6q5df4rydQXVODzRkg=
+buf.build/gen/go/namespace/cloud/grpc/go v1.5.1-20251001125529-1bc0888670a5.2 h1:uzJReqrMh77z0ryZ6RnJO9W5RfduptbVrQ0VpRP/VHI=
+buf.build/gen/go/namespace/cloud/grpc/go v1.5.1-20251001125529-1bc0888670a5.2/go.mod h1:znVFbHJ2KWaYLtqwyqZO6XJs08qpDo6MbOSyM2SM/mI=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.9-20251001125529-1bc0888670a5.1 h1:zANvsSVvcMqxsUn5yWQXDr1IxoUse21emzY4Hm5Ji2k=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.9-20251001125529-1bc0888670a5.1/go.mod h1:zLe6Um329KUJqAvDG0uXPD7gZ6q5df4rydQXVODzRkg=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -1529,8 +1529,8 @@ namespacelabs.dev/go-filenotify v0.0.0-20220511192020-53ea11be7eaa h1:jj2kjs0Hvu
 namespacelabs.dev/go-filenotify v0.0.0-20220511192020-53ea11be7eaa/go.mod h1:e8NJRaInXRRm1+KPA6EkGEzdLJAgEvVSIKiLzpP97nI=
 namespacelabs.dev/go-ids v0.0.0-20221124082625-9fc72ee06af7 h1:8NlnfPlzDSJr8TYV/qarIWwhjLd1gOXf3Jme0M/oGBM=
 namespacelabs.dev/go-ids v0.0.0-20221124082625-9fc72ee06af7/go.mod h1:J+Sd+ngeffnCsaO/M7zgs2bR8Klq/ZBhS0+bbnDEH2M=
-namespacelabs.dev/integrations v0.0.9-0.20250918101040-0dbd4703b078 h1:bd6iOATG3nqSDdh33XuEpL1WYevPtLn/1Fyj2SZ/yZs=
-namespacelabs.dev/integrations v0.0.9-0.20250918101040-0dbd4703b078/go.mod h1:5SEJeSHfwziGvYtR88i6aZFfXq8i2Qw8958/njIzV/M=
+namespacelabs.dev/integrations v0.0.9-0.20251001125846-0c2c49d265dd h1:3TykVEIqMqi0lgkS2JyERAzoWrme4XJ6OjKE3v4d9X0=
+namespacelabs.dev/integrations v0.0.9-0.20251001125846-0c2c49d265dd/go.mod h1:/SJ8zgqZmLcQ7cdqI8LlPG9ZoMFYWVMW10v2qyoY4rQ=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/internal/cli/cmd/cluster/registry.go
+++ b/internal/cli/cmd/cluster/registry.go
@@ -1,0 +1,405 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	registryv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/registry/v1beta"
+	"buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/stdlib"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/console/tui"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+	registryapi "namespacelabs.dev/integrations/api/registry"
+	"namespacelabs.dev/integrations/auth"
+)
+
+func NewRegistryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "Manage container registry images.",
+	}
+
+	cmd.AddCommand(newRegistryListCmd())
+	cmd.AddCommand(newRegistryDescribeCmd())
+	cmd.AddCommand(newRegistryShareCmd())
+
+	return cmd
+}
+
+func newRegistryListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List images or repositories in the registry.",
+		Args:  cobra.NoArgs,
+	}
+
+	repositories := cmd.Flags().Bool("repositories", false, "List repositories instead of images")
+	output := cmd.Flags().StringP("output", "o", "table", "Output format: table, json")
+	matchRepo := cmd.Flags().String("repository", "", "Filter images by repository name")
+
+	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
+		tokenSource, err := auth.LoadDefaults()
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to get authentication token: %w", err)
+		}
+
+		client, err := registryapi.NewClient(ctx, tokenSource)
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to create registry client: %w", err)
+		}
+		defer client.Close()
+
+		if *repositories {
+			resp, err := client.ContainerRegistry.ListRepositories(ctx, &registryv1beta.ListRepositoriesRequest{})
+			if err != nil {
+				return fnerrors.InvocationError("registry", "failed to list repositories: %w", err)
+			}
+
+			switch *output {
+			case "json":
+				var b bytes.Buffer
+				fmt.Fprint(&b, "[")
+				for k, repo := range resp.Repositories {
+					if k > 0 {
+						fmt.Fprint(&b, ",")
+					}
+
+					bb, err := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Marshal(repo)
+					if err != nil {
+						return err
+					}
+
+					fmt.Fprintf(&b, "\n%s", bb)
+				}
+				fmt.Fprint(&b, "\n]\n")
+
+				console.Stdout(ctx).Write(b.Bytes())
+
+				return nil
+			case "table":
+				return printRepositoriesTable(ctx, resp.Repositories)
+			default:
+				return fnerrors.BadInputError("invalid output format: %s", *output)
+			}
+		} else {
+			req := &registryv1beta.ListImagesRequest{}
+			if *matchRepo != "" {
+				req.MatchRepository = &stdlib.StringMatcher{
+					Values: []string{*matchRepo},
+				}
+			}
+
+			resp, err := client.ContainerRegistry.ListImages(ctx, req)
+			if err != nil {
+				return fnerrors.InvocationError("registry", "failed to list images: %w", err)
+			}
+
+			switch *output {
+			case "json":
+				var b bytes.Buffer
+				fmt.Fprint(&b, "[")
+				for k, img := range resp.Images {
+					if k > 0 {
+						fmt.Fprint(&b, ",")
+					}
+
+					bb, err := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Marshal(img)
+					if err != nil {
+						return err
+					}
+
+					fmt.Fprintf(&b, "\n%s", bb)
+				}
+				fmt.Fprint(&b, "\n]\n")
+
+				console.Stdout(ctx).Write(b.Bytes())
+
+				return nil
+			case "table":
+				return printImagesTable(ctx, resp.Images)
+			default:
+				return fnerrors.BadInputError("invalid output format: %s", *output)
+			}
+		}
+	})
+
+	return cmd
+}
+
+func newRegistryDescribeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Get detailed information about a specific image.",
+		Args:  cobra.NoArgs,
+	}
+
+	repository := cmd.Flags().String("repository", "", "Repository name (required)")
+	reference := cmd.Flags().String("reference", "", "Image reference (tag or digest) (required)")
+	output := cmd.Flags().StringP("output", "o", "table", "Output format: table, json")
+
+	cmd.MarkFlagRequired("repository")
+	cmd.MarkFlagRequired("reference")
+
+	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
+		tokenSource, err := auth.LoadDefaults()
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to get authentication token: %w", err)
+		}
+
+		client, err := registryapi.NewClient(ctx, tokenSource)
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to create registry client: %w", err)
+		}
+		defer client.Close()
+
+		req := &registryv1beta.GetImageRequest{
+			Repository: *repository,
+			Reference:  *reference,
+		}
+
+		resp, err := client.ContainerRegistry.GetImage(ctx, req)
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to get image: %w", err)
+		}
+
+		switch *output {
+		case "json":
+			bb, err := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Marshal(resp)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(console.Stdout(ctx), string(bb))
+			return nil
+
+		case "table":
+			return printImageDetails(ctx, resp)
+
+		default:
+			return fnerrors.BadInputError("invalid output format: %s", *output)
+		}
+	})
+
+	return cmd
+}
+
+func newRegistryShareCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "share",
+		Short: "Share an image publicly or with partner accounts.",
+		Args:  cobra.NoArgs,
+	}
+
+	repository := cmd.Flags().String("repository", "", "Repository name (required)")
+	digest := cmd.Flags().String("digest", "", "Image digest (required)")
+	visibility := cmd.Flags().String("visibility", "public", "Visibility level: public, partner")
+	expiresAt := cmd.Flags().String("expires_at", "", "Expiration time in RFC3339 format (e.g., 2024-12-31T23:59:59Z)")
+	output := cmd.Flags().StringP("output", "o", "table", "Output format: table, json")
+
+	cmd.MarkFlagRequired("repository")
+	cmd.MarkFlagRequired("digest")
+
+	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
+		tokenSource, err := auth.LoadDefaults()
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to get authentication token: %w", err)
+		}
+
+		client, err := registryapi.NewClient(ctx, tokenSource)
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to create registry client: %w", err)
+		}
+		defer client.Close()
+
+		req := &registryv1beta.ShareImageRequest{
+			Repository: *repository,
+			Digest:     *digest,
+		}
+
+		// Parse visibility
+		switch strings.ToLower(*visibility) {
+		case "public":
+			req.Visibility = registryv1beta.Visibility_PUBLIC
+		case "partner":
+			req.Visibility = registryv1beta.Visibility_PARTNER
+		default:
+			return fnerrors.BadInputError("invalid visibility: %s (must be 'public' or 'partner')", *visibility)
+		}
+
+		// Parse expiration time if provided
+		if *expiresAt != "" {
+			t, err := time.Parse(time.RFC3339, *expiresAt)
+			if err != nil {
+				return fnerrors.BadInputError("invalid expires_at time format: %w", err)
+			}
+			req.ExpiresAt = timestamppb.New(t)
+		}
+
+		sharedImage, err := client.ContainerRegistry.ShareImage(ctx, req)
+		if err != nil {
+			return fnerrors.InvocationError("registry", "failed to share image: %w", err)
+		}
+
+		switch *output {
+		case "json":
+			bb, err := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Marshal(sharedImage)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(console.Stdout(ctx), string(bb))
+			return nil
+
+		case "table":
+			return printSharedImage(ctx, sharedImage)
+
+		default:
+			return fnerrors.BadInputError("invalid output format: %s", *output)
+		}
+	})
+
+	return cmd
+}
+
+func printRepositoriesTable(ctx context.Context, repositories []*registryv1beta.Repository) error {
+	if len(repositories) == 0 {
+		fmt.Fprintf(console.Stdout(ctx), "No repositories found.\n")
+		return nil
+	}
+
+	cols := []tui.Column{
+		{Key: "name", Title: "Repository Name", MinWidth: 20, MaxWidth: 60},
+		{Key: "last_push", Title: "Last Push", MinWidth: 20, MaxWidth: 30},
+	}
+
+	rows := []tui.Row{}
+	for _, repo := range repositories {
+		lastPush := ""
+		if repo.LastPush != nil {
+			lastPush = repo.LastPush.AsTime().Format(time.RFC3339)
+		}
+
+		row := tui.Row{
+			"name":      repo.Name,
+			"last_push": lastPush,
+		}
+		rows = append(rows, row)
+	}
+
+	return tui.StaticTable(ctx, cols, rows)
+}
+
+func printImagesTable(ctx context.Context, images []*registryv1beta.Image) error {
+	if len(images) == 0 {
+		fmt.Fprintf(console.Stdout(ctx), "No images found.\n")
+		return nil
+	}
+
+	cols := []tui.Column{
+		{Key: "repository", Title: "Repository", MinWidth: 20, MaxWidth: 40},
+		{Key: "digest", Title: "Digest", MinWidth: 15, MaxWidth: 30},
+		{Key: "size", Title: "Size", MinWidth: 10, MaxWidth: 15},
+		{Key: "created", Title: "Created", MinWidth: 20, MaxWidth: 30},
+	}
+
+	rows := []tui.Row{}
+	for _, img := range images {
+		created := ""
+		if img.CreatedAt != nil {
+			created = img.CreatedAt.AsTime().Format(time.RFC3339)
+		}
+
+		digest := img.Digest
+		if len(digest) > 20 {
+			digest = digest[:20] + "..."
+		}
+
+		size := "-"
+		if img.Sizes != nil && img.Sizes.Total > 0 {
+			size = fmt.Sprintf("%d MB", img.Sizes.Total/(1024*1024))
+		}
+
+		row := tui.Row{
+			"repository": img.Repository,
+			"digest":     digest,
+			"size":       size,
+			"created":    created,
+		}
+		rows = append(rows, row)
+	}
+
+	return tui.StaticTable(ctx, cols, rows)
+}
+
+func printImageDetails(ctx context.Context, resp *registryv1beta.GetImageResponse) error {
+	stdout := console.Stdout(ctx)
+
+	if resp.Image == nil {
+		fmt.Fprintf(stdout, "No image found.\n")
+		return nil
+	}
+
+	img := resp.Image
+
+	fmt.Fprintf(stdout, "Repository:  %s\n", img.Repository)
+	fmt.Fprintf(stdout, "Digest:      %s\n", img.Digest)
+
+	if img.Sizes != nil && img.Sizes.Total > 0 {
+		fmt.Fprintf(stdout, "Size:        %d bytes (%d MB)\n", img.Sizes.Total, img.Sizes.Total/(1024*1024))
+		if len(img.Sizes.PerPlatform) > 0 {
+			fmt.Fprintf(stdout, "Sizes per platform:\n")
+			for platform, size := range img.Sizes.PerPlatform {
+				fmt.Fprintf(stdout, "  %s: %d bytes (%d MB)\n", platform, size, size/(1024*1024))
+			}
+		}
+	}
+
+	if img.CreatedAt != nil {
+		fmt.Fprintf(stdout, "Created At:  %s\n", img.CreatedAt.AsTime().Format(time.RFC3339))
+	}
+
+	if img.ExpiresAt != nil {
+		fmt.Fprintf(stdout, "Expires At:  %s\n", img.ExpiresAt.AsTime().Format(time.RFC3339))
+	}
+
+	if len(img.Labels) > 0 {
+		fmt.Fprintf(stdout, "Labels:\n")
+		for _, label := range img.Labels {
+			fmt.Fprintf(stdout, "  %s: %s\n", label.Name, label.Value)
+		}
+	}
+
+	return nil
+}
+
+func printSharedImage(ctx context.Context, sharedImage *registryv1beta.SharedImage) error {
+	stdout := console.Stdout(ctx)
+
+	fmt.Fprintf(stdout, "Shared Image ID:  %s\n", sharedImage.Id)
+	fmt.Fprintf(stdout, "Repository:       %s\n", sharedImage.SharedRepository)
+	fmt.Fprintf(stdout, "Digest:           %s\n", sharedImage.SharedDigest)
+	fmt.Fprintf(stdout, "Visibility:       %s\n", sharedImage.Visibility.String())
+
+	if sharedImage.ExpiresAt != nil {
+		fmt.Fprintf(stdout, "Expires At:       %s\n", sharedImage.ExpiresAt.AsTime().Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(stdout, "Expires At:       Never\n")
+	}
+
+	if sharedImage.ImageRef != "" {
+		fmt.Fprintf(stdout, "\nShared Reference: %s\n", sharedImage.ImageRef)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implements `nsc registry` commands for managing container registry images:
- `list` - List images or repositories  
- `describe` - Get image details
- `share` - Share images publicly or with partners

🤖 Generated with [Claude Code](https://claude.com/claude-code)