### PR TITLE
tracing/filter: drop skipped spans regardless of parent sampling

### DIFF
--- a/std/monitoring/tracing/filter/filter.go
+++ b/std/monitoring/tracing/filter/filter.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const DefaultEnvKey = "FOUNDATION_TRACE_SKIP_SPANS"
@@ -32,13 +31,7 @@ type sampler struct {
 }
 
 func (s sampler) ShouldSample(params sdktrace.SamplingParameters) sdktrace.SamplingResult {
-	parent := trace.SpanContextFromContext(params.ParentContext)
-
-	// If the parent is valid and sampled, inherit
-	if parent.IsValid() && parent.IsSampled() {
-		return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
-	}
-
+	// Check the drop list first, regardless of parent sampling decision.
 	if _, shouldDrop := s.drop[params.Name]; shouldDrop {
 		return sdktrace.SamplingResult{Decision: sdktrace.Drop}
 	}


### PR DESCRIPTION
## Problem

The span filter sampler inherited the parent's sampling decision before checking the drop list. This meant `FOUNDATION_TRACE_SKIP_SPANS` had no effect on spans with a sampled parent context — they were always recorded.

## Fix

Ignore parent trace sampling for spans in the drop list. If a span name matches the skip list, it is always dropped. The parent-inherit check was redundant after this change and has been removed.