### PR TITLE
build: upgrade Go to 1.26.x

### DIFF
--- a/.github/workflows/check_fmt.yaml
+++ b/.github/workflows/check_fmt.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/check_license.yaml
+++ b/.github/workflows/check_license.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
       - name: Setup cross-invocation caching (Go)
         uses: namespacelabs/nscloud-cache-action@v1
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
       - name: Setup cross-invocation caching (Go)
         uses: namespacelabs/nscloud-cache-action@v1
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
 
       - name: Setup cross-invocation caching (Go)
@@ -274,7 +274,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
 
       - name: Setup cross-invocation caching (Go)

--- a/.github/workflows/publish-installers.yaml
+++ b/.github/workflows/publish-installers.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
 
       - name: Publish installer scripts to Tigris

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Check out code
         uses: actions/checkout@v6
       - name: Run go vet
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
 
       - name: Setup runner cache

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741853207,
-        "narHash": "sha256-bylUOjxTv8Hs4Dt77RAfYqCbjvZSFcUj5gghFdhX5b4=",
+        "lastModified": 1777850260,
+        "narHash": "sha256-JAUeVdfi74mIJMmX9Zb4KpIt2ciRuIgSfVLngdj6hFQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8b971f757f31f378e7983e35944f438cc34ea57",
+        "rev": "4e35ead9f1ef6d9a9a0062db07e92ec4f59ea892",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     in {
       devShell = pkgs.mkShell {
         buildInputs = with pkgs; [
-          go_1_24
+          go_1_26
           gopls
           go-outline
           go-tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module namespacelabs.dev/foundation
 
-go 1.25.0
+go 1.26.0
 
 require (
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.19.2-20260428103031-54a76bb6cfa2.1

--- a/internal/cli/cmd/sdk/sdk.go
+++ b/internal/cli/cmd/sdk/sdk.go
@@ -36,7 +36,7 @@ import (
 func NewSdkCmd(hidden bool) *cobra.Command {
 	sdks := []string{"go", "k3d", "kubectl", "grpcurl", "deno", "buildctl", "melange"}
 
-	goSdkVersion := "1.25"
+	goSdkVersion := "1.26"
 
 	cmd := &cobra.Command{
 		Use:    "sdk",

--- a/internal/dependencies/pins/pins.json
+++ b/internal/dependencies/pins/pins.json
@@ -1,5 +1,6 @@
 {
 	"images": {
+		"docker.io/library/golang:1.26.2": "b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716",
 		"docker.io/library/golang:1.24.12": "c2131140c7c29ff277b1c412d524b7f56289513f49672c57a3d992247dd146f8",
 		"docker.io/library/golang:1.25.6": "ce63a16e0f7063787ebb4eb28e72d477b00b4726f79874b3205a965ffd797ab2",
 		"docker.io/library/alpine:3.14": "e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",

--- a/internal/sdk/buf/image/versions.json
+++ b/internal/sdk/buf/image/versions.json
@@ -1,6 +1,6 @@
 {
 	"buf": {
-		"go": "docker.io/library/golang:1.25.6",
+		"go": "docker.io/library/golang:1.26.2",
 		"prebuilt": "us-docker.pkg.dev/foundation-344819/prebuilts/namespacelabs.dev/foundation/internal/sdk/buf/image/prebuilt@sha256:5a9f9711fcd93aa2cdb5d2ee2aaa1b2fdd23b7e139ff4a39438153668b9b84ef"
 	},
 	"goPackages": {

--- a/internal/sdk/golang/gosdk.json
+++ b/internal/sdk/golang/gosdk.json
@@ -1,9 +1,16 @@
 {
 	"versions": {
+		"1.26": "1.26.2",
 		"1.25": "1.25.6",
 		"1.24": "1.24.12"
 	},
 	"artifacts": {
+		"1.26.2": {
+			"linux/amd64": "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282",
+			"linux/arm64": "c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23",
+			"darwin/amd64": "bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966",
+			"darwin/arm64": "32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af"
+		},
 		"1.25.6": {
 			"linux/amd64": "f022b6aad78e362bcba9b0b94d09ad58c5a70c6ba3b7582905fababf5fe0181a",
 			"linux/arm64": "738ef87d79c34272424ccdf83302b7b0300b8b096ed443896089306117943dd5",

--- a/internal/versions/versions.json
+++ b/internal/versions/versions.json
@@ -1,5 +1,5 @@
 {
-	"api_version": 158,
+	"api_version": 159,
 	"minimum_api_version": 40,
 	"cache_version": 1
 }


### PR DESCRIPTION
## Summary
- upgrade the repo Go baseline to 1.26 and switch the default SDK selection to 1.26
- add Go 1.26.2 SDK checksums and pin `docker.io/library/golang:1.26.2` for shared SDK image usage
- update the Nix dev shell and lockfile so `go_1_26` is available locally
- bump the internal API version to `159`

## Testing
- `go run ./cmd/nsdev test`
- `go test ./...`
- `go test ./internal/sdk/golang ./internal/dependencies/pins ./internal/cli/cmd/sdk`
- `go test ./internal/sdk/buf/image`
- `nix develop .#devShell.x86_64-linux --command go version`

## Notes
- this change updates the buf SDK Go image pin but does not rebuild and repin the published buf prebuilt image digest
