### PR TITLE
git-checkout: fix deadlock on error, add context cancellation and ret…

### DIFF
--- a/internal/cli/cmd/cluster/gitcheckout.go
+++ b/internal/cli/cmd/cluster/gitcheckout.go
@@ -59,6 +59,9 @@ func newUpdateSubmodulesCmd(mirrorBaseDir *string) *cobra.Command {
 	maxRecurseDepth := cmd.Flags().Int("max-recurse-depth", 20, "max depth of recursion into subdirectories")
 	cmd.Flags().MarkHidden("max-recurse-depth")
 
+	maxAttempts := cmd.Flags().Int("max-attempts", 3, "maximum number of attempts for each git command")
+	cmd.Flags().MarkHidden("max-attempts")
+
 	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
 		p := &processor{
 			repoPath:          *repositoryPath,
@@ -70,6 +73,7 @@ func newUpdateSubmodulesCmd(mirrorBaseDir *string) *cobra.Command {
 			numWorkers:        *numWorkers,
 			repoBufLen:        *repoBufLen,
 			maxRecurseDepth:   *maxRecurseDepth,
+			maxAttempts:       maxAttempts,
 		}
 		return p.updateSubmodules(ctx)
 	})
@@ -97,6 +101,7 @@ type processor struct {
 	numWorkers      int
 	repoBufLen      int
 	maxRecurseDepth int
+	maxAttempts     *int
 
 	processRepoJobQueue         chan processRepoJob
 	doProcessRepoJobQueue       chan processRepoJob
@@ -201,17 +206,24 @@ func (p *processor) updateSubmodules(ctx context.Context) error {
 		})
 	}
 
-	p.scheduleProcessRepo(ctx, p.repoPath, 0)
+	if err := p.scheduleProcessRepo(groupCtx, p.repoPath, 0); err != nil {
+		return err
+	}
 
 	return group.Wait()
 }
 
