### PR TITLE
artifact/download: retry transient download failures

### DIFF
--- a/internal/artifacts/download/download.go
+++ b/internal/artifacts/download/download.go
@@ -6,19 +6,29 @@ package download
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"syscall"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"namespacelabs.dev/foundation/internal/artifacts"
 	"namespacelabs.dev/foundation/internal/bytestream"
 	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/ctxio"
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/tasks"
 )
+
+// Maximum total time we'll spend retrying transient download failures.
+const downloadMaxElapsed = 2 * time.Minute
 
 func URL(ref artifacts.Reference) compute.Computable[bytestream.ByteStream] {
 	return &downloadUrl{url: ref.URL, digest: &ref.Digest}
@@ -66,9 +76,45 @@ func (dl *downloadUrl) Compute(ctx context.Context, _ compute.Resolved) (bytestr
 		url += "?" + query
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 500 * time.Millisecond
+	b.RandomizationFactor = 0.5
+	b.Multiplier = 1.5
+	b.MaxInterval = 5 * time.Second
+	b.MaxElapsedTime = downloadMaxElapsed
+	b.Reset()
+
+	var result bytestream.ByteStream
+	attempt := 0
+	err := backoff.Retry(func() error {
+		attempt++
+		bs, finalURL, err := dl.attempt(ctx, url)
+		if err == nil {
+			result = bs
+			return nil
+		}
+		if isRetryableDownloadError(err) {
+			fmt.Fprintf(console.Warnings(ctx), "artifact.download: %s: attempt %d failed with transient error, retrying (final url=%s): %v\n", dl.url, attempt, finalURL, err)
+			return err
+		}
+		fmt.Fprintf(console.Warnings(ctx), "artifact.download: %s: attempt %d failed with permanent error (final url=%s): %v\n", dl.url, attempt, finalURL, err)
+		return backoff.Permanent(err)
+	}, backoff.WithContext(b, ctx))
 	if err != nil {
 		return nil, err
+	}
+	return result, nil
+}
+
+// attempt performs a single download attempt. It always returns the final URL it observed
+// (after following redirects); on error this lets callers log where the failure actually
+// originated rather than just the user-supplied URL.
+func (dl *downloadUrl) attempt(ctx context.Context, requestURL string) (bytestream.ByteStream, string, error) {
+	finalURL := requestURL
+
+	req, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+	if err != nil {
+		return nil, finalURL, err
 	}
 
 	if dl.useNamespaceHeaders {
@@ -77,18 +123,28 @@ func (dl *downloadUrl) Compute(ctx context.Context, _ compute.Resolved) (bytestr
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err
+		// *url.Error.URL is the URL of the request that failed, which reflects the post-redirect
+		// URL when the failure happens after a redirect was followed.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) && urlErr.URL != "" {
+			finalURL = urlErr.URL
+		}
+		return nil, finalURL, err
 	}
 
 	defer resp.Body.Close()
 
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return nil, fnerrors.InvocationError("http", "failed to download %s: got status %d", dl.url, resp.StatusCode)
+		return nil, finalURL, newHTTPStatusError(dl.url, resp.StatusCode)
 	}
 
 	bsw, err := compute.NewByteStream(ctx)
 	if err != nil {
-		return nil, err
+		return nil, finalURL, err
 	}
 
 	defer bsw.Close()
@@ -104,27 +160,117 @@ func (dl *downloadUrl) Compute(ctx context.Context, _ compute.Resolved) (bytestr
 
 	w := io.MultiWriter(bsw, p)
 
-	_, err = io.Copy(ctxio.WriterWithContext(ctx, w, nil), resp.Body)
-	if err != nil {
-		return nil, err
+	if _, err := io.Copy(ctxio.WriterWithContext(ctx, w, nil), resp.Body); err != nil {
+		return nil, finalURL, err
 	}
 
 	bs, err := bsw.Complete()
 	if err != nil {
-		return nil, err
+		return nil, finalURL, err
 	}
 
 	if dl.digest != nil {
 		resultDigest, err := bytestream.Digest(ctx, bs)
 		if err != nil {
-			return nil, err
+			return nil, finalURL, err
 		}
 
 		if !resultDigest.Equals(*dl.digest) {
-			return nil, fnerrors.InternalError("artifact.download: %s: digest didn't match, got %s expected %s", dl.url, resultDigest, dl.digest)
+			// Treat as transient: a truncated/corrupted body may not surface as a transport-level
+			// EOF (e.g. with a known Content-Length the server can still deliver short bytes that
+			// are mistakenly framed as a clean close). Retrying recovers from those cases.
+			return nil, finalURL, newDigestMismatchError(dl.url, resultDigest.String(), dl.digest.String())
 		}
 	}
 
 	// XXX support returning a io.Reader here so we don't need to buffer the download.
-	return bs, nil
+	return bs, finalURL, nil
+}
+
+type httpStatusError struct {
+	url    string
+	status int
+	err    error
+}
+
+func (e *httpStatusError) Error() string { return e.err.Error() }
+func (e *httpStatusError) Unwrap() error { return e.err }
+
+func newHTTPStatusError(url string, status int) *httpStatusError {
+	return &httpStatusError{
+		url:    url,
+		status: status,
+		err:    fnerrors.InvocationError("http", "failed to download %s: got status %d", url, status),
+	}
+}
+
+type digestMismatchError struct {
+	err error
+}
+
+func (e *digestMismatchError) Error() string { return e.err.Error() }
+func (e *digestMismatchError) Unwrap() error { return e.err }
+
+func newDigestMismatchError(url, got, want string) *digestMismatchError {
+	return &digestMismatchError{
+		err: fnerrors.InternalError("artifact.download: %s: digest didn't match, got %s expected %s", url, got, want),
+	}
+}
+
+// isRetryableDownloadError returns true if err is likely to be transient and worth retrying.
+func isRetryableDownloadError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Don't retry on cancellation/deadline of the caller context.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Mid-body truncation — the symptom we're trying to fix here.
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+
+	// Connection reset, broken pipe, etc.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		// net/http surfaces transient transport errors wrapped in *url.Error; if the underlying
+		// error wasn't already matched above, treat any url.Error other than a context error as
+		// retryable.
+		if temp, ok := urlErr.Err.(interface{ Temporary() bool }); ok && temp.Temporary() {
+			return true
+		}
+		return urlErr.Timeout()
+	}
+
+	var statusErr *httpStatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.status {
+		case http.StatusRequestTimeout, // 408
+			http.StatusTooManyRequests,     // 429
+			http.StatusInternalServerError, // 500
+			http.StatusBadGateway,          // 502
+			http.StatusServiceUnavailable,  // 503
+			http.StatusGatewayTimeout:      // 504
+			return true
+		}
+		return false
+	}
+
+	var digestErr *digestMismatchError
+	if errors.As(err, &digestErr) {
+		return true
+	}
+
+	return false
 }

