### PR TITLE
Update `nsc instance report` to be more user-friendly:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	filippo.io/age v1.2.1
 	github.com/agext/levenshtein v1.2.3
 	github.com/andybalholm/brotli v1.0.4
+	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
+github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -970,6 +972,7 @@ github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGq
 github.com/sassoftware/relic v7.2.1+incompatible/go.mod h1:CWfAxv73/iLZ17rbyhIEq3K9hs5w6FpNMdUT//qR+zk=
 github.com/sassoftware/relic/v7 v7.6.2 h1:rS44Lbv9G9eXsukknS4mSjIAuuX+lMq/FnStgmZlUv4=
 github.com/sassoftware/relic/v7 v7.6.2/go.mod h1:kjmP0IBVkJZ6gXeAu35/KCEfca//+PKM6vTAsyDPY+k=
+github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0 h1:l+H5ErcW0PAehBNrBxoGv1jjNpGYdZ9RcheFkB2WI14=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0/go.mod h1:MRKONWmRoFzPNQ9USRF9i1mc7MvAVvF1LlW8X5VWDvk=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=

--- a/internal/cli/cmd/cluster/generatereport.go
+++ b/internal/cli/cmd/cluster/generatereport.go
@@ -7,6 +7,7 @@ package cluster
 import (
 	"context"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -14,9 +15,11 @@ import (
 
 	computev1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/compute/v1beta"
 	"buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/stdlib"
+	"github.com/araddon/dateparse"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/integrations/api/compute"
 	"namespacelabs.dev/integrations/auth"
@@ -29,8 +32,9 @@ func NewGenerateReportCmd() *cobra.Command {
 		Args:  cobra.NoArgs, // for now
 	}
 
-	start := cmd.Flags().String("start", "", "Start time of the report (RFC3339, e.g. 2024-01-15T10:30:00Z).")
-	end := cmd.Flags().String("end", "", "End time of the report, defaults to now (RFC3339, e.g. 2024-01-15T10:30:00Z).")
+	start := cmd.Flags().String("start", "", "Start time of the report.")
+	end := cmd.Flags().String("end", "", "End time of the report, defaults to now if not provided.")
+	outPath := cmd.Flags().String("out", "", "Output file path. Creates a temporary file in /tmp if not provided. Use '-' for stdout.")
 
 	// Args for filtering. We allow multiple strings per filter type. Each matcher can have
 	// either <matcher>Args or <matcher>ExcArgs nonempty, depending on if the filter should
@@ -73,10 +77,10 @@ func NewGenerateReportCmd() *cobra.Command {
 
 	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
 		if *start == "" {
-			return fnerrors.Newf("--start is required")
+			return fnerrors.New("--start is required. Example:\n    nsc instance report --start \"2026-01-01\" --end \"2026-01-02\"")
 		}
 
-		startTs, err := time.Parse(time.RFC3339, *start)
+		startTs, err := dateparse.ParseAny(*start)
 		if err != nil {
 			return fnerrors.Newf("invalid --start timestamp: %w", err)
 		}
@@ -85,11 +89,35 @@ func NewGenerateReportCmd() *cobra.Command {
 		if *end == "" {
 			endTs = time.Now()
 		} else {
-			endTs, err = time.Parse(time.RFC3339, *end)
+			endTs, err = dateparse.ParseAny(*end)
 			if err != nil {
 				return fnerrors.Newf("invalid --end timestamp: %w", err)
 			}
 		}
+
+		var outFile *os.File
+		var outName string
+		switch *outPath {
+		case "-":
+			outFile = os.Stdout
+			outName = "stdout"
+		case "":
+			tmp, err := os.CreateTemp("", "nsc-report-*")
+			if err != nil {
+				return fnerrors.Newf("Failed to create temp file: %w", err)
+			}
+			outFile = tmp
+			outName = tmp.Name()
+		default:
+			file, err := os.Create(*outPath)
+			if err != nil {
+				return fnerrors.Newf("Failed to create output file %s: %w", *outPath, err)
+			}
+			outFile = file
+			outName = *outPath
+		}
+
+		fmt.Fprintf(console.Stdout(ctx), "Writing output to path: %s\n", outName)
 
 		filter := &computev1beta.GetUsageTimeSeriesRequest_UsageFilter{}
 
@@ -157,7 +185,7 @@ func NewGenerateReportCmd() *cobra.Command {
 			return fnerrors.Newf("Unable to generate report: %w", err)
 		}
 
-		csvWriter := csv.NewWriter(os.Stdout)
+		csvWriter := csv.NewWriter(outFile)
 
 		header := []string{
 			"instance_id",


### PR DESCRIPTION
- date parsing is much more flexible, using the `dateparse` package
- output is written to a temporary file instead of stdout by default; --output flag allows for a custom output path
- example usage is given if `--start` flag is missing