### PR TITLE
npm: use Node 24 for publishing

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - name: Set version from tag


### PR DESCRIPTION
## Summary
Update the npm publishing workflow to run on Node 24.

## Motivation
The current tag publish job uses Node 22, which includes npm 10. Current npm trusted publishing/OIDC flows require npm 11.5.1+, causing scoped package publishes to fail with a misleading 404.

## Key features
- Runs the npm publish workflow on Node 24 so it uses an npm version compatible with trusted publishing and provenance.