--- a/internal/artifacts/download/download_test.go
+++ b/internal/artifacts/download/download_test.go
@@ -1,0 +1,164 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"namespacelabs.dev/foundation/internal/artifacts"
+	"namespacelabs.dev/foundation/internal/bytestream"
+	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/tasks"
+)
+
+func TestRetriesTransientEOF(t *testing.T) {
+	body := []byte("hello world, this is the payload")
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requests.Add(1)
+		// Fail the first 2 attempts with a truncated body.
+		if n <= 2 {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body[:5])
+			// Hijack to abort the connection so the client surfaces io.ErrUnexpectedEOF
+			// rather than getting a clean close.
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					_ = conn.Close()
+					return
+				}
+			}
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	hash := sha256.Sum256(body)
+	ref := artifacts.Reference{
+		URL:    server.URL,
+		Digest: schema.Digest{Algorithm: "sha256", Hex: hex.EncodeToString(hash[:])},
+	}
+
+	ctx := tasks.WithSink(context.Background(), tasks.NullSink())
+
+	var got []byte
+	err := compute.Do(ctx, func(ctx context.Context) error {
+		bs, err := compute.GetValue(ctx, URL(ref))
+		if err != nil {
+			return err
+		}
+		got, err = bytestream.ReadAll(bs)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q, want %q", got, body)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("want 3 requests (2 transient failures + 1 success), got %d", requests.Load())
+	}
+}
+
+func TestNonRetryable4xx(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "nope", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	ctx := tasks.WithSink(context.Background(), tasks.NullSink())
+
+	err := compute.Do(ctx, func(ctx context.Context) error {
+		_, err := compute.GetValue(ctx, UnverifiedURL(server.URL))
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("want 1 request (4xx is permanent), got %d", requests.Load())
+	}
+}
+
+func TestRetries5xx(t *testing.T) {
+	body := []byte("payload")
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requests.Add(1)
+		if n == 1 {
+			http.Error(w, "boom", http.StatusBadGateway)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	ctx := tasks.WithSink(context.Background(), tasks.NullSink())
+
+	var got []byte
+	err := compute.Do(ctx, func(ctx context.Context) error {
+		bs, err := compute.GetValue(ctx, UnverifiedURL(server.URL))
+		if err != nil {
+			return err
+		}
+		got, err = bytestream.ReadAll(bs)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q, want %q", got, body)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("want 2 requests (1 502 + 1 success), got %d", requests.Load())
+	}
+}
+
+func TestErrorClassification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"plain EOF", io.EOF, true},
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"http 502", newHTTPStatusError("u", http.StatusBadGateway), true},
+		{"http 503", newHTTPStatusError("u", http.StatusServiceUnavailable), true},
+		{"http 429", newHTTPStatusError("u", http.StatusTooManyRequests), true},
+		{"http 403", newHTTPStatusError("u", http.StatusForbidden), false},
+		{"http 404", newHTTPStatusError("u", http.StatusNotFound), false},
+		{"digest mismatch", newDigestMismatchError("u", "a", "b"), true},
+		{"random error", errors.New("foo"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableDownloadError(tc.err); got != tc.want {
+				t.Fatalf("isRetryableDownloadError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Wraps `download.Compute` in an exponential backoff retry loop using `cenkalti/backoff/v4`.
- Treats mid-body EOFs, connection resets, `*net.OpError`, 408/429/500/502/503/504 and digest mismatches as transient; everything else is a permanent error.
- Each attempt creates a fresh request and `ByteStream`. Warning logs include the post-redirect URL (from `resp.Request.URL` or `*url.Error.URL`) so it is clear which upstream actually failed.
- Preserves the original public error types via `fnerrors.InvocationError`/`InternalError` wrappers.

## Validation

- `go build ./internal/artifacts/download/`
- `go vet ./internal/artifacts/download/`
