### PR TITLE
cuefrontend: load startup env secret packages

### DIFF
--- a/internal/frontend/cuefrontend/frontend.go
+++ b/internal/frontend/cuefrontend/frontend.go
@@ -142,7 +142,7 @@ func (ft impl) ParsePackage(ctx context.Context, loc pkggraph.Location) (*pkggra
 		return nil, fnerrors.Newf("package must only define one of: server, service, extension, binary or test")
 	}
 
-	p := phase1plan{owner: loc, partial: partial, Value: v, Left: partial.Left}
+	p := phase1plan{owner: loc, partial: partial, loader: ft.loader, Value: v, Left: partial.Left}
 	plan, err := p.EvalProvision(ctx, ft.env, pkggraph.ProvisionInputs{ServerLocation: loc})
 	if err != nil {
 		return nil, err

--- a/internal/frontend/cuefrontend/phase1.go
+++ b/internal/frontend/cuefrontend/phase1.go
@@ -13,6 +13,7 @@ import (
 	"namespacelabs.dev/foundation/internal/frontend/cuefrontend/args"
 	"namespacelabs.dev/foundation/internal/frontend/cuefrontend/binary"
 	"namespacelabs.dev/foundation/internal/frontend/fncue"
+	"namespacelabs.dev/foundation/internal/parsing/invariants"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/pkggraph"
 )
@@ -20,6 +21,7 @@ import (
 type phase1plan struct {
 	owner   pkggraph.Location
 	partial *fncue.Partial
+	loader  pkggraph.PackageLoader
 
 	Value *fncue.CueV
 	Left  []fncue.KeyAndPath // injected values left to be filled.
@@ -60,6 +62,14 @@ func (p1 phase1plan) EvalProvision(ctx context.Context, env *schema.Environment,
 	var pdata evalProvisionResult
 
 	pdata.Startup = phase2plan{owner: p1.owner, partial: p1.partial, Value: vv, Left: left}
+
+	if startup := lookupTransition(vv, "startup"); startup.Exists() {
+		if env := startup.LookupPath("env"); env.Exists() {
+			if err := ensureStartupEnvSecretPackagesLoaded(ctx, p1.loader, p1.owner, env.Val); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if stackVal := lookupTransition(vv, "stack"); stackVal.Exists() {
 		var stack cueStack
@@ -116,6 +126,41 @@ func (p1 phase1plan) EvalProvision(ctx context.Context, env *schema.Environment,
 	}
 
 	return &pdata, nil
+}
+
+func ensureStartupEnvSecretPackagesLoaded(ctx context.Context, pl pkggraph.PackageLoader, loc pkggraph.Location, env cue.Value) error {
+	var err error
+	env.Walk(func(v cue.Value) bool {
+		if err != nil {
+			return false
+		}
+
+		secret := v.LookupPath(cue.ParsePath("fromSecret"))
+		if !secret.Exists() {
+			return true
+		}
+
+		var ref string
+		ref, err = secret.String()
+		if err != nil {
+			err = fnerrors.NewWithLocation(loc, "startup.env.fromSecret: %w", err)
+			return false
+		}
+
+		var secretRef *schema.PackageRef
+		secretRef, err = schema.ParsePackageRef(loc, ref)
+		if err != nil {
+			return false
+		}
+
+		if err = invariants.EnsurePackageLoaded(ctx, pl, loc, secretRef); err != nil {
+			return false
+		}
+
+		return true
+	}, nil)
+
+	return err
 }
 
 func parseContainers(loc pkggraph.Location, kind string, v cue.Value) ([]*schema.Container, error) {

--- a/internal/frontend/cuefrontend/phase1_test.go
+++ b/internal/frontend/cuefrontend/phase1_test.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cuefrontend
+
+import (
+	"context"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/pkggraph"
+)
+
+func TestEnsureStartupEnvSecretPackagesLoaded(t *testing.T) {
+	ctx := context.Background()
+	loc := pkggraph.Location{PackageName: "example.com/current/service"}
+	v := cuecontext.New().CompileString(`{
+	STATIC: "value"
+	LOCAL: fromSecret: ":local"
+	REMOTE: fromSecret: "example.com/shared/secrets:password"
+}`)
+	if err := v.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	loader := &recordingPackageLoader{}
+	if err := ensureStartupEnvSecretPackagesLoaded(ctx, loader, loc, v); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(loader.ensured) != 1 || loader.ensured[0] != "example.com/shared/secrets" {
+		t.Fatalf("expected only remote secret package to be ensured, got %v", loader.ensured)
+	}
+}
+
+type recordingPackageLoader struct {
+	ensured []schema.PackageName
+}
+
+func (r *recordingPackageLoader) Resolve(context.Context, schema.PackageName) (pkggraph.Location, error) {
+	panic("unexpected Resolve")
+}
+
+func (r *recordingPackageLoader) LoadByName(context.Context, schema.PackageName) (*pkggraph.Package, error) {
+	panic("unexpected LoadByName")
+}
+
+func (r *recordingPackageLoader) Ensure(_ context.Context, packageName schema.PackageName) error {
+	r.ensured = append(r.ensured, packageName)
+	return nil
+}

--- a/internal/frontend/cuefrontend/phase2.go
+++ b/internal/frontend/cuefrontend/phase2.go
@@ -61,7 +61,7 @@ func (s phase2plan) EvalStartup(ctx context.Context, env pkggraph.Context, info 
 			return nil, err
 		}
 
-		envVar, err := raw.Env.Parsed(ctx, nil, s.owner)
+		envVar, err := raw.Env.Parsed(ctx, env, s.owner)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- Loads packages referenced by old CUE `configure.startup.env` `fromSecret` values during phase1, before the package graph is sealed.
- Passes the package loader through phase2 startup env parsing so startup env refs are validated consistently.
- Adds a focused test for startup env secret package loading.

## Validation

- `go test ./internal/frontend/cuefrontend -count=1`
- `go run ./cmd/nsdev test --explain tmp/startupenv-secret-test/test` with a temporary old-CUE test package that referenced a secret from another package in `configure.startup.env`
