### PR TITLE
nsc create: forward instance features payload to internal create request

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -52,6 +52,8 @@ func NewCreateCmd() *cobra.Command {
 	cmd.Flags().MarkHidden("ssh_key")
 	experimental := cmd.Flags().String("experimental", "", "JSON definition of experimental features.")
 	experimentalFrom := cmd.Flags().String("experimental_from", "", "Load experimental definitions from the specified file.")
+	experimentalInstanceFeatures := cmd.Flags().String("experimental_instance_features", "", "Raw JSON for internal CreateInstanceRequest.features.")
+	cmd.Flags().MarkHidden("experimental_instance_features")
 
 	duration := fncobra.Duration(cmd.Flags(), "duration", 0, "For how long to run the ephemeral environment.")
 
@@ -86,6 +88,15 @@ func NewCreateCmd() *cobra.Command {
 			SecretIDs:    *availableSecrets,
 			Duration:     *duration,
 			Experimental: map[string]any{},
+		}
+
+		if *experimentalInstanceFeatures != "" {
+			var features any
+			if err := json.Unmarshal([]byte(*experimentalInstanceFeatures), &features); err != nil {
+				return fnerrors.Newf("failed to parse --experimental_instance_features: %w", err)
+			}
+
+			opts.ExperimentalInstanceFeatures = features
 		}
 
 		if len(opts.Labels) == 0 {

--- a/internal/providers/nscloud/api/rpc.go
+++ b/internal/providers/nscloud/api/rpc.go
@@ -206,14 +206,15 @@ type CreateClusterOpts struct {
 	// This is typically needed if you want to execute multiple ns commands on an ephemeral cluster.
 	KeepAtExit bool
 
-	Purpose      string
-	Features     []string
-	UniqueTag    string
-	Labels       map[string]string
-	Duration     time.Duration
-	Experimental map[string]any
-	Volumes      []VolumeSpec
-	SecretIDs    []string
+	Purpose                      string
+	Features                     []string
+	UniqueTag                    string
+	Labels                       map[string]string
+	Duration                     time.Duration
+	Experimental                 map[string]any
+	ExperimentalInstanceFeatures any
+	Volumes                      []VolumeSpec
+	SecretIDs                    []string
 
 	WaitClusterOpts
 }
@@ -245,6 +246,7 @@ func CreateCluster(ctx context.Context, api API, opts CreateClusterOpts) (*Creat
 				Feature:           opts.Features,
 				UniqueTag:         opts.UniqueTag,
 				Experimental:      opts.Experimental,
+				Features:          opts.ExperimentalInstanceFeatures,
 			}
 
 			if len(opts.Volumes) > 0 {

--- a/internal/providers/nscloud/api/types.go
+++ b/internal/providers/nscloud/api/types.go
@@ -20,6 +20,7 @@ type CreateInstanceRequest struct {
 	Feature           []string                               `json:"feature,omitempty"`
 	AvailableSecrets  []*SecretRef                           `json:"available_secrets,omitempty"`
 	Experimental      map[string]any                         `json:"experimental,omitempty"`
+	Features          any                                    `json:"features,omitempty"` // Internal API extension.
 
 	Container []*ContainerRequest `json:"container,omitempty"`
 


### PR DESCRIPTION
Add support in `nsc create` to accept a raw JSON instance feature payload and forward it to internal compute `CreateInstanceRequest.features`.