### PR TITLE
framework/rpcerrors: Do actually save the code in rpcerrors.Wrap.

### DIFF
--- a/framework/rpcerrors/rpcerrors.go
+++ b/framework/rpcerrors/rpcerrors.go
@@ -35,6 +35,7 @@ func WrapWithSkip(code codes.Code, err error, skip int) *Error {
 
 	return &Error{
 		Err:   err,
+		Code:  code,
 		stack: stack[:length],
 	}
 }


### PR DESCRIPTION
Was lost in a refactoring.