### PR TITLE
cluster: support workload mTLS bazel cache setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.19.2-20260504084716-a20f6e68b60f.1
 	buf.build/gen/go/namespace/cloud/grpc/go v1.6.1-20260504084716-a20f6e68b60f.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260504084716-a20f6e68b60f.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260511001724-817e83dbee30.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.19.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/namespace/cloud/connectrpc/go v1.19.2-20260504084716-a20f6e68b6
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.19.2-20260504084716-a20f6e68b60f.1/go.mod h1:ttyEpPtz4KJJTrVXDVeubF0IAkCEc+rvjLSbCOEhdEk=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.1-20260504084716-a20f6e68b60f.1 h1:OZhpMPMYcxK+0Nyec/qzWpg3HXmXIxZ67H/GAsldbCc=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.1-20260504084716-a20f6e68b60f.1/go.mod h1:LzZSaX1GB2x74wpBwMG6XKptHg3Lq1gx8xhcf81thLI=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260504084716-a20f6e68b60f.1 h1:IAbnduHG5gB/Vl/OuVqPEvn6yGMRXT2Jf7roBb8Ve50=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260504084716-a20f6e68b60f.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260511001724-817e83dbee30.1 h1:VJX7T+w3R0+qeYIdAcaI8PUEuf5HiyqeNMnTc993oTg=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260511001724-817e83dbee30.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/cli/cmd/auth/clientcert.go
+++ b/internal/cli/cmd/auth/clientcert.go
@@ -1,0 +1,132 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/fnapi"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+)
+
+func NewIssueClientCertCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "issue-client-cert",
+		Short: "Issue a client certificate for the current Namespace authentication token.",
+		Args:  cobra.NoArgs,
+	}
+
+	publicKeyPath := cmd.Flags().String("public_key_file", "", "If specified, use this PEM-encoded public key instead of generating one.")
+	outputPrivateKeyPath := cmd.Flags().String("output_private_key_file", "", "If specified, write the generated private key PEM to this path.")
+	outputPublicKeyPath := cmd.Flags().String("output_public_key_file", "", "If specified, write the generated public key PEM to this path.")
+
+	return fncobra.Cmd(cmd).Do(func(ctx context.Context) error {
+		var privateKeyPem []byte
+
+		publicKeyPem, privateKeyPem, err := loadOrCreatePublicKey(*publicKeyPath)
+		if err != nil {
+			return err
+		}
+
+		if *publicKeyPath != "" && *outputPrivateKeyPath != "" {
+			return fnerrors.Newf("--output_private_key_file cannot be used with --public_key_file")
+		}
+
+		if err := writePemFile(*outputPrivateKeyPath, privateKeyPem, 0600); err != nil {
+			return err
+		}
+
+		if err := writePemFile(*outputPublicKeyPath, publicKeyPem, 0644); err != nil {
+			return err
+		}
+
+		tok, err := fnapi.FetchToken(ctx)
+		if err != nil {
+			return err
+		}
+
+		clientCertPem, err := fnapi.IssueTenantClientCertFromToken(ctx, tok, string(publicKeyPem))
+		if err != nil {
+			return err
+		}
+
+		if *publicKeyPath == "" && *outputPrivateKeyPath == "" && *outputPublicKeyPath == "" {
+			fmt.Fprint(console.Stdout(ctx), string(privateKeyPem))
+			if !strings.HasSuffix(string(privateKeyPem), "\n") {
+				fmt.Fprintln(console.Stdout(ctx))
+			}
+		}
+
+		fmt.Fprint(console.Stdout(ctx), clientCertPem)
+		if !strings.HasSuffix(clientCertPem, "\n") {
+			fmt.Fprintln(console.Stdout(ctx))
+		}
+
+		return nil
+	})
+}
+
+func loadOrCreatePublicKey(path string) ([]byte, []byte, error) {
+	if path != "" {
+		publicKeyPem, err := os.ReadFile(path)
+		if err != nil {
+			return nil, nil, fnerrors.Newf("failed to read %q: %w", path, err)
+		}
+
+		return publicKeyPem, nil, nil
+	}
+
+	privateKeyPem, publicKeyPem, err := generateClientKeyPair()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return publicKeyPem, privateKeyPem, nil
+}
+
+func writePemFile(path string, contents []byte, mode os.FileMode) error {
+	if path == "" {
+		return nil
+	}
+
+	if err := os.WriteFile(path, contents, mode); err != nil {
+		return fnerrors.Newf("failed to write %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func generateClientKeyPair() ([]byte, []byte, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fnerrors.Newf("failed to generate private key: %w", err)
+	}
+
+	publicKeyDer, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, nil, fnerrors.Newf("failed to marshal public key: %w", err)
+	}
+
+	privateKeyDer, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fnerrors.Newf("failed to marshal private key: %w", err)
+	}
+
+	privateKeyPem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyDer})
+	publicKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyDer})
+
+	return privateKeyPem, publicKeyPem, nil
+}

