### PR TITLE
Fix incorrect 'Already up-to-date' message during version update

### DIFF
--- a/internal/cli/nsboot/update.go
+++ b/internal/cli/nsboot/update.go
@@ -142,15 +142,18 @@ func ForceUpdate(ctx context.Context, command string) error {
 	newVersion, _, err := performUpdate(ctx, command, &reportedExistingVersion{
 		TagName: curr.Version,
 		SHA256:  curr.GitCommit,
-	}, "", true)
+	}, curr.Version, true)
 	if err != nil {
 		return err
 	}
 
-	switch curr.Version {
-	case newVersion.TagName:
-		fmt.Fprintf(console.Stdout(ctx), "Already up-to-date at %s.\n", newVersion.TagName)
+	if newVersion == nil {
+		// No update was needed - current version is already >= latest.
+		fmt.Fprintf(console.Stdout(ctx), "Already up-to-date at %s.\n", curr.Version)
+		return nil
+	}
 
+	switch curr.Version {
 	case version.DevelopmentBuildVersion:
 		fmt.Fprintf(console.Stdout(ctx), "Ignoring update: %s is a development build.\n", command)
 


### PR DESCRIPTION
## Problem

When running `nsc version update`, the CLI would display "Already up-to-date at vX.X.X" even when an update was actually performed.

## Root Cause

The `ForceUpdate` function was passing an empty string as `currentVersion` to `performUpdate`. This bypassed the version comparison check (line 198), causing the binary to always be downloaded. Afterward, the code compared the old version against the new version and incorrectly showed "Already up-to-date" because the versions matched after the download.

## Fix

Pass `curr.Version` as the `currentVersion` parameter so `performUpdate` can properly skip the download when already up-to-date (returning `nil`), and handle that case explicitly with the correct message.