-func (p *processor) scheduleProcessRepo(ctx context.Context, repoPath string, recursionDepth int) {
+func (p *processor) scheduleProcessRepo(ctx context.Context, repoPath string, recursionDepth int) error {
 	fmt.Fprintf(console.Debug(ctx), "N%d: In %s: scheduled processing\n", recursionDepth, repoPath)
 
-	p.processRepoJobQueue <- processRepoJob{
+	select {
+	case p.processRepoJobQueue <- processRepoJob{
 		repoPath:       repoPath,
 		recursionDepth: recursionDepth,
+	}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -290,7 +302,9 @@ func (p *processor) doProcessRepo(ctx context.Context, job processRepoJob) error
 	mirrorReadyChan := make(chan ensureMirrorResult, len(submodules))
 	for _, submod := range submodules {
 		fmt.Fprintf(console.Info(ctx), "N%d: In %s: Found submodule %s -> %s\n", job.recursionDepth, job.repoPath, submod.relativePath, submod.remoteUrl)
-		p.scheduleEnsureMirror(submod, mirrorReadyChan)
+		if err := p.scheduleEnsureMirror(ctx, submod, mirrorReadyChan); err != nil {
+			return err
+		}
 	}
 
 	// The actual "update" operations for submodules must be performed sequentially
@@ -333,22 +347,28 @@ func (p *processor) doUpdateSubmodule(ctx context.Context, repoPath string, recu
 		submoduleUpdateArgs = append(submoduleUpdateArgs, "--filter", p.filter)
 	}
 	submoduleUpdateArgs = append(submoduleUpdateArgs, submod.relativePath)
-	cmd := inRepoGit(repoPath, submoduleUpdateArgs...)
-	_, err := runAndPrintIfFails(ctx, cmd)
-	if err != nil {
+
+	if err := p.runGitWithRetries(ctx, repoPath, submoduleUpdateArgs...); err != nil {
 		return fmt.Errorf("could not update submodule '%s': %v", submod.relativePath, err)
 	}
 
 	if p.recurseSubmodules {
 		recursePath := filepath.Join(repoPath, submod.relativePath)
-		p.scheduleProcessRepo(ctx, recursePath, recursionDepth+1)
+		if err := p.scheduleProcessRepo(ctx, recursePath, recursionDepth+1); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (p *processor) scheduleEnsureMirror(submod submodule, resultChan chan ensureMirrorResult) {
-	p.ensureMirrorJobQueue <- ensureMirrorJob{submod: submod, resultChan: resultChan}
+func (p *processor) scheduleEnsureMirror(ctx context.Context, submod submodule, resultChan chan ensureMirrorResult) error {
+	select {
+	case p.ensureMirrorJobQueue <- ensureMirrorJob{submod: submod, resultChan: resultChan}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (p *processor) ensureMirrorCoordinator(ctx context.Context) error {
@@ -477,7 +497,7 @@ func (p *processor) workerForDoEnsureMirror(ctx context.Context) error {
 
 func (p *processor) doEnsureMirror(ctx context.Context, job doEnsureMirrorJob) error {
 	fmt.Fprintf(console.Info(ctx), "fetching or cloning mirror for %s at %s\n", job.remoteUrl, job.mirrorDir)
-	err := ensureMirrorWork(ctx, job.remoteUrl, job.mirrorDir)
+	err := p.ensureMirrorWork(ctx, job.remoteUrl, job.mirrorDir)
 
 	select {
 	case p.doEnsureMirrorDoneNotification <- doEnsureMirrorResult{remoteUrl: job.remoteUrl, mirrorDir: job.mirrorDir, err: err}:
@@ -487,33 +507,39 @@ func (p *processor) doEnsureMirror(ctx context.Context, job doEnsureMirrorJob) e
 	}
 }
 
-func ensureMirrorWork(ctx context.Context, remoteUrl string, mirrorDir string) error {
+func (p *processor) ensureMirrorWork(ctx context.Context, remoteUrl string, mirrorDir string) error {
 	if err := os.MkdirAll(mirrorDir, os.ModePerm); err != nil {
 		return fmt.Errorf("can not create '%s' for '%s': %v", mirrorDir, remoteUrl, err)
 	}
 
-	if isMirrorRepo(mirrorDir) {
+	if isMirrorRepo(ctx, mirrorDir) {
 		// Make sure the mirror is up to date
-		cmd := inRepoGit(mirrorDir, "fetch", "--no-recurse-submodules", "origin")
-		_, err := runAndPrintIfFails(ctx, cmd)
-		if err != nil {
+		if err := p.runGitWithRetries(ctx, mirrorDir, "fetch", "--no-recurse-submodules", "origin"); err != nil {
 			return fmt.Errorf("could not git fetch '%s' in '%s': %v", remoteUrl, mirrorDir, err)
 		}
 	} else {
 		// Create new mirror
-		cmd := exec.Command("git", "clone", "--mirror", "--", remoteUrl, mirrorDir)
-		_, err := runAndPrintIfFails(ctx, cmd)
-		if err != nil {
+		if err := p.runGitCmdWithRetries(ctx, func() (*exec.Cmd, error) {
+			// Clean up any partial clone from a previous failed attempt
+			// so git clone doesn't fail with "directory already exists".
+			if err := os.RemoveAll(mirrorDir); err != nil {
+				return nil, fmt.Errorf("could not clean up '%s': %v", mirrorDir, err)
+			}
+			if err := os.MkdirAll(mirrorDir, os.ModePerm); err != nil {
+				return nil, fmt.Errorf("could not create '%s': %v", mirrorDir, err)
+			}
+			return exec.CommandContext(ctx, "git", "clone", "--mirror", "--", remoteUrl, mirrorDir), nil
+		}); err != nil {
 			return fmt.Errorf("could not git clone '%s' to '%s': %v", remoteUrl, mirrorDir, err)
 		}
 	}
 	return nil
 }
 
-func isMirrorRepo(mirrorDir string) bool {
+func isMirrorRepo(ctx context.Context, mirrorDir string) bool {
 	// Mirror repos are bare repositories, so check for that.
 	// This not failing implies that mirrorDir is a git repository in the first place.
-	err := inRepoGit(mirrorDir, "rev-parse", "--is-bare-repository").Run()
+	err := inRepoGit(ctx, mirrorDir, "rev-parse", "--is-bare-repository").Run()
 	return err == nil
 }
 
@@ -538,18 +564,19 @@ func checkIsDir(repoPath string) error {
 	return nil
 }
 
-// Executes "git" as if it ran in "repoPath" in a different way :-)
-// Becuase git submodule doesn't seem to support --work-tree.
-func inRepoGit(repoPath string, args ...string) *exec.Cmd {
+// Executes "git" as if it ran in "repoPath".
+// Because git submodule doesn't seem to support --work-tree.
+// The command is killed when the context is cancelled.
+func inRepoGit(ctx context.Context, repoPath string, args ...string) *exec.Cmd {
 	allArgs := append(
 		[]string{"-C", repoPath},
 		args...)
 
-	return exec.Command("git", allArgs...)
+	return exec.CommandContext(ctx, "git", allArgs...)
 }
 
 func getRepoRemoteOrigin(ctx context.Context, repoPath string) (string, error) {
-	cmd := inRepoGit(repoPath, "config", "--get", "remote.origin.url")
+	cmd := inRepoGit(ctx, repoPath, "config", "--get", "remote.origin.url")
 	output, err := runAndPrintIfFails(ctx, cmd)
 	if err != nil {
 		return "", err
@@ -575,7 +602,7 @@ func resolveRelativeRemoteUrls(submodules []submodule, originRemoteUrl string) (
 }
 
 func getSubmodules(ctx context.Context, repoPath string) ([]submodule, error) {
-	cmd := inRepoGit(repoPath, "config", "--file", ".gitmodules", "--get-regexp", "submodule\\.")
+	cmd := inRepoGit(ctx, repoPath, "config", "--file", ".gitmodules", "--get-regexp", "submodule\\.")
 	fmt.Fprintf(console.Debug(ctx), "exec: %s\n", strings.Join(cmd.Args, " "))
 
 	stdout, err := cmd.StdoutPipe()
@@ -685,6 +712,45 @@ func runAndPrintIfFails(ctx context.Context, cmd *exec.Cmd) (string, error) {
 	return string(output), nil
 }
 
+// runGitWithRetries runs a git command in repoPath, retrying up to max-attempts times on failure.
+func (p *processor) runGitWithRetries(ctx context.Context, repoPath string, args ...string) error {
+	return p.runGitCmdWithRetries(ctx, func() (*exec.Cmd, error) {
+		return inRepoGit(ctx, repoPath, args...), nil
+	})
+}
+
+// runGitCmdWithRetries runs a git command created by makeCmd, retrying up to max-attempts times on failure.
+// makeCmd is called for each attempt because exec.Cmd cannot be reused.
+func (p *processor) runGitCmdWithRetries(ctx context.Context, makeCmd func() (*exec.Cmd, error)) error {
+	maxAttempts := 1
+	if p.maxAttempts != nil && *p.maxAttempts > 1 {
+		maxAttempts = *p.maxAttempts
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			delay := time.Duration(attempt-1) * time.Second
+			fmt.Fprintf(console.Warnings(ctx), "command failed (attempt %d/%d), retrying in %v: %v\n", attempt-1, maxAttempts, delay, lastErr)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		cmd, err := makeCmd()
+		if err != nil {
+			return err
+		}
+		_, lastErr = runAndPrintIfFails(ctx, cmd)
+		if lastErr == nil {
+			return nil
+		}
+	}
+	return lastErr
+}
+
 // Filters submoduleMap: Only retains entries that point to a "commit" git object.
 // submoduleMap is modified in place.
 func filterSubmodules(ctx context.Context, repoPath string, submoduleMap map[string]*submodule) error {
@@ -704,7 +770,7 @@ func filterSubmodules(ctx context.Context, repoPath string, submoduleMap map[str
 		args = append(args, submodule.relativePath)
 	}
 
-	cmd := inRepoGit(repoPath, args...)
+	cmd := inRepoGit(ctx, repoPath, args...)
 	fmt.Fprintf(console.Debug(ctx), "exec: %s\n", strings.Join(cmd.Args, " "))
 
 	stdout, err := cmd.StdoutPipe()

--- a/internal/cli/cmd/cluster/gitcheckout_test.go
+++ b/internal/cli/cmd/cluster/gitcheckout_test.go
@@ -4,7 +4,14 @@
 
 package cluster
 
-import "testing"
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestParseGitConfigKeyValue(t *testing.T) {
 	tests := []struct {
@@ -60,5 +67,91 @@ func TestParseSubmoduleConfigKey(t *testing.T) {
 					tt.input, ok, configKey, attrName, tt.wantOk, tt.wantConfigKey, tt.wantAttrName)
 			}
 		})
+	}
+}
+
+// TestUpdateSubmodulesNoDeadlock verifies that updateSubmodules returns promptly
+// when mirror clones fail, rather than deadlocking on unbuffered channel sends
+// after the errgroup context is cancelled.
+func TestUpdateSubmodulesNoDeadlock(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a main repo with multiple submodules pointing to non-existent URLs.
+	// Multiple submodules are needed to trigger the deadlock: one worker hits an
+	// error while another is blocked sending on an unbuffered channel.
+	repoDir := filepath.Join(tmpDir, "repo")
+	mirrorDir := filepath.Join(tmpDir, "mirror")
+	os.MkdirAll(mirrorDir, os.ModePerm)
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		// Allow local file:// transport for submodule setup.
+		cmd.Env = append(os.Environ(), "GIT_PROTOCOL_FROM_USER=0", "GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=protocol.file.allow", "GIT_CONFIG_VALUE_0=always")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(tmpDir, "git", "init", repoDir)
+	run(repoDir, "git", "config", "user.email", "test@test.com")
+	run(repoDir, "git", "config", "user.name", "Test")
+
+	// Create an initial commit so HEAD exists, and set a remote origin.
+	run(repoDir, "git", "commit", "--allow-empty", "-m", "init")
+	run(repoDir, "git", "remote", "add", "origin", "https://github.com/nonexistent/repo.git")
+
+	// Create multiple submodule entries in .gitmodules pointing to bad URLs.
+	submodNames := []string{"sub-a", "sub-b", "sub-c", "sub-d"}
+
+	// For each submodule, create a real gitlink by adding a local repo as submodule.
+	for _, name := range submodNames {
+		fakeRemote := filepath.Join(tmpDir, "fake-"+name)
+		run(tmpDir, "git", "init", fakeRemote)
+		run(fakeRemote, "git", "config", "user.email", "test@test.com")
+		run(fakeRemote, "git", "config", "user.name", "Test")
+		run(fakeRemote, "git", "commit", "--allow-empty", "-m", "init")
+		run(repoDir, "git", "submodule", "add", "--name", name, fakeRemote, name)
+	}
+
+	// Overwrite .gitmodules URLs to point to non-existent repos.
+	gitmodules := ""
+	for _, name := range submodNames {
+		gitmodules += "[submodule \"" + name + "\"]\n"
+		gitmodules += "\tpath = " + name + "\n"
+		gitmodules += "\turl = file:///nonexistent-repo-" + name + "\n"
+	}
+	os.WriteFile(filepath.Join(repoDir, ".gitmodules"), []byte(gitmodules), 0644)
+	run(repoDir, "git", "add", "-A")
+	run(repoDir, "git", "commit", "-m", "add submodules")
+
+	maxAttempts := 1
+	p := &processor{
+		repoPath:        repoDir,
+		mirrorBaseDir:   mirrorDir,
+		numWorkers:      4,
+		repoBufLen:      1000,
+		maxRecurseDepth: 20,
+		maxAttempts:     &maxAttempts,
+	}
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.updateSubmodules(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error from updateSubmodules, got nil")
+		}
+		// Success: returned an error without deadlocking.
+	case <-time.After(10 * time.Second):
+		t.Fatal("updateSubmodules deadlocked: did not return within 10 seconds")
 	}
 }


### PR DESCRIPTION
…ries

Fix a deadlock in update-submodules that causes the process to hang indefinitely when a git command fails (e.g. a mirror clone for a private repo that isn't accessible via HTTPS).

The deadlock occurs because scheduleProcessRepo and scheduleEnsureMirror perform unconditional sends on unbuffered channels. When a worker returns an error, the errgroup cancels the context and the coordinator goroutines exit. But other workers may still be blocked trying to send on these channels, with no reader on the other end. Since errgroup.Wait waits for all goroutines, it never returns.

Fix by adding a select with ctx.Done() on all unbuffered channel sends so workers unblock promptly on cancellation.

Additionally, all git child processes now use exec.CommandContext so they are killed when the context is cancelled. Previously a long-running git clone (e.g. cloning a large mirror repo) would keep the worker goroutine blocked in cmd.CombinedOutput indefinitely, also preventing errgroup.Wait from returning.

Also add a --max-attempts flag (default 3, hidden) that retries failed git commands with linear backoff. This makes transient git failures (network issues, rate limits) recoverable without restarting the entire checkout.

Amp-Thread-ID: https://ampcode.com/threads/T-019c6d75-e67e-73be-adf5-7daff3c146d5