--- a/internal/cli/cmd/auth/cmd.go
+++ b/internal/cli/cmd/auth/cmd.go
@@ -27,6 +27,7 @@ func NewAuthCmd() *cobra.Command {
 	cmd.AddCommand(newExchangeAwsCognitoCmd())
 	cmd.AddCommand(newTrustAwsCognitoCmd())
 	cmd.AddCommand(NewIssueIdTokenCmd())
+	cmd.AddCommand(NewIssueClientCertCmd())
 	cmd.AddCommand(NewExchangeOIDCTokenCmd())
 	cmd.AddCommand(NewGenerateDevTokenCmd())
 	cmd.AddCommand(NewGenerateTokenCmd())

--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -7,7 +7,9 @@ package cluster
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"os"
@@ -60,7 +62,8 @@ const defaultBazelCommand = "build"
 
 func newSetupCacheCmd() *cobra.Command {
 	var bazelRcPath, output, certPath, bazelCommand string
-	var sendBuildEvents, useAbsoluteCredHelperPath, static bool
+	var experimentalCacheName string
+	var sendBuildEvents, useAbsoluteCredHelperPath, static, experimentalDirect bool
 	var version int64
 	var staticDur time.Duration
 
@@ -74,6 +77,8 @@ func newSetupCacheCmd() *cobra.Command {
 		flags.BoolVar(&sendBuildEvents, "send_build_events", false, "If specified, send build events to the build event service.")
 		flags.BoolVar(&useAbsoluteCredHelperPath, "use_absolute_credentialhelper_path", false, "If specified, use an absolute path to the credential helper binary.")
 		flags.BoolVar(&static, "static", false, "If specified, use a static bearer token in --remote_header instead of a credential helper.")
+		flags.BoolVar(&experimentalDirect, "experimental_direct", false, "If specified, configure Bazel to connect directly to the cache endpoint with a freshly issued client certificate.")
+		flags.StringVar(&experimentalCacheName, "experimental_cache_name", "", "If specified, request a named experimental Bazel cache backing instance.")
 		flags.Int64Var(&version, "version", 1, "Which bazel version to use.")
 		fncobra.DurationVar(flags, &staticDur, "static_token_duration", 4*time.Hour, "The minimum duration of the static token configured (requires --static).")
 		flags.StringVar(&bazelCommand, "command", defaultBazelCommand, "The bazel command to use in the generated bazelrc (e.g., 'build' or 'common').")
@@ -88,9 +93,17 @@ func newSetupCacheCmd() *cobra.Command {
 			return err
 		}
 
-		req := connect.NewRequest(&bazelv1beta.EnsureBazelCacheRequest{
-			Version: version,
-		})
+		if experimentalDirect && static {
+			return fnerrors.Newf("--experimental_direct may not be used with --static")
+		}
+
+		if experimentalDirect && sendBuildEvents {
+			return fnerrors.Newf("--experimental_direct may not be used with --send_build_events")
+		}
+
+		msg := makeEnsureBazelCacheRequest(version, experimentalDirect, experimentalCacheName)
+
+		req := connect.NewRequest(msg)
 
 		resp, err := client.EnsureBazelCache(ctx, req)
 		if err != nil {
@@ -100,6 +113,15 @@ func newSetupCacheCmd() *cobra.Command {
 		response := resp.Msg
 		if response.GetCacheEndpoint() == "" {
 			return fnerrors.Newf("did not receive a valid cache endpoint")
+		}
+
+		useWorkloadMtls := response.GetUseWorkloadMtls()
+		if useWorkloadMtls && static {
+			return fnerrors.Newf("server requires workload mTLS; --static may not be used")
+		}
+
+		if useWorkloadMtls && sendBuildEvents {
+			return fnerrors.Newf("server requires workload mTLS; --send_build_events may not be used")
 		}
 
 		if certPath != "" {
@@ -114,12 +136,9 @@ func newSetupCacheCmd() *cobra.Command {
 			expiresAt = &t
 		}
 
-		out := bazelSetup{
-			Endpoint:  response.GetCacheEndpoint(),
-			ExpiresAt: expiresAt,
-		}
+		out := baseBazelSetup(response, expiresAt)
 
-		if len(response.GetServerCaPem()) > 0 {
+		if !useWorkloadMtls && len(response.GetServerCaPem()) > 0 {
 			if certPath == "" {
 				loc, err := writeTempFile(bazelCachePathBase, "*.cert", []byte(response.GetServerCaPem()))
 				if err != nil {
@@ -136,7 +155,52 @@ func newSetupCacheCmd() *cobra.Command {
 			}
 		}
 
-		if len(response.GetClientCertPem()) > 0 {
+		if useWorkloadMtls {
+			privateKeyPem, publicKeyPem, err := genPrivAndPublicKeysPEM()
+			if err != nil {
+				return fnerrors.Newf("failed to generate client key pair: %w", err)
+			}
+
+			privateKeyPem, err = convertECPrivateKeyToPKCS8(privateKeyPem)
+			if err != nil {
+				return fnerrors.Newf("failed to encode client key in PKCS#8: %w", err)
+			}
+
+			clientCertPem, err := fetchClientCert(ctx, string(publicKeyPem))
+			if err != nil {
+				return fnerrors.Newf("failed to issue client certificate: %w", err)
+			}
+
+			if certPath == "" {
+				loc, err := writeTempFile(bazelCachePathBase, "*.cert", []byte(clientCertPem))
+				if err != nil {
+					return fnerrors.Newf("failed to create temp file: %w", err)
+				}
+
+				out.ClientCert = loc
+			} else {
+				out.ClientCert = filepath.Join(certPath, "client.cert")
+
+				if err := writeFile(out.ClientCert, []byte(clientCertPem)); err != nil {
+					return err
+				}
+			}
+
+			if certPath == "" {
+				loc, err := writeTempFile(bazelCachePathBase, "*.key", privateKeyPem)
+				if err != nil {
+					return fnerrors.Newf("failed to create temp file: %w", err)
+				}
+
+				out.ClientKey = loc
+			} else {
+				out.ClientKey = filepath.Join(certPath, "client.key")
+
+				if err := writeFile(out.ClientKey, privateKeyPem); err != nil {
+					return err
+				}
+			}
+		} else if len(response.GetClientCertPem()) > 0 {
 			if certPath == "" {
 				loc, err := writeTempFile(bazelCachePathBase, "*.cert", []byte(response.GetClientCertPem()))
 				if err != nil {
@@ -153,7 +217,7 @@ func newSetupCacheCmd() *cobra.Command {
 			}
 		}
 
-		if len(response.GetClientKeyPem()) > 0 {
+		if !useWorkloadMtls && len(response.GetClientKeyPem()) > 0 {
 			if certPath == "" {
 				loc, err := writeTempFile(bazelCachePathBase, "*.key", []byte(response.GetClientKeyPem()))
 				if err != nil {
@@ -167,14 +231,6 @@ func newSetupCacheCmd() *cobra.Command {
 				if err := writeFile(out.ClientKey, []byte(response.GetClientKeyPem())); err != nil {
 					return err
 				}
-			}
-		}
-
-		if len(response.GetCredentialHelperDomains()) > 0 {
-			out = bazelSetup{
-				Endpoint:                response.GetHttpsCacheEndpoint(),
-				ExpiresAt:               expiresAt,
-				CredentialHelperDomains: response.GetCredentialHelperDomains(),
 			}
 		}
 
@@ -259,6 +315,51 @@ func newSetupCacheCmd() *cobra.Command {
 
 		return nil
 	})
+}
+
+func makeEnsureBazelCacheRequest(version int64, experimentalDirect bool, experimentalCacheName string) *bazelv1beta.EnsureBazelCacheRequest {
+	msg := &bazelv1beta.EnsureBazelCacheRequest{}
+	msg.SetVersion(version)
+	msg.SetExperimentalDirectMtls(experimentalDirect)
+	msg.SetExperimentalCacheName(experimentalCacheName)
+
+	return msg
+}
+
+func baseBazelSetup(response *bazelv1beta.EnsureBazelCacheResponse, expiresAt *time.Time) bazelSetup {
+	out := bazelSetup{
+		Endpoint:  response.GetCacheEndpoint(),
+		ExpiresAt: expiresAt,
+	}
+
+	if len(response.GetCredentialHelperDomains()) > 0 && !response.GetUseWorkloadMtls() {
+		out = bazelSetup{
+			Endpoint:                response.GetHttpsCacheEndpoint(),
+			ExpiresAt:               expiresAt,
+			CredentialHelperDomains: response.GetCredentialHelperDomains(),
+		}
+	}
+
+	return out
+}
+
+func convertECPrivateKeyToPKCS8(privateKeyPem []byte) ([]byte, error) {
+	block, _ := pem.Decode(privateKeyPem)
+	if block == nil {
+		return nil, fnerrors.New("failed to decode private key PEM")
+	}
+
+	privateKey, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes}), nil
 }
 
 func writeTempFile(base, pattern string, content []byte) (string, error) {

--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -1,0 +1,124 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
+)
+
+func TestBaseBazelSetup(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now()
+	response := &bazelv1beta.EnsureBazelCacheResponse{
+		CacheEndpoint:           "grpcs://cache.example:444",
+		HttpsCacheEndpoint:      "grpcs://ingress.example:443",
+		CredentialHelperDomains: []string{"api.example.com"},
+	}
+
+	t.Run("uses credential helper config by default", func(t *testing.T) {
+		t.Parallel()
+
+		out := baseBazelSetup(response, &expiresAt)
+		if out.Endpoint != response.GetHttpsCacheEndpoint() {
+			t.Fatalf("unexpected endpoint: %q", out.Endpoint)
+		}
+		if len(out.CredentialHelperDomains) != 1 || out.CredentialHelperDomains[0] != "api.example.com" {
+			t.Fatalf("unexpected credential helper domains: %v", out.CredentialHelperDomains)
+		}
+	})
+
+	t.Run("uses direct cache endpoint when response requires workload mtls", func(t *testing.T) {
+		t.Parallel()
+
+		response := &bazelv1beta.EnsureBazelCacheResponse{
+			CacheEndpoint:           response.GetCacheEndpoint(),
+			HttpsCacheEndpoint:      response.GetHttpsCacheEndpoint(),
+			CredentialHelperDomains: append([]string(nil), response.GetCredentialHelperDomains()...),
+		}
+		response.SetUseWorkloadMtls(true)
+
+		out := baseBazelSetup(response, &expiresAt)
+		if out.Endpoint != response.GetCacheEndpoint() {
+			t.Fatalf("unexpected endpoint: %q", out.Endpoint)
+		}
+		if len(out.CredentialHelperDomains) != 0 {
+			t.Fatalf("unexpected credential helper domains: %v", out.CredentialHelperDomains)
+		}
+	})
+}
+
+func TestMakeEnsureBazelCacheRequest(t *testing.T) {
+	t.Parallel()
+
+	msg := makeEnsureBazelCacheRequest(7, true, "amp-test")
+
+	if got := msg.GetVersion(); got != 7 {
+		t.Fatalf("unexpected version: %d", got)
+	}
+	if !msg.GetExperimentalDirectMtls() {
+		t.Fatal("expected experimental_direct_mtls to be set")
+	}
+	if got := msg.GetExperimentalCacheName(); got != "amp-test" {
+		t.Fatalf("unexpected experimental cache name: %q", got)
+	}
+}
+
+func TestToBazelConfigExperimentalDirect(t *testing.T) {
+	t.Parallel()
+
+	config, err := toBazelConfig(context.Background(), bazelSetup{
+		Endpoint:     "grpcs://cache.example:444",
+		ServerCaCert: "/tmp/server_ca.cert",
+		ClientCert:   "/tmp/client.cert",
+		ClientKey:    "/tmp/client.key",
+	}, false, "build")
+	if err != nil {
+		t.Fatalf("toBazelConfig: %v", err)
+	}
+
+	got := string(config)
+	for _, want := range []string{
+		"build --remote_cache=grpcs://cache.example:444\n",
+		"build --tls_certificate=/tmp/server_ca.cert\n",
+		"build --tls_client_certificate=/tmp/client.cert\n",
+		"build --tls_client_key=/tmp/client.key\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing config line %q in %q", want, got)
+		}
+	}
+
+	if strings.Contains(got, "credential_helper") {
+		t.Fatalf("unexpected credential helper config: %q", got)
+	}
+}
+
+func TestConvertECPrivateKeyToPKCS8(t *testing.T) {
+	t.Parallel()
+
+	privateKeyPem, _, err := genPrivAndPublicKeysPEM()
+	if err != nil {
+		t.Fatalf("genPrivAndPublicKeysPEM: %v", err)
+	}
+
+	converted, err := convertECPrivateKeyToPKCS8(privateKeyPem)
+	if err != nil {
+		t.Fatalf("convertECPrivateKeyToPKCS8: %v", err)
+	}
+
+	got := string(converted)
+	if !strings.Contains(got, "BEGIN PRIVATE KEY") {
+		t.Fatalf("expected PKCS#8 private key, got %q", got)
+	}
+	if strings.Contains(got, "BEGIN EC PRIVATE KEY") {
+		t.Fatalf("unexpected EC private key format: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add `--experimental_direct` and `--experimental_cache_name` to `nsc bazel cache setup`
- update direct Bazel cache setup to follow `EnsureBazelCacheResponse.use_workload_mtls` and generate a workload client certificate when requested
- write direct-mode Bazel config with `--remote_cache` pointing at `cacheEndpoint` and no credential helpers

## Validation

- `go test ./internal/cli/cmd/cluster`
- `NSC_TOKEN_FILE=/var/run/nsc/token.json go run ./cmd/nsc bazel cache setup --experimental_direct --experimental_cache_name amp-direct-2 --bazelrc /tmp/amp-bazel-real/cache.bazelrc --cred_path /tmp/amp-bazel-real/creds --output json`
- `/tmp/amp-bin/bazelisk --bazelrc=/tmp/amp-bazel-real/cache.bazelrc build //:skycfg`
