### PR TITLE
Extend `nsc run` with `--documented_purpose`

### DIFF
--- a/internal/cli/cmd/cluster/run.go
+++ b/internal/cli/cmd/cluster/run.go
@@ -43,6 +43,7 @@ func NewRunCmd() *cobra.Command {
 	wait := run.Flags().Bool("wait", false, "Wait for the container to start running.")
 	waitTimeout := fncobra.Duration(run.Flags(), "wait_timeout", time.Minute, "For how long to wait until the instance becomes ready.")
 	features := run.Flags().StringSlice("features", nil, "A set of features to attach to the instance.")
+	documentedPurpose := run.Flags().String("documented_purpose", "Manually created from CLI", "What documented purpose to attach to the created instance.")
 	ingressRules := run.Flags().StringToString("ingress", map[string]string{}, "Specify ingress rules for ports; specify * to apply rules to any port; separate each rule with ;.")
 	duration := fncobra.Duration(run.Flags(), "duration", 0, "For how long to run the ephemeral environment.")
 	labels := run.Flags().StringToString("label", nil, "Create the environment with a set of labels.")
@@ -92,21 +93,26 @@ func NewRunCmd() *cobra.Command {
 			if *duration > 0 {
 				return fnerrors.Newf("--duration can only be set when creating an environment (i.e. it can't be set when --on is specified)")
 			}
+
+			if run.Flags().Changed("documented_purpose") {
+				return fnerrors.Newf("--documented_purpose can only be set when creating an environment (i.e. it can't be set when --on is specified)")
+			}
 		}
 
 		opts := CreateContainerOpts{
-			Name:            name,
-			Image:           *image,
-			Args:            args,
-			Env:             *env,
-			Features:        *features,
-			Labels:          *labels,
-			InternalExtra:   *internalExtra,
-			EnableDocker:    *enableDocker,
-			ForwardNscState: *forwardNscState,
-			ExposeNscBins:   *exposeNscBins,
-			Network:         *network,
-			User:            *user,
+			Name:              name,
+			Image:             *image,
+			Args:              args,
+			Env:               *env,
+			Features:          *features,
+			DocumentedPurpose: *documentedPurpose,
+			Labels:            *labels,
+			InternalExtra:     *internalExtra,
+			EnableDocker:      *enableDocker,
+			ForwardNscState:   *forwardNscState,
+			ExposeNscBins:     *exposeNscBins,
+			Network:           *network,
+			User:              *user,
 		}
 
 		if *experimental != "" {
@@ -264,6 +270,7 @@ type CreateContainerOpts struct {
 	Flags                        []string
 	ExportedPorts                []exportContainerPort
 	Features                     []string
+	DocumentedPurpose            string
 	Labels                       map[string]string
 	InternalExtra                string
 	EnableDocker                 bool
@@ -337,12 +344,13 @@ func CreateContainerInstance(ctx context.Context, machineType string, duration, 
 
 		resp, err := tasks.Return(ctx, tasks.Action("nscloud.create-containers").HumanReadable(label), func(ctx context.Context) (*CreateContainerResult, error) {
 			req := api.CreateInstanceRequest{
-				MachineType:  machineType,
-				Container:    []*api.ContainerRequest{container},
-				Label:        labels,
-				Feature:      opts.Features,
-				Experimental: opts.InstanceExperimental,
-				Features:     opts.ExperimentalInstanceFeatures,
+				MachineType:       machineType,
+				DocumentedPurpose: opts.DocumentedPurpose,
+				Container:         []*api.ContainerRequest{container},
+				Label:             labels,
+				Feature:           opts.Features,
+				Experimental:      opts.InstanceExperimental,
+				Features:          opts.ExperimentalInstanceFeatures,
 			}
 
 			if duration > 0 {

--- a/internal/cli/cmd/cluster/run_test.go
+++ b/internal/cli/cmd/cluster/run_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRunCmdRejectsDocumentedPurposeWithOn(t *testing.T) {
+	cmd := NewRunCmd()
+	cmd.SetArgs([]string{
+		"--image", "busybox:latest",
+		"--on", "existing-instance",
+		"--documented_purpose", "testing-purpose",
+	})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("ExecuteContext() error = nil, want validation error")
+	}
+
+	if !strings.Contains(err.Error(), "--documented_purpose can only be set when creating an environment") {
+		t.Fatalf("ExecuteContext() error = %q, want documented_purpose validation error", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `--documented_purpose` flag to `nsc run`, matching `nsc create` semantics and default text
- thread the value through `CreateContainerOpts` into `CreateInstanceRequest.DocumentedPurpose` when `nsc run` creates a new ephemeral environment
- reject explicit `--documented_purpose` when `--on` is used, since no new environment is created in that mode
- add `TestRunCmdRejectsDocumentedPurposeWithOn` to cover the new validation behavior

## Testing
- `go test ./internal/cli/cmd/cluster -run TestRunCmdRejectsDocumentedPurposeWithOn`
- `go test ./internal/cli/cmd/cluster`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a90c7334-b685-4e5f-98b2-a3c5d1be6f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a90c7334-b685-4e5f-98b2-a3c5d1be6f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

