### PR TITLE
Use intstr.Parse for update_strategy max_surge/max_unavailable

### DIFF
--- a/internal/runtime/kubernetes/deployment.go
+++ b/internal/runtime/kubernetes/deployment.go
@@ -976,11 +976,11 @@ func prepareDeployment(ctx context.Context, target BoundNamespace, deployable ru
 				rol := appsv1.RollingUpdateDeployment()
 
 				if us.MaxSurge != "" {
-					rol = rol.WithMaxSurge(intstr.FromString(us.MaxSurge))
+					rol = rol.WithMaxSurge(intstr.Parse(us.MaxSurge))
 				}
 
 				if us.MaxUnavailable != "" {
-					rol = rol.WithMaxUnavailable(intstr.FromString(us.MaxUnavailable))
+					rol = rol.WithMaxUnavailable(intstr.Parse(us.MaxUnavailable))
 				}
 
 				strategy = appsv1.DeploymentStrategy().WithRollingUpdate(rol)
@@ -1042,11 +1042,11 @@ func prepareDeployment(ctx context.Context, target BoundNamespace, deployable ru
 				rol := appsv1.RollingUpdateDaemonSet()
 
 				if us.MaxSurge != "" {
-					rol = rol.WithMaxSurge(intstr.FromString(us.MaxSurge))
+					rol = rol.WithMaxSurge(intstr.Parse(us.MaxSurge))
 				}
 
 				if us.MaxUnavailable != "" {
-					rol = rol.WithMaxUnavailable(intstr.FromString(us.MaxUnavailable))
+					rol = rol.WithMaxUnavailable(intstr.Parse(us.MaxUnavailable))
 				}
 
 				updateStrategy = appsv1.DaemonSetUpdateStrategy().WithRollingUpdate(rol)

--- a/internal/versions/versions.json
+++ b/internal/versions/versions.json
@@ -1,5 +1,5 @@
 {
-	"api_version": 159,
+	"api_version": 160,
 	"minimum_api_version": 40,
 	"cache_version": 1
 }


### PR DESCRIPTION
## Summary

- Switches `max_surge` and `max_unavailable` parsing from `intstr.FromString` to `intstr.Parse` in stateless Deployment and DaemonSet rolling update configs.
- Allows integer values (e.g. `"0"`, `"1"`) in addition to percentage strings (e.g. `"25%"`). Previously plain integer strings failed at apply time with: `a valid percent string must be a numeric string followed by an ending '%'`.
- Bumps `api_version` to 160.

## Validation

- `go build ./internal/runtime/kubernetes/...`