### PR TITLE
nsc create: unhide ssh_key flag

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -49,7 +49,6 @@ func NewCreateCmd() *cobra.Command {
 	outputRegistryPath := cmd.Flags().String("output_registry_to", "", "If specified, write the registry address to this path.")
 	output := cmd.Flags().StringP("output", "o", "plain", "One of plain or json.")
 	userSshey := cmd.Flags().String("ssh_key", "", "Injects the specified ssh public key in the created instance.")
-	cmd.Flags().MarkHidden("ssh_key")
 	experimental := cmd.Flags().String("experimental", "", "JSON definition of experimental features.")
 	experimentalFrom := cmd.Flags().String("experimental_from", "", "Load experimental definitions from the specified file.")
 


### PR DESCRIPTION
The `ssh_key` flag on `nsc create` was marked as hidden, so it didn't appear in `--help` output.

However, we reference this flag in our documentation for native SSH access:
https://namespace.so/docs/architecture/compute/ssh-remote-display#ssh-access

Since the flag is part of our public API contract via the docs, it should be visible and discoverable in CLI help.