### PR TITLE
servercore: trigger HTTP/2 GOAWAY on lameduck

### DIFF
--- a/std/go/grpc/drain.go
+++ b/std/go/grpc/drain.go
@@ -11,6 +11,13 @@ import (
 var (
 	DrainFunc        func()
 	DrainFuncsByName = map[string]func(){}
+
+	// LameduckFuncsByName are invoked after MarkShutdownStarted and before any
+	// drain function. Their purpose is to signal to clients that the server is
+	// going away (e.g. by sending HTTP/2 GOAWAY frames) without waiting for
+	// in-flight work to drain. Lameduck functions should return quickly; any
+	// long-running drain logic belongs in DrainFunc/DrainFuncsByName.
+	LameduckFuncsByName = map[string]func(){}
 )
 
 func SetDrainFunc(f func()) {
@@ -31,4 +38,20 @@ func SetNamedDrainFunc(name string, f func()) {
 	}
 
 	DrainFuncsByName[name] = f
+}
+
+// SetNamedLameduckFunc registers a lameduck function that runs after
+// MarkShutdownStarted and before any drain function. Lameduck functions
+// signal to clients that the server is going away (typically by triggering
+// HTTP/2 GOAWAY) and should return quickly.
+//
+// SetNamedLameduckFunc may be called both during initialization and during
+// Listen (e.g. by the foundation framework itself once the http server has
+// been constructed).
+func SetNamedLameduckFunc(name string, f func()) {
+	if _, ok := LameduckFuncsByName[name]; ok {
+		panic("lameduck func was already set")
+	}
+
+	LameduckFuncsByName[name] = f
 }

--- a/std/go/grpc/servercore/listener.go
+++ b/std/go/grpc/servercore/listener.go
@@ -232,6 +232,24 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 
 		core.ZLog.Info().Msgf("Starting HTTP listen on %v", gwLis.Addr())
 
+		// Register a lameduck hook so SIGTERM triggers HTTP/2 GOAWAY on
+		// open h2c connections (wired up via http2.ConfigureServer in
+		// NewHttp2CapableServer). Calling Shutdown here also closes the
+		// listener; that's intentional: by the time SIGTERM is delivered
+		// the pod is being rolled and Kubernetes is removing us from the
+		// service endpoints, so refusing new TCP connections is fine and
+		// the OnShutdown hooks (which fan out the GOAWAY frames in
+		// goroutines) are what matters for in-flight pooled clients.
+		gogrpc.SetNamedLameduckFunc("servercore.http", func() {
+			// Shutdown blocks until tracked HTTP/1 connections idle out,
+			// so run it asynchronously to keep the lameduck phase short.
+			go func() {
+				if err := httpServer.Shutdown(context.Background()); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					core.ZLog.Error().Err(err).Msg("http server lameduck shutdown failed")
+				}
+			}()
+		})
+
 		eg.Go(func() error { return ListenAndGracefullyShutdownHTTP(egCtx, "http", httpServer, gwLis) })
 	}
 
