### PR TITLE
tracing: add FOUNDATION_HTTP_TRACE_SKIP_HEADERS to filter HTTP spans …

### DIFF
--- a/std/monitoring/tracing/wire.go
+++ b/std/monitoring/tracing/wire.go
@@ -242,6 +242,25 @@ func Prepare(ctx context.Context, deps ExtensionDeps) error {
 		}
 	}
 
+	// FOUNDATION_HTTP_TRACE_SKIP_HEADERS is a comma-separated list of header names. If any of these
+	// headers are present in the request, the HTTP-level span is skipped.
+	// This is useful for protocols that use standard Content-Types (e.g. application/json) but
+	// include a distinguishing header. For example, Connect unary RPCs with JSON encoding
+	// send "Connect-Protocol-Version: 1".
+	// Recommended value: "Connect-Protocol-Version"
+	if skipStr := os.Getenv("FOUNDATION_HTTP_TRACE_SKIP_HEADERS"); skipStr != "" {
+		skipHeaders := strings.Split(skipStr, ",")
+		base := httpFilter
+		httpFilter = func(r *http.Request) bool {
+			for _, h := range skipHeaders {
+				if r.Header.Get(h) != "" {
+					return false
+				}
+			}
+			return base(r)
+		}
+	}
+
 	if skipStr := os.Getenv("FOUNDATION_HTTP_TRACE_SKIP_PATHS"); skipStr != "" {
 		skipPaths := strings.Split(skipStr, ",")
 		base := httpFilter


### PR DESCRIPTION
…by request header

Adds a new env var that skips HTTP-level tracing when specific request headers are present. This complements FOUNDATION_HTTP_TRACE_SKIP_CONTENT_TYPES for protocols that use standard Content-Types (e.g. application/json) but include a distinguishing header.

For example, Connect unary RPCs with JSON encoding use Content-Type: application/json (indistinguishable from plain HTTP) but send a Connect-Protocol-Version header that can be used to identify them.

Also removes the hardcoded Connect-Protocol-Version check that was previously embedded in the content-type filter.

Amp-Thread-ID: https://ampcode.com/threads/T-019cb427-d4ef-76cc-96d0-40d8a00806f2