### PR TITLE
Nsc create instance_id output

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -242,7 +242,8 @@ func NewCreateCmd() *cobra.Command {
 			enc.SetIndent("", "  ")
 
 			out := createOutput{
-				ClusterId: cluster.ClusterId,
+				ClusterId:  cluster.ClusterId,
+				InstanceId: cluster.ClusterId,
 			}
 
 			if cluster.Cluster != nil {

--- a/internal/cli/cmd/cluster/run.go
+++ b/internal/cli/cmd/cluster/run.go
@@ -459,6 +459,7 @@ func PrintCreateContainersResult(ctx context.Context, output string, resp *Creat
 
 		if err := d.Encode(createOutput{
 			ClusterId:  resp.InstanceId,
+			InstanceId: resp.InstanceId,
 			ClusterUrl: resp.InstanceUrl,
 			Container:  containers,
 		}); err != nil {
@@ -514,6 +515,7 @@ func generateNameFromImage(image string) string {
 
 type createOutput struct {
 	ClusterId     string           `json:"cluster_id,omitempty"`
+	InstanceId    string           `json:"instance_id,omitempty"`
 	ClusterUrl    string           `json:"cluster_url,omitempty"`
 	Container     []*api.Container `json:"container,omitempty"`
 	IngressDomain string           `json:"ingress_domain,omitempty"`


### PR DESCRIPTION
Add `instance_id` to `nsc create -o json` output to avoid confusing agents.

---
Linear Issue: [NSL-7319](https://linear.app/namespacelabs/issue/NSL-7319/include-instance-id-in-nsc-create-o-json-output)

<p><a href="https://cursor.com/background-agent?bcId=bc-e271a929-841c-4d08-9cd0-f5109f3b464b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e271a929-841c-4d08-9cd0-f5109f3b464b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

