### PR TITLE
Installer binary location macOS

### DIFF
--- a/install/install_nsc.sh
+++ b/install/install_nsc.sh
@@ -83,16 +83,22 @@ do_install() {
 
   echo "Detected ${architecture} as the platform architecture"
 
-  # Determine bin_dir
+  # Determine old_bin_dir for compatibility with existing installations
   case "$os" in
-    darwin) bin_dir="$HOME/Library/Application Support/ns/bin" ;;
-    linux) bin_dir="$HOME/.ns/bin" ;;
+    darwin) old_bin_dir="$HOME/Library/Application Support/ns/bin" ;;
+    linux) old_bin_dir="$HOME/.ns/bin" ;;
   esac
+
+  # Default to ~/.local/bin, use old path only for compatibility
+  bin_dir="$HOME/.local/bin"
 
   if [ ! -z "${NS_ROOT:-}" ]; then
     bin_dir="$NS_ROOT/bin"
   elif [ ! -z "${NS_INSTALL_DIR:-}" ]; then
     bin_dir="$NS_INSTALL_DIR"
+  elif [ -x "$old_bin_dir/$tool_name" ]; then
+    # Compatibility: use old path if there's an existing installation
+    bin_dir="$old_bin_dir"
   fi
 
   # If no version specified, query the latest version


### PR DESCRIPTION
Update `install_nsc.sh` to default `ns` binary installation to `~/.local/bin`.

This aligns with the expected default location and `nsc install` behavior, while preserving compatibility with existing installations in legacy paths.

---
Linear Issue: [NSL-7378](https://linear.app/namespacelabs/issue/NSL-7378/installer-puts-ns-binaries-in-wrong-directory-on-macos)

<p><a href="https://cursor.com/background-agent?bcId=bc-a7847a31-3337-4f98-a979-9fa303a168f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7847a31-3337-4f98-a979-9fa303a168f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

