### PR TITLE
nsc version check

### DIFF
--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -17,6 +17,7 @@ import (
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/cli/nsboot"
 	"namespacelabs.dev/foundation/internal/cli/version"
+	"namespacelabs.dev/foundation/internal/cli/versioncheck"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/versions"
@@ -24,7 +25,10 @@ import (
 )
 
 func NewVersionCmd() *cobra.Command {
-	var buildInfo bool
+	var (
+		buildInfo bool
+		short     bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "version",
@@ -45,6 +49,11 @@ func NewVersionCmd() *cobra.Command {
 				return err
 			}
 
+			if short {
+				fmt.Fprintln(console.Stdout(ctx), v.Binary.GetVersion())
+				return nil
+			}
+
 			out := console.Stdout(ctx)
 			FormatVersionInfo(out, v)
 			return nil
@@ -52,9 +61,12 @@ func NewVersionCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&buildInfo, "build_info", buildInfo, "Output all of build info.")
+	cmd.Flags().BoolVar(&short, "short", false, "Only print the version number.")
+	cmd.MarkFlagsMutuallyExclusive("build_info", "short")
 
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newEnsureCmd())
+	cmd.AddCommand(newCheckCmd())
 
 	return cmd
 }
@@ -103,12 +115,97 @@ func newEnsureCmd() *cobra.Command {
 	return cmd
 }
 
+func newCheckCmd() *cobra.Command {
+	var (
+		latest  bool
+		atLeast string
+		quiet   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Checks whether the current binary is up to date.",
+		Long: `Checks whether the current binary is up to date.
+
+By default (--latest), checks if a newer version is available.
+With --at_least, checks if the current version satisfies a minimum version constraint.
+
+Exits with code 0 if the version is up to date or the constraint is met.
+Exits with code 2 if the version is outdated or the constraint is not met.`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			"ns.skip-version-check": "true",
+		},
+
+		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
+			current := version.Tag
+			if current == version.DevelopmentBuildVersion {
+				fmt.Fprintf(console.Stdout(ctx), "Development build, skipping version check.\n")
+				return nil
+			}
+
+			currentV := current
+			if currentV != "" && currentV[0] != 'v' {
+				currentV = "v" + currentV
+			}
+
+			if atLeast != "" {
+				requiredV := atLeast
+				if requiredV != "" && requiredV[0] != 'v' {
+					requiredV = "v" + requiredV
+				}
+
+				if semver.Compare(currentV, requiredV) >= 0 {
+					if !quiet {
+						fmt.Fprintf(console.Stderr(ctx), "✔ Current version %s matches constraint >= %s.\n", current, atLeast)
+					}
+					return nil
+				}
+
+				fmt.Fprintf(console.Stderr(ctx), "✘ Version %s is older than required version %s.\n", current, atLeast)
+				return fnerrors.ExitWithCode(fmt.Errorf("version check failed"), 2)
+			}
+
+			// --latest mode (default).
+			ver, err := version.Current()
+			if err != nil {
+				return err
+			}
+
+			status, err := versioncheck.CheckRemote(ctx, ver, "nsc")
+			if err != nil {
+				return err
+			}
+
+			if status != nil && status.NewVersion {
+				fmt.Fprintf(console.Stderr(ctx), "✘ A newer version is available: %s (current: %s).\n", status.Version, current)
+				return fnerrors.ExitWithCode(fmt.Errorf("newer version available"), 2)
+			}
+
+			if !quiet {
+				fmt.Fprintf(console.Stderr(ctx), "✔ Already on latest version.\n")
+			}
+			return nil
+		}),
+	}
+
+	cmd.Flags().BoolVar(&latest, "latest", true, "Check if a newer version is available.")
+	cmd.Flags().StringVar(&atLeast, "at_least", "", "Check if the current version is at least the given version (does not check for newer versions).")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "Suppress successful output, only prints if version is outdated.")
+	cmd.MarkFlagsMutuallyExclusive("latest", "at_least")
+
+	return cmd
+}
+
 func newUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update",
 		Short:   "Updates the current binary to the latest version.",
 		Aliases: []string{"update-ns"},
 		Args:    cobra.NoArgs,
+		Annotations: map[string]string{
+			"ns.skip-version-check": "true",
+		},
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
 			return nsboot.ForceUpdate(ctx, "nsc")

--- a/internal/cli/fncobra/main.go
+++ b/internal/cli/fncobra/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 	"namespacelabs.dev/foundation/framework/console/termios"
 	"namespacelabs.dev/foundation/framework/ulimit"
 	"namespacelabs.dev/foundation/internal/clerk"
@@ -145,8 +144,8 @@ func doMain(opts MainOpts) (colors.Style, error) {
 
 		ctx := cmd.Context()
 
-		// This is a bit of an hack. But don't run version checks when doing an update.
-		if opts.NotifyOnNewVersion && !slices.Contains(cmd.Aliases, "update-ns") {
+		// Don't run version checks for commands that opt out (e.g. update, check).
+		if opts.NotifyOnNewVersion && cmd.Annotations["ns.skip-version-check"] == "" {
 			DeferCheckVersion(ctx, opts.Name)
 		}
 


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### nsc version check

```
$ nsc version check --help
Checks whether the current binary is up to date.

By default (--latest), checks if a newer version is available.
With --at_least, checks if the current version satisfies a minimum version constraint.

Exits with code 0 if the version is up to date or the constraint is met.
Exits with code 2 if the version is outdated or the constraint is not met.

Usage:
  nsc version check [flags]

Flags:
      --at_least string   Check if the current version is at least the given version (does not check for newer versions).
  -h, --help              help for check
      --latest            Check if a newer version is available. (default true)
      --quiet             Suppress successful output, only prints if version is outdated.
```
<!-- pr-cli body end -->