### PR TITLE
Consolidate create-token implementation across gradle and sccache

### DIFF
--- a/internal/cli/cmd/cluster/createtoken.go
+++ b/internal/cli/cmd/cluster/createtoken.go
@@ -1,0 +1,130 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	iamv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/iam/v1beta"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/console/colors"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/go-ids"
+	"namespacelabs.dev/integrations/api/iam"
+	"namespacelabs.dev/integrations/auth"
+)
+
+type createTokenConfig struct {
+	Short       string
+	CacheLabel  string // e.g. "Gradle" or "sccache", used in help text and descriptions.
+	TokenPrefix string // e.g. "gradle-cache" or "sccache", used as token name prefix.
+	SetupCmd    string // e.g. "nsc gradle cache setup" or "nsc cache sccache setup".
+
+	GetRequiredPerms func(ctx context.Context, cacheName string) ([]*iamv1beta.Permission, error)
+}
+
+func newCreateCacheTokenCmd(cfg createTokenConfig) *cobra.Command {
+	var name string
+	var expiresIn time.Duration
+	var tokenFile, scope string
+
+	return fncobra.Cmd(&cobra.Command{
+		Use:   "create-token",
+		Short: cfg.Short,
+	}).WithFlags(func(flags *pflag.FlagSet) {
+		flags.StringVar(&name, "cache_name", "", fmt.Sprintf("Select a %s cache to grant access to. By default, all %s caches can be accessed.", cfg.CacheLabel, cfg.CacheLabel))
+		fncobra.DurationVar(flags, &expiresIn, "expires_in", 24*time.Hour, "Duration until the token expires (max 90 days).")
+		flags.StringVar(&tokenFile, "token", "token.json", "Write token to this file in JSON format.")
+		flags.StringVar(&scope, "scope", "user", "Set the scope of the generated access token. Valid options: `tenant`, `user`. Tokens with user scope are bound to the tenant membership of the current user.")
+	}).Do(func(ctx context.Context) error {
+		requiredPerms, err := cfg.GetRequiredPerms(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		if len(requiredPerms) == 0 {
+			return fnerrors.New("no permissions required for this cache (unexpected)")
+		}
+
+		tokenSource, err := auth.LoadDefaults()
+		if err != nil {
+			return fnerrors.InvocationError(cfg.TokenPrefix, "failed to get authentication token: %w", err)
+		}
+
+		iamClient, err := iam.NewClient(ctx, tokenSource)
+		if err != nil {
+			return fnerrors.InvocationError(cfg.TokenPrefix, "failed to create IAM client: %w", err)
+		}
+		defer iamClient.Close()
+
+		suffix := ids.NewRandomBase32ID(4)
+		tokenName := fmt.Sprintf("%s-%s-%s", cfg.TokenPrefix, name, suffix)
+		expiresAt := time.Now().Add(expiresIn)
+
+		req := &iamv1beta.CreateRevokableTokenRequest{
+			Name:        tokenName,
+			Description: fmt.Sprintf("%s access token for cache %q", cfg.CacheLabel, name),
+			ExpiresAt:   timestamppb.New(expiresAt),
+			Access: &iamv1beta.AccessPolicy{
+				Grants: requiredPerms,
+			},
+		}
+
+		switch scope {
+		case "tenant":
+			req.Scope = iamv1beta.RevokableToken_TENANT_SCOPE
+
+		case "user":
+			req.Scope = iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE
+		}
+
+		resp, err := iamClient.Tokens.CreateRevokableToken(ctx, req)
+		if err != nil {
+			return fnerrors.InvocationError("token", "failed to create token: %w", err)
+		}
+
+		fmt.Fprintf(console.Stdout(ctx), "Token ID:    %s\n", resp.Token.GetTokenId())
+		fmt.Fprintf(console.Stdout(ctx), "Name:        %s\n", resp.Token.GetName())
+		fmt.Fprintf(console.Stdout(ctx), "Expires At:  %s\n", expiresAt.Format(time.RFC3339))
+
+		if err := writeTokenToFile(tokenFile, resp.BearerToken); err != nil {
+			return fnerrors.InvocationError("token", "failed to write token to file: %w", err)
+		}
+
+		fmt.Fprintf(console.Stdout(ctx), "Wrote token contents to %q\n", tokenFile)
+		fmt.Fprintf(console.Stdout(ctx), "You can set up your %s config with:\n", cfg.CacheLabel)
+
+		style := colors.Ctx(ctx)
+		cmd := fmt.Sprintf("%s --token %s", cfg.SetupCmd, tokenFile)
+		if name != "" {
+			cmd = fmt.Sprintf("%s --cache_name %s", cmd, name)
+		}
+
+		fmt.Fprintf(console.Stdout(ctx), "  %s\n", style.Highlight.Apply(cmd))
+
+		return nil
+	})
+}
+
+func writeTokenToFile(path string, bearerToken string) error {
+	tokenData := map[string]string{
+		"bearer_token": bearerToken,
+	}
+
+	bb, err := json.MarshalIndent(tokenData, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, bb, 0600)
+}

--- a/internal/cli/cmd/cluster/gradle.go
+++ b/internal/cli/cmd/cluster/gradle.go
@@ -19,7 +19,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"namespacelabs.dev/foundation/framework/atomic"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
@@ -27,9 +26,6 @@ import (
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/workspace/dirs"
-	"namespacelabs.dev/go-ids"
-	"namespacelabs.dev/integrations/api/iam"
-	"namespacelabs.dev/integrations/auth"
 )
 
 const gradleCachePathBase = "gradle"
@@ -42,7 +38,7 @@ func NewGradleCmd() *cobra.Command {
 
 	cache := &cobra.Command{Use: "cache", Short: "Gradle cache related functionality."}
 	cache.AddCommand(newSetupGradleCacheCmd())
-	cache.AddCommand(newCreateTokenCmd())
+	cache.AddCommand(newGradleCreateTokenCmd())
 
 	cmd.AddCommand(cache)
 
@@ -58,7 +54,7 @@ func NewGradleCacheCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newSetupGradleCacheCmd())
-	cmd.AddCommand(newCreateTokenCmd())
+	cmd.AddCommand(newGradleCreateTokenCmd())
 
 	return cmd
 }