@@ -306,20 +324,37 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 }
 
 func NewHttp2CapableServer(mux http.Handler, opts HTTPOptions) *http.Server {
-	return &http.Server{
-		Handler: h2c.NewHandler(mux, &http2.Server{
-			MaxConcurrentStreams:         opts.HTTP2MaxConcurrentStreams,
-			MaxReadFrameSize:             opts.HTTP2MaxReadFrameSize,
-			IdleTimeout:                  opts.HTTP2IdleTimeout,
-			MaxUploadBufferPerConnection: opts.HTTP2MaxUploadBufferPerConnection,
-			MaxUploadBufferPerStream:     opts.HTTP2MaxUploadBufferPerStream,
-		}),
+	h2srv := &http2.Server{
+		MaxConcurrentStreams:         opts.HTTP2MaxConcurrentStreams,
+		MaxReadFrameSize:             opts.HTTP2MaxReadFrameSize,
+		IdleTimeout:                  opts.HTTP2IdleTimeout,
+		MaxUploadBufferPerConnection: opts.HTTP2MaxUploadBufferPerConnection,
+		MaxUploadBufferPerStream:     opts.HTTP2MaxUploadBufferPerStream,
+	}
+
+	srv := &http.Server{
+		Handler:           h2c.NewHandler(mux, h2srv),
 		ReadTimeout:       opts.HTTP1ReadTimeout,
 		ReadHeaderTimeout: opts.HTTP1ReadHeaderTimeout,
 		WriteTimeout:      opts.HTTP1WriteTimeout,
 		IdleTimeout:       opts.HTTP1IdleTimeout,
 		MaxHeaderBytes:    opts.HTTP1MaxHeaderBytes,
 	}
+
+	// Wire up HTTP/2 graceful shutdown for h2c. ConfigureServer registers an
+	// OnShutdown handler on srv that, when invoked, sends GOAWAY frames to
+	// every active HTTP/2 connection served by h2srv (h2c hijacks the
+	// underlying net.Conn from the *http.Server and feeds it to
+	// h2srv.ServeConn, so without this call those hijacked connections are
+	// invisible to srv.Shutdown and would never receive GOAWAY).
+	if err := http2.ConfigureServer(srv, h2srv); err != nil {
+		// ConfigureServer only returns errors when the http.Server has an
+		// invalid TLS configuration, which our h2c plaintext server never
+		// has. Treat it as a programmer error.
+		panic(fmt.Errorf("http2.ConfigureServer: %w", err))
+	}
+
+	return srv
 }
 
 func ListenAndGracefullyShutdownGRPC(ctx context.Context, label string, srv *grpc.Server, lis net.Listener) error {

--- a/std/go/grpc/servercore/listener_test.go
+++ b/std/go/grpc/servercore/listener_test.go
@@ -1,0 +1,154 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package servercore
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// TestNewHttp2CapableServer_GoawayOnShutdown verifies that
+// NewHttp2CapableServer wires up HTTP/2 graceful shutdown for h2c
+// connections (via http2.ConfigureServer): an in-flight request
+// completes successfully, and a new request on the same pooled
+// connection observes the GOAWAY and is forced to dial a fresh
+// connection.
+func TestNewHttp2CapableServer_GoawayOnShutdown(t *testing.T) {
+	started := make(chan struct{})
+	finish := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-finish
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	mux.HandleFunc("/quick", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := NewHttp2CapableServer(mux, HTTPOptions{})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer lis.Close()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(lis) }()
+
+	// Build an HTTP/2-only client that talks h2c (cleartext) to our
+	// server. AllowHTTP=true plus a plain net.Dial in DialTLSContext
+	// is the standard recipe for h2c on the client side.
+	transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+
+	base := "http://" + lis.Addr().String()
+
+	// Prime the connection: a quick request so the http2 client has an
+	// open conn to reuse for the slow request.
+	if resp, err := client.Get(base + "/quick"); err != nil {
+		t.Fatalf("priming request: %v", err)
+	} else {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// Kick off a long-running request. It will block in the handler
+	// until we close `finish`.
+	var inflightWG sync.WaitGroup
+	inflightWG.Add(1)
+	var slowResp *http.Response
+	var slowErr error
+	go func() {
+		defer inflightWG.Done()
+		slowResp, slowErr = client.Get(base + "/slow")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow handler never started")
+	}
+
+	// Trigger graceful shutdown. With http2.ConfigureServer wired in
+	// NewHttp2CapableServer, this fires GOAWAY on the active h2c
+	// connection.
+	shutdownErr := make(chan error, 1)
+	go func() { shutdownErr <- srv.Shutdown(context.Background()) }()
+
+	// Give Shutdown a moment to fire OnShutdown handlers (which run
+	// in goroutines from inside http.Server.Shutdown) and for the
+	// GOAWAY frame to propagate to the client.
+	time.Sleep(200 * time.Millisecond)
+
+	// Issue a follow-up request. The client received GOAWAY on the
+	// pooled conn, so http2.Transport will refuse to open a new stream
+	// on it and try to dial a fresh conn instead. Dial must fail because
+	// Shutdown has closed our listener.
+	postShutdownReq, _ := http.NewRequest(http.MethodGet, base+"/quick", nil)
+	if resp, err := client.Do(postShutdownReq); err == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		t.Errorf("post-shutdown request unexpectedly succeeded with status %d; expected dial failure after GOAWAY", resp.StatusCode)
+	}
+
+	// Release the in-flight handler and verify the original request
+	// completes successfully — Shutdown should not have RST'd it.
+	close(finish)
+	inflightWG.Wait()
+
+	if slowErr != nil {
+		t.Fatalf("in-flight request failed during shutdown: %v", slowErr)
+	}
+	if slowResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected in-flight request to return 200, got %d", slowResp.StatusCode)
+	}
+	body, _ := io.ReadAll(slowResp.Body)
+	slowResp.Body.Close()
+	if string(body) != "ok" {
+		t.Fatalf("unexpected body: %q", body)
+	}
+
+	select {
+	case err := <-shutdownErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Shutdown returned: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not return")
+	}
+
+	// Drain the Serve goroutine.
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Serve returned: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return")
+	}
+}

