### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   goreleaser:
     runs-on: namespace-profile-foundation-releaser
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
Adds `contents: write` permission to the goreleaser job to fix the 403 error when creating GitHub releases.

Fixes the error: `failed to publish artifacts: could not release: POST https://api.github.com/repos/namespacelabs/foundation/releases: 403 Resource not accessible by integration`