### PR TITLE
nsc: don't show 'unexpected' message for NotFound errors

### DIFF
--- a/cmd/nsc/main.go
+++ b/cmd/nsc/main.go
@@ -225,7 +225,7 @@ func formatErr(out io.Writer, style colors.Style, err error) {
 		if re.findDetail(&envNotExist) {
 			fmt.Fprintf(ww, "%q does not exist.", envNotExist.ClusterId)
 		} else {
-			generic(ww, style, re.code, msg, re.rid)
+			fmt.Fprintf(ww, "%s%s.", msg, appendRid(re.rid))
 		}
 
 	case codes.FailedPrecondition:


### PR DESCRIPTION
NotFound errors like expired artifacts are expected scenarios, so we shouldn't tell users 'This was unexpected' and ask them to contact support.

Before:
```
Failed: the artifact has expired at 2026-02-03T23:24:28Z (NotFound).

This was unexpected. Please reach out to our team at support@namespace.so and mention request ID pafjtcbecq8ksgg6mttpu4iufs.
```

After:
```
the artifact has expired at 2026-02-03T23:24:28Z (request id: pafjtcbecq8ksgg6mttpu4iufs).
```