### PR TITLE
Replace vcpu/memory_mb with machine_type in github profile commands

### DIFF
--- a/internal/cli/cmd/cluster/machinetype.go
+++ b/internal/cli/cmd/cluster/machinetype.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"strconv"
+	"strings"
+
+	"namespacelabs.dev/foundation/internal/fnerrors"
+)
+
+// ParseMachineType parses a machine type string in the format "CPUxMemoryGB" (e.g., "4x8")
+// and returns the vCPU count and memory in megabytes.
+// This function is used for converting the shorthand format into structured data.
+func ParseMachineType(machineType string) (vcpu int32, memoryMB int32, err error) {
+	parts := strings.Split(machineType, "x")
+	if len(parts) != 2 {
+		return 0, 0, fnerrors.Newf("invalid machine_type format: expected 'CPUxMemoryGB' (e.g., '4x8'), got %q", machineType)
+	}
+
+	cpu, err := strconv.ParseInt(parts[0], 10, 32)
+	if err != nil {
+		return 0, 0, fnerrors.Newf("invalid CPU value in machine_type %q: %w", machineType, err)
+	}
+
+	memoryGB, err := strconv.ParseInt(parts[1], 10, 32)
+	if err != nil {
+		return 0, 0, fnerrors.Newf("invalid memory value in machine_type %q: %w", machineType, err)
+	}
+
+	return int32(cpu), int32(memoryGB * 1024), nil
+}


### PR DESCRIPTION
## Summary

Replace separate `--vcpu` and `--memory_mb` flags with a single `--machine_type` flag in `nsc github profile` commands (create and update).

## Changes

- Add `ParseMachineType` utility function to parse "CPUxMemoryGB" format (e.g., "4x8" for 4 vCPU and 8GB memory)
- Create new `machinetype.go` utility module in cluster package for consolidating machine type parsing
- Update `nsc github profile create` command to use `--machine_type` flag with default value "4x8"
- Update `nsc github profile update` command to use `--machine_type` flag
- Server-side validation handles all other commands (run, create, attachdocker) - no client-side validation added

## Example Usage

```bash
# Create a profile with 4 vCPU and 8GB memory
nsc github profile create --tag my-profile --machine_type 4x8

# Update a profile to use 8 vCPU and 16GB memory
nsc github profile update --profile_id <id> --machine_type 8x16
```

## Benefits

- Unified machine type specification across commands
- Cleaner CLI interface with single parameter instead of two
- Reusable parsing utility for future commands
- Better alignment with how other commands handle machine types

🤖 Generated with [Claude Code](https://claude.com/claude-code)