--- a/std/go/grpc/servercore/sigterm.go
+++ b/std/go/grpc/servercore/sigterm.go
@@ -18,6 +18,29 @@ import (
 // How long do we expect it would take Kubernetes to notice that we're no longer ready.
 const readinessPropagationDelay = 15 * time.Second
 
+// runShutdownPhases runs the lameduck phase and then the drain phase. It is
+// extracted from handleGracefulShutdown so it can be unit-tested without
+// having to send a real signal to the process.
+func runShutdownPhases(lameducks map[string]func(), drainFunc func(), drainFuncs map[string]func()) {
+	// Lameduck phase: signal clients that we're going away (e.g. send
+	// HTTP/2 GOAWAY) before we start blocking on in-flight work. This
+	// gives clients a head start to migrate to other backends while the
+	// drain phase below waits for the requests we already have to
+	// complete.
+	for name, f := range lameducks {
+		core.ZLog.Info().Str("name", name).Msg("running lameduck func")
+		f()
+	}
+
+	if drainFunc != nil {
+		drainFunc()
+	}
+
+	for _, f := range drainFuncs {
+		f()
+	}
+}
+
 func handleGracefulShutdown(ctx context.Context, finishShutdown func()) {
 	sigint := make(chan os.Signal, 1)
 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
@@ -41,13 +64,7 @@ func handleGracefulShutdown(ctx context.Context, finishShutdown func()) {
 		t := time.Now()
 		core.MarkShutdownStarted()
 
-		if nsgrpc.DrainFunc != nil {
-			nsgrpc.DrainFunc()
-		}
-
-		for _, f := range nsgrpc.DrainFuncsByName {
-			f()
-		}
+		runShutdownPhases(nsgrpc.LameduckFuncsByName, nsgrpc.DrainFunc, nsgrpc.DrainFuncsByName)
 
 		delta := time.Since(t)
 		if delta < readinessPropagationDelay {

--- a/std/go/grpc/servercore/sigterm_test.go
+++ b/std/go/grpc/servercore/sigterm_test.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package servercore
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// TestRunShutdownPhases verifies that all lameduck functions run before any
+// drain function (so clients get the GOAWAY signal before drain phase blocks
+// on in-flight work) and that DrainFunc runs before DrainFuncsByName.
+func TestRunShutdownPhases(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		events []string
+	)
+	record := func(name string) func() {
+		return func() {
+			mu.Lock()
+			events = append(events, name)
+			mu.Unlock()
+		}
+	}
+
+	lameducks := map[string]func(){
+		"lame.a": record("lame.a"),
+		"lame.b": record("lame.b"),
+	}
+	drainFuncs := map[string]func(){
+		"drain.x": record("drain.x"),
+		"drain.y": record("drain.y"),
+	}
+	drainFunc := record("drain-singleton")
+
+	runShutdownPhases(lameducks, drainFunc, drainFuncs)
+
+	// Map iteration order is non-deterministic, so we only assert the
+	// phase boundaries: every "lame.*" event must come before every
+	// "drain*" event, and "drain-singleton" must come before all
+	// "drain.*" events.
+	lameDone := map[string]bool{}
+	drainSeen := false
+	singletonAt := -1
+	firstNamedDrainAt := -1
+	for i, ev := range events {
+		switch {
+		case ev == "drain-singleton":
+			singletonAt = i
+			drainSeen = true
+		case len(ev) >= 5 && ev[:5] == "lame.":
+			if drainSeen {
+				t.Errorf("lameduck %q ran after a drain func; events=%v", ev, events)
+			}
+			lameDone[ev] = true
+		case len(ev) >= 6 && ev[:6] == "drain.":
+			if !drainSeen {
+				t.Errorf("drain func %q ran before drain-singleton; events=%v", ev, events)
+			}
+			if firstNamedDrainAt == -1 {
+				firstNamedDrainAt = i
+			}
+			drainSeen = true
+		}
+	}
+
+	if singletonAt == -1 {
+		t.Errorf("drain-singleton never ran; events=%v", events)
+	}
+	if firstNamedDrainAt != -1 && singletonAt > firstNamedDrainAt {
+		t.Errorf("drain-singleton ran after named drain func; events=%v", events)
+	}
+
+	wantLameducks := []string{"lame.a", "lame.b"}
+	gotLameducks := make([]string, 0, len(lameDone))
+	for k := range lameDone {
+		gotLameducks = append(gotLameducks, k)
+	}
+	if !sameSet(gotLameducks, wantLameducks) {
+		t.Errorf("expected lameducks %v to all run, got %v; events=%v", wantLameducks, gotLameducks, events)
+	}
+}
+
+// TestRunShutdownPhases_NilDrainFunc verifies the function is robust to a
+// nil top-level drain func.
+func TestRunShutdownPhases_NilDrainFunc(t *testing.T) {
+	called := []string{}
+	runShutdownPhases(
+		map[string]func(){"l": func() { called = append(called, "l") }},
+		nil,
+		map[string]func(){"d": func() { called = append(called, "d") }},
+	)
+	if !reflect.DeepEqual(called, []string{"l", "d"}) {
+		t.Errorf("expected [l d], got %v", called)
+	}
+}
+
+func sameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := map[string]int{}
+	for _, s := range a {
+		m[s]++
+	}
+	for _, s := range b {
+		m[s]--
+	}
+	for _, c := range m {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- `NewHttp2CapableServer` now calls `http2.ConfigureServer` so h2c-hijacked connections register with the `http2.Server`'s internal state and `http.Server.Shutdown` actually fans out GOAWAY frames to them.
- New `LameduckFuncsByName` registry that runs after `MarkShutdownStarted` and before any drain func, used to signal clients we are going away (e.g. via GOAWAY) without waiting for in-flight work.
- `Listen` auto-registers a lameduck for the http server that calls `Shutdown` asynchronously, so SIGTERM immediately initiates the HTTP/2 graceful shutdown handshake while drain funcs continue to hold the process up.

## Validation

- `go build ./...`
- `go vet ./std/go/grpc/... ./std/go/core/...`