### PR TITLE
nsc: note image and tag expirations are separate in update-image-expiration

### DIFF
--- a/internal/cli/cmd/cluster/registry.go
+++ b/internal/cli/cmd/cluster/registry.go
@@ -711,6 +711,7 @@ Alternatively, use --repository and --digest flags.`,
 			}
 			fmt.Fprintln(stdout)
 			fmt.Fprintf(stdout, "Image expiry updated successfully.\n")
+			fmt.Fprintln(stdout, "\nNote: image and tag expirations are tracked separately. This updated the image (manifest); any tags pointing to it keep their own expiration.")
 			return nil
 
 		default:


### PR DESCRIPTION
`nsc registry update-image-expiration` updates the expiration of the image (manifest) it resolves to. Image and tag expirations are tracked separately, so a tag pointing to the image keeps its own expiration and is unaffected.

The command output now prints a short note clarifying this, to avoid the expectation that updating an image also changes the expiration of its tags.