### PR TITLE
nsc: note that registry policy set only affects new images

### DIFF
--- a/internal/cli/cmd/cluster/registry.go
+++ b/internal/cli/cmd/cluster/registry.go
@@ -913,6 +913,7 @@ func setPolicy(ctx context.Context, repository string, expiration time.Duration,
 		} else {
 			fmt.Fprintf(stdout, "Repository %q has been updated to expire images after %s.\n", repository, newExpiry.AsDuration().String())
 		}
+		fmt.Fprintln(stdout, "\nNote: this only applies to images pushed after this change; existing images keep their current expiration.")
 
 		return nil
 	}
@@ -936,6 +937,7 @@ func setPolicy(ctx context.Context, repository string, expiration time.Duration,
 	} else {
 		fmt.Fprintf(stdout, "Default configuration has been updated to expire images after %s.\n", newExpiry.AsDuration().String())
 	}
+	fmt.Fprintln(stdout, "\nNote: this only applies to images pushed after this change; existing images keep their current expiration.")
 
 	return nil
 }


### PR DESCRIPTION
`nsc registry policy set` only changes the expiration applied to newly pushed images; existing images keep their current expiration. This was previously documented but not surfaced in the command output, which was confusing.

The success message now includes a note clarifying that the change only applies to images pushed afterwards.