### PR TITLE
Also retry concurrent tuple updates (e.g. when a function replace inv…

### DIFF
--- a/library/oss/postgres/prepare/database/main.go
+++ b/library/oss/postgres/prepare/database/main.go
@@ -82,7 +82,7 @@ func run(ctx context.Context, p *provider.Provider[*postgres.DatabaseIntent]) er
 			}
 		}()
 
-		if err := helpers.ApplyWithCleanup(ctx, p.Intent, db); err != nil {
+		if err := helpers.ApplyWithHelpers(ctx, p.Intent, db); err != nil {
 			return err
 		}
 	}

--- a/universe/db/postgres/tx.go
+++ b/universe/db/postgres/tx.go
@@ -7,6 +7,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/jackc/pgerrcode"
@@ -103,6 +104,10 @@ func ErrorIsRetryable(err error) bool {
 	var pgerr *pgconn.PgError
 	if !errors.As(err, &pgerr) {
 		return false
+	}
+
+	if pgerr.SQLState() == pgerrcode.InternalError {
+		return strings.Contains(pgerr.Message, "tuple concurrently updated")
 	}
 
 	return slices.Contains(retryableSqlStates, pgerr.SQLState())


### PR DESCRIPTION
…alidates the query planner).

Apply helper functions one by one.
Retire ability to clean up helper functions.