### PR TITLE
Artifact describe not found json

### DIFF
--- a/internal/cli/cmd/cluster/artifact.go
+++ b/internal/cli/cmd/cluster/artifact.go
@@ -624,6 +624,15 @@ func writeArtifactDescribeNotFound(w io.Writer, output, path, namespace string) 
 	return msg, nil
 }
 
+func artifactDescribeNotFoundError(w io.Writer, output, path, namespace string) error {
+	msg, err := writeArtifactDescribeNotFound(w, output, path, namespace)
+	if err != nil {
+		return err
+	}
+
+	return fnerrors.ExitWithCode(errors.New(msg), 2)
+}
+
 func newArtifactDescribeCmd() *cobra.Command {
 	var namespace string
 	var output string
@@ -658,11 +667,7 @@ func newArtifactDescribeCmd() *cobra.Command {
 		})
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
-				msg, err := writeArtifactDescribeNotFound(console.Stdout(ctx), output, path, namespace)
-				if err != nil {
-					return err
-				}
-				return fnerrors.ExitWithCode(errors.New(msg), 2)
+				return artifactDescribeNotFoundError(console.Stdout(ctx), output, path, namespace)
 			}
 			return err
 		}
@@ -670,11 +675,7 @@ func newArtifactDescribeCmd() *cobra.Command {
 		desc := res.GetDescription()
 
 		if desc.GetStatus() == storagev1beta.Artifact_EXPIRED {
-			msg, err := writeArtifactDescribeNotFound(console.Stdout(ctx), output, path, namespace)
-			if err != nil {
-				return err
-			}
-			return fnerrors.ExitWithCode(errors.New(msg), 2)
+			return artifactDescribeNotFoundError(console.Stdout(ctx), output, path, namespace)
 		}
 
 		switch output {

--- a/internal/cli/cmd/cluster/artifact_test.go
+++ b/internal/cli/cmd/cluster/artifact_test.go
@@ -268,3 +268,25 @@ func TestWriteArtifactDescribeNotFoundInvalidOutput(t *testing.T) {
 		t.Fatalf("expected bad input error, got: %T (%v)", err, err)
 	}
 }
+
+func TestArtifactDescribeNotFoundErrorRetainsExitCode(t *testing.T) {
+	for _, output := range []string{"plain", "json"} {
+		t.Run(output, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			err := artifactDescribeNotFoundError(&buf, output, "foo/bar", "main")
+			if err == nil {
+				t.Fatalf("expected not-found error")
+			}
+
+			exitErr, ok := err.(fnerrors.ExitError)
+			if !ok {
+				t.Fatalf("expected fnerrors.ExitError, got %T (%v)", err, err)
+			}
+
+			if code := exitErr.ExitCode(); code != 2 {
+				t.Fatalf("expected exit code 2, got %d", code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Align `nsc artifact describe`'s not-found output with `-o json` flag for consistent JSON error reporting.

---
<p><a href="https://cursor.com/agents/bc-8b894100-fb57-4914-9d64-5daf6dae8da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b894100-fb57-4914-9d64-5daf6dae8da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->