@@ -230,107 +226,28 @@ Or by placing it in ~/.gradle/init.d/ to apply to all builds.`,
 	})
 }
 
-func newCreateTokenCmd() *cobra.Command {
-	var name string
-	var expiresIn time.Duration
-	var tokenFile, scope string
+func newGradleCreateTokenCmd() *cobra.Command {
+	return newCreateCacheTokenCmd(createTokenConfig{
+		Short:       "Create a revokable token for accessing the Gradle cache.",
+		CacheLabel:  "Gradle",
+		TokenPrefix: "gradle-cache",
+		SetupCmd:    "nsc cache gradle setup",
+		GetRequiredPerms: func(ctx context.Context, cacheName string) ([]*iamv1beta.Permission, error) {
+			gradleClient, err := fnapi.NewGradleCacheServiceClient(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-	return fncobra.Cmd(&cobra.Command{
-		Use:   "create-token",
-		Short: "Create a revokable token for accessing the Gradle cache.",
-	}).WithFlags(func(flags *pflag.FlagSet) {
-		flags.StringVar(&name, "cache_name", "", "Select a Gradle cache to grant access to. By default, all Gradle caches can be accessed.")
-		fncobra.DurationVar(flags, &expiresIn, "expires_in", 24*time.Hour, "Duration until the token expires (max 90 days).")
-		flags.StringVar(&tokenFile, "token", "token.json", "Write token to this file in JSON format.")
-		flags.StringVar(&scope, "scope", "user", "Set the scope of the generated access token. Valid options: `tenant`, `user`. Tokens with user scope are bound to the tenant membership of the current user.")
-	}).Do(func(ctx context.Context) error {
-		gradleClient, err := fnapi.NewGradleCacheServiceClient(ctx)
-		if err != nil {
-			return err
-		}
+			policyResp, err := gradleClient.GetAccessPolicy(ctx, connect.NewRequest(&gradlev1beta.GetAccessPolicyRequest{
+				Name: cacheName,
+			}))
+			if err != nil {
+				return nil, fnerrors.Newf("failed to get access policy: %w", err)
+			}
 
-		policyResp, err := gradleClient.GetAccessPolicy(ctx, connect.NewRequest(&gradlev1beta.GetAccessPolicyRequest{
-			Name: name,
-		}))
-		if err != nil {
-			return fnerrors.Newf("failed to get access policy: %w", err)
-		}
-
-		requiredPerms := policyResp.Msg.GetRequiredPermission()
-		if len(requiredPerms) == 0 {
-			return fnerrors.New("no permissions required for this cache (unexpected)")
-		}
-
-		tokenSource, err := auth.LoadDefaults()
-		if err != nil {
-			return fnerrors.InvocationError("gradle", "failed to get authentication token: %w", err)
-		}
-
-		iamClient, err := iam.NewClient(ctx, tokenSource)
-		if err != nil {
-			return fnerrors.InvocationError("gradle", "failed to create IAM client: %w", err)
-		}
-		defer iamClient.Close()
-
-		suffix := ids.NewRandomBase32ID(4)
-		tokenName := fmt.Sprintf("gradle-cache-%s-%s", name, suffix)
-		expiresAt := time.Now().Add(expiresIn)
-
-		req := &iamv1beta.CreateRevokableTokenRequest{
-			Name:        tokenName,
-			Description: fmt.Sprintf("Gradle cache access token for cache %q", name),
-			ExpiresAt:   timestamppb.New(expiresAt),
-			Access: &iamv1beta.AccessPolicy{
-				Grants: requiredPerms,
-			},
-		}
-
-		switch scope {
-		case "tenant":
-			req.Scope = iamv1beta.RevokableToken_TENANT_SCOPE
-
-		case "user":
-			req.Scope = iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE
-		}
-
-		resp, err := iamClient.Tokens.CreateRevokableToken(ctx, req)
-		if err != nil {
-			return fnerrors.InvocationError("token", "failed to create token: %w", err)
-		}
-
-		fmt.Fprintf(console.Stdout(ctx), "Token ID:    %s\n", resp.Token.GetTokenId())
-		fmt.Fprintf(console.Stdout(ctx), "Name:        %s\n", resp.Token.GetName())
-		fmt.Fprintf(console.Stdout(ctx), "Expires At:  %s\n", expiresAt.Format(time.RFC3339))
-
-		if err := writeGradleTokenToFile(tokenFile, resp.BearerToken); err != nil {
-			return fnerrors.InvocationError("token", "failed to write token to file: %w", err)
-		}
-
-		fmt.Fprintf(console.Stdout(ctx), "You can set up your gradle cache config with:\n")
-
-		style := colors.Ctx(ctx)
-		cmd := fmt.Sprintf("nsc gradle cache setup --token %s", tokenFile)
-		if name != "" {
-			cmd = fmt.Sprintf("%s --name %s", cmd, name)
-		}
-
-		fmt.Fprintf(console.Stdout(ctx), "  %s\n", style.Highlight.Apply(cmd))
-
-		return nil
+			return policyResp.Msg.GetRequiredPermission(), nil
+		},
 	})
-}
-
-func writeGradleTokenToFile(path string, bearerToken string) error {
-	tokenData := map[string]string{
-		"bearer_token": bearerToken,
-	}
-
-	bb, err := json.MarshalIndent(tokenData, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, bb, 0600)
 }
 
 func toGradleInitScript(out gradleSetup) ([]byte, error) {

--- a/internal/cli/cmd/cluster/sccache.go
+++ b/internal/cli/cmd/cluster/sccache.go
@@ -18,15 +18,10 @@ import (
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
-	"namespacelabs.dev/foundation/internal/console/colors"
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
-	"namespacelabs.dev/go-ids"
-	"namespacelabs.dev/integrations/api/iam"
-	"namespacelabs.dev/integrations/auth"
 )
 
 func NewSccacheCmd() *cobra.Command {
@@ -141,92 +136,26 @@ The output includes:
 }
 
 func newCreateSccacheTokenCmd() *cobra.Command {
-	var name string
-	var expiresIn time.Duration
-	var tokenFile, scope string
+	return newCreateCacheTokenCmd(createTokenConfig{
+		Short:       "Create a revokable token for accessing the sccache cache.",
+		CacheLabel:  "sccache",
+		TokenPrefix: "sccache",
+		SetupCmd:    "nsc cache sccache setup",
+		GetRequiredPerms: func(ctx context.Context, cacheName string) ([]*iamv1beta.Permission, error) {
+			httpCacheClient, err := fnapi.NewHttpCacheServiceClient(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-	return fncobra.Cmd(&cobra.Command{
-		Use:   "create-token",
-		Short: "Create a revokable token for accessing the sccache cache.",
-	}).WithFlags(func(flags *pflag.FlagSet) {
-		flags.StringVar(&name, "cache_name", "", "Select a cache to grant access to. By default, all caches can be accessed.")
-		fncobra.DurationVar(flags, &expiresIn, "expires_in", 24*time.Hour, "Duration until the token expires (max 90 days).")
-		flags.StringVar(&tokenFile, "token", "token.json", "Write token to this file in JSON format.")
-		flags.StringVar(&scope, "scope", "user", "Set the scope of the generated access token. Valid options: `tenant`, `user`. Tokens with user scope are bound to the tenant membership of the current user.")
-	}).Do(func(ctx context.Context) error {
-		httpCacheClient, err := fnapi.NewHttpCacheServiceClient(ctx)
-		if err != nil {
-			return err
-		}
+			policyResp, err := httpCacheClient.GetAccessPolicy(ctx, connect.NewRequest(&httpcachev1beta.GetAccessPolicyRequest{
+				Name: cacheName,
+			}))
+			if err != nil {
+				return nil, fnerrors.Newf("failed to get access policy: %w", err)
+			}
 
-		policyResp, err := httpCacheClient.GetAccessPolicy(ctx, connect.NewRequest(&httpcachev1beta.GetAccessPolicyRequest{
-			Name: name,
-		}))
-		if err != nil {
-			return fnerrors.Newf("failed to get access policy: %w", err)
-		}
-
-		requiredPerms := policyResp.Msg.GetRequiredPermission()
-		if len(requiredPerms) == 0 {
-			return fnerrors.New("no permissions required for this cache (unexpected)")
-		}
-
-		tokenSource, err := auth.LoadDefaults()
-		if err != nil {
-			return fnerrors.InvocationError("sccache", "failed to get authentication token: %w", err)
-		}
-
-		iamClient, err := iam.NewClient(ctx, tokenSource)
-		if err != nil {
-			return fnerrors.InvocationError("sccache", "failed to create IAM client: %w", err)
-		}
-		defer iamClient.Close()
-
-		suffix := ids.NewRandomBase32ID(4)
-		tokenName := fmt.Sprintf("sccache-%s-%s", name, suffix)
-		expiresAt := time.Now().Add(expiresIn)
-
-		req := &iamv1beta.CreateRevokableTokenRequest{
-			Name:        tokenName,
-			Description: fmt.Sprintf("sccache access token for cache %q", name),
-			ExpiresAt:   timestamppb.New(expiresAt),
-			Access: &iamv1beta.AccessPolicy{
-				Grants: requiredPerms,
-			},
-		}
-
-		switch scope {
-		case "tenant":
-			req.Scope = iamv1beta.RevokableToken_TENANT_SCOPE
-
-		case "user":
-			req.Scope = iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE
-		}
-
-		resp, err := iamClient.Tokens.CreateRevokableToken(ctx, req)
-		if err != nil {
-			return fnerrors.InvocationError("token", "failed to create token: %w", err)
-		}
-
-		fmt.Fprintf(console.Stdout(ctx), "Token ID:    %s\n", resp.Token.GetTokenId())
-		fmt.Fprintf(console.Stdout(ctx), "Name:        %s\n", resp.Token.GetName())
-		fmt.Fprintf(console.Stdout(ctx), "Expires At:  %s\n", expiresAt.Format(time.RFC3339))
-
-		if err := writeGradleTokenToFile(tokenFile, resp.BearerToken); err != nil {
-			return fnerrors.InvocationError("token", "failed to write token to file: %w", err)
-		}
-
-		fmt.Fprintf(console.Stdout(ctx), "You can set up your sccache config with:\n")
-
-		style := colors.Ctx(ctx)
-		cmd := fmt.Sprintf("nsc cache sccache setup --token %s", tokenFile)
-		if name != "" {
-			cmd = fmt.Sprintf("%s --name %s", cmd, name)
-		}
-
-		fmt.Fprintf(console.Stdout(ctx), "  %s\n", style.Highlight.Apply(cmd))
-
-		return nil
+			return policyResp.Msg.GetRequiredPermission(), nil
+		},
 	})
 }
 


### PR DESCRIPTION
Extract shared create-token logic into `createtoken.go` with a `createTokenConfig` struct. Both `nsc cache gradle create-token` and `nsc cache sccache create-token` now delegate to the shared `newCreateCacheTokenCmd` helper, providing only cache-specific config (access policy client, labels, setup command hint).

Also fixes:
- Gradle create-token now uses `--cache_name` (was `--name`) in setup hint
- Gradle create-token now outputs "Wrote token contents to ..." message
- Renamed `writeGradleTokenToFile` to `writeTokenToFile`