### PR TITLE
Add experimental_instance_features support to nsc run

### DIFF
--- a/internal/cli/cmd/cluster/run.go
+++ b/internal/cli/cmd/cluster/run.go
@@ -53,6 +53,7 @@ func NewRunCmd() *cobra.Command {
 	network := run.Flags().String("network", "", "The network setting to start the container with.")
 	experimental := run.Flags().String("experimental", "", "A set of experimental settings to pass during creation.")
 	instanceExperimental := run.Flags().String("instance_experimental", "", "A set of experimental instance settings to pass during creation.")
+	experimentalInstanceFeatures := run.Flags().String("experimental_instance_features", "", "Raw JSON for internal CreateInstanceRequest.features.")
 	userSshey := run.Flags().String("ssh_key", "", "Injects the specified ssh public key in the created instance.")
 	volumes := run.Flags().StringSlice("volume", nil, "Attach a volume to the instance, {cache|persistent}:{tag}:{mountpoint}:{size}")
 
@@ -64,6 +65,7 @@ func NewRunCmd() *cobra.Command {
 	run.Flags().MarkHidden("network")
 	run.Flags().MarkHidden("experimental")
 	run.Flags().MarkHidden("instance_experimental")
+	run.Flags().MarkHidden("experimental_instance_features")
 	run.Flags().MarkHidden("expose_nsc_bins")
 	run.Flags().MarkHidden("ssh_key")
 
@@ -119,9 +121,9 @@ func NewRunCmd() *cobra.Command {
 			}
 		}
 
-		if *instanceExperimental != "" {
-			if err := json.Unmarshal([]byte(*instanceExperimental), &opts.InstanceExperimental); err != nil {
-				return fnerrors.Newf("failed to parse: %w", err)
+		if *experimentalInstanceFeatures != "" {
+			if err := json.Unmarshal([]byte(*experimentalInstanceFeatures), &opts.ExperimentalInstanceFeatures); err != nil {
+				return fnerrors.Newf("failed to parse --experimental_instance_features: %w", err)
 			}
 		}
 
@@ -255,22 +257,23 @@ func fillInIngressRules(ports []int32, ingressRules map[string]string) ([]export
 }
 
 type CreateContainerOpts struct {
-	Name                 string
-	Image                string
-	Args                 []string
-	Env                  map[string]string
-	Flags                []string
-	ExportedPorts        []exportContainerPort
-	Features             []string
-	Labels               map[string]string
-	InternalExtra        string
-	EnableDocker         bool
-	ForwardNscState      bool
-	ExposeNscBins        bool
-	Network              string
-	Experimental         map[string]any
-	InstanceExperimental map[string]any
-	User                 string
+	Name                         string
+	Image                        string
+	Args                         []string
+	Env                          map[string]string
+	Flags                        []string
+	ExportedPorts                []exportContainerPort
+	Features                     []string
+	Labels                       map[string]string
+	InternalExtra                string
+	EnableDocker                 bool
+	ForwardNscState              bool
+	ExposeNscBins                bool
+	Network                      string
+	Experimental                 map[string]any
+	InstanceExperimental         map[string]any
+	ExperimentalInstanceFeatures any
+	User                         string
 }
 
 type exportContainerPort struct {
@@ -339,6 +342,7 @@ func CreateContainerInstance(ctx context.Context, machineType string, duration, 
 				Label:        labels,
 				Feature:      opts.Features,
 				Experimental: opts.InstanceExperimental,
+				Features:     opts.ExperimentalInstanceFeatures,
 			}
 
 			if duration > 0 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add hidden `--experimental_instance_features` flag to `nsc run`, matching `nsc create`
- parse the flag as raw JSON with a specific parse error message for this option
- thread parsed value through run container creation and set `CreateInstanceRequest.Features`

## Testing
- `go test ./internal/cli/cmd/cluster/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-906cf70d-f4d0-4c25-a08c-fc34822ceefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-906cf70d-f4d0-4c25-a08c-fc34822ceefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

