### PR TITLE
simplelog: add WriteLines for race-free concurrent output

### DIFF
--- a/.github/workflows/scripts/ns_cluster_tests.sh
+++ b/.github/workflows/scripts/ns_cluster_tests.sh
@@ -46,16 +46,19 @@ sleep 3
 tmux capture-pane -t NsSSHSession -p | grep "Linux $CLUSTER_ID"
 tmux send-keys -t NsSSHSession "exit" Enter
 
+# Spawn an nginx pod to generate application logs.
+$NSC_BIN kubectl $CLUSTER_ID run nginx --image=nginx --restart=Never
+
 # Test ns cluster logs
 s=1
-for i in $(seq 1 10); do
-    LOGS=$($NSC_BIN logs $CLUSTER_ID | wc -l)
-    if [[ $(($LOGS)) -gt 0 ]]; then
+for i in $(seq 1 20); do
+    LOGS=$($NSC_BIN logs $CLUSTER_ID --all | wc -l)
+    if [[ $(($LOGS)) -gt 10 ]]; then
         echo "Found cluster logs!"
         s=0
         break
     fi
-    echo "Still no logs from cluster..."
+    echo "Still no logs from cluster... (attempt $i, got $LOGS lines)"
     sleep 5
 done
 if [[ $s -gt 0 ]]; then

--- a/std/tasks/simplelog/logger.go
+++ b/std/tasks/simplelog/logger.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/spf13/pflag"
 	"namespacelabs.dev/foundation/internal/console/colors"
@@ -49,6 +51,8 @@ func (sl *logger) Waiting(ra *tasks.RunningAction) {
 }
 
 func (sl *logger) write(b []byte) {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
 	_, _ = sl.out.Write(b)
 }
 
@@ -115,4 +119,36 @@ func (sl *logger) AttachmentsUpdated(tasks.ActionID, *tasks.ResultData) { /* not
 
 func (sl *logger) Output(name, contentType string, outputType idtypes.CatOutputType) io.Writer {
 	return nil
+}
+
+func (sl *logger) WriteLines(_ idtypes.IdAndHash, name string, cat idtypes.CatOutputType, _ tasks.ActionID, _ time.Time, lines [][]byte) {
+	var buf bytes.Buffer
+	for _, line := range lines {
+		switch name {
+		case idtypes.KnownStdout, idtypes.KnownStderr:
+			fmt.Fprintf(&buf, "%s\n", line)
+		default:
+			fmt.Fprintf(&buf, "%s: %s\n", name, line)
+		}
+	}
+
+	// preserve default from consoleOutputFromCtx
+	var w io.Writer = os.Stdout
+
+	switch name {
+	case idtypes.KnownStdout:
+		w = os.Stdout
+
+	case idtypes.KnownStderr:
+		w = sl.out
+	}
+
+	switch cat {
+	case idtypes.CatOutputDebug, idtypes.CatOutputInfo, idtypes.CatOutputWarnings, idtypes.CatOutputErrors:
+		w = sl.out
+	}
+
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	w.Write(buf.Bytes())
 }


### PR DESCRIPTION
Implementing WriteLines on simplelog routes all console output through a single mutex, preventing interleaved lines from concurrent goroutines.

Output routing matches consoleOutputFromCtx fallback behavior:
- KnownStdout and named tool output -> os.Stdout
- KnownStderr and debug/info/warning/error categories -> sl.out (stderr or file)

Also fixes ns_cluster_tests.sh to use --all and check >10 lines, matching the internal test and preventing false passes.

Amp-Thread-ID: https://ampcode.com/threads/T-019c5226-fd3c-7284-a5ae-d7ebdad21624