### PR TITLE
Roll forward now that release is fully live.

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -81,25 +81,13 @@ do_install() {
 
   echo "Detected ${architecture} as the platform architecture"
 
-  ns_root=${NS_ROOT:-}
-  if [ -z "$ns_root"  ]; then
-    case "$os" in
-      darwin) ns_root="$HOME/Library/Application Support/ns" ;;
-      linux) ns_root="$HOME/.ns" ;;
-    esac
-  fi
-
   case "$os" in
-    darwin) bin_dir="$(printf %q "$ns_root")/bin" ;;
-    # printf is not available in sh on Github runners.
-    linux) bin_dir="$ns_root/bin" ;;
+    darwin) old_bin_dir="$HOME/Library/Application Support/ns/bin" ;;
+    linux) old_bin_dir="$HOME/.ns/bin" ;;
   esac
 
-  temp_tar="$(mktemp)"
-
-  if [ ! -d "$bin_dir" ]; then
-    $sh_c "mkdir -p ${bin_dir}"
-  fi
+  TEMP_DIR=$(mktemp -d)
+  trap "rm -rf $TEMP_DIR" EXIT
 
   download_uri="https://get.namespace.so/packages/${tool_name}/latest?arch=${architecture}&os=${os}"
   if [ ! -z "${version:-}" ]; then
@@ -113,32 +101,29 @@ do_install() {
     ci_header="-H 'CI: ${CI}'"
   fi
 
-  $sh_c "curl $ci_header --fail --location --progress-bar --user-agent install.sh --output ${temp_tar} \"${download_uri}\""
+  cd ${TEMP_DIR}
+  $sh_c "curl $ci_header --fail --location --progress-bar --user-agent install.sh \"${download_uri}\" | tar -xz"
 
-  $sh_c "tar -xzf ${temp_tar} -C ${bin_dir} ${tool_name}"
+  $sh_c "chmod +x ${tool_name}"
 
-  $sh_c "chmod +x ${bin_dir}/${tool_name}"
+  if [ -z "${version:-}" ]; then
+    echo "Installing latest version of Foundation"
+    install_args=""
+    if [ -x "$old_bin_dir/$tool_name" ]; then
+      install_args="--dir=\"$old_bin_dir\""
+    fi
 
-  $sh_c "rm ${temp_tar}"
+    $sh_c "./${tool_name} install $install_args"
+  else
+    echo "Installing version ${version} of Foundation to ${old_bin_dir}"
+    # Old versions may not contain the install command - hence copying instead
+    $sh_c "cp ${tool_name} \"${old_bin_dir}/\""
+  fi
 
-  echo
-  echo "Foundation was successfully installed to ${bin_dir}/${tool_name}"
-  echo
+  # Clean up the temporary binary
+  $sh_c "rm ${tool_name}"
 
-
-  case `echo $0` in
-    *zsh) shell_profile=".zshrc" ;;
-    *bash) shell_profile=".bashrc" ;;
-    *) shell_profile=".profile" ;;
-  esac
-  echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
-  echo "  export PATH=\"$ns_root/bin:\$PATH\""
-  echo
-  echo "Or simply run ${bin_dir}/${tool_name}"
-
-  echo
-  echo "Check out our examples at https://namespace.so/docs#examples to get started."
-  echo
+  echo "Installation complete"
 }
 
 do_install "$@"


### PR DESCRIPTION
Respect old bin dirs in installer scripts
Ensure the scripts work when selecting old releases.
Ensure printed hints are flushed before command termination.