### PR TITLE
Replace Docker Engine module imports with Moby

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/docker/buildx v0.32.1
 	github.com/docker/cli v29.2.1+incompatible
-	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
@@ -79,6 +78,8 @@ require (
 	github.com/miekg/dns v1.1.57
 	github.com/minio/minio-go/v7 v7.0.47
 	github.com/moby/buildkit v0.28.1
+	github.com/moby/moby/api v1.53.0
+	github.com/moby/moby/client v0.2.2
 	github.com/moby/patternmatcher v0.6.1
 	github.com/morikuni/aec v1.1.0
 	github.com/muesli/cancelreader v0.2.2
@@ -221,6 +222,7 @@ require (
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
+	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
@@ -319,8 +321,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/moby/api v1.53.0 // indirect
-	github.com/moby/moby/client v0.2.2 // indirect
 	github.com/moby/policy-helpers v0.0.0-20260211190020-824747bfdd3c // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect

--- a/internal/build/binary/genbinary/llbgen.go
+++ b/internal/build/binary/genbinary/llbgen.go
@@ -36,7 +36,8 @@ type llbBinary struct {
 }
 
 func (l llbBinary) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
-	hostPlatform := docker.HostPlatform()
+	hostPlatform := platform.RuntimePlatform()
+	hostPlatform.OS = "linux"
 
 	bin, err := l.bin.BuildImage(ctx, env, build.NewBuildTarget(&hostPlatform).WithWorkspace(l.module))
 	if err != nil {

--- a/internal/build/buildkit/client.go
+++ b/internal/build/buildkit/client.go
@@ -23,8 +23,8 @@ import (
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
+	nsplatform "namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/internal/providers/nscloud/api"
-	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/internal/runtime/kubernetes"
 	"namespacelabs.dev/foundation/internal/workspace/dirs"
 	"namespacelabs.dev/foundation/schema"
@@ -232,7 +232,9 @@ func buildRemotely(conf cfg.Configuration, platform *specs.Platform) bool {
 	}
 
 	target := formatPlatformOrDefault(platform)
-	host := platforms.Format(docker.HostPlatform())
+	hostPlatform := nsplatform.RuntimePlatform()
+	hostPlatform.OS = "linux"
+	host := platforms.Format(hostPlatform)
 
 	if BuildOnNamespaceCloudUnlessHost.Get(conf) && target != host {
 		return true
@@ -246,7 +248,9 @@ func formatPlatformOrDefault(p *specs.Platform) string {
 		return platforms.Format(*p)
 	}
 
-	return platforms.Format(docker.HostPlatform())
+	hostPlatform := nsplatform.RuntimePlatform()
+	hostPlatform.OS = "linux"
+	return platforms.Format(hostPlatform)
 }
 
 func parsePlatformOrDefault(p *specs.Platform) (api.BuildPlatform, error) {
@@ -254,7 +258,9 @@ func parsePlatformOrDefault(p *specs.Platform) (api.BuildPlatform, error) {
 		return api.ParseBuildPlatform(p.Architecture)
 	}
 
-	return api.ParseBuildPlatform(docker.HostPlatform().Architecture)
+	hostPlatform := nsplatform.RuntimePlatform()
+	hostPlatform.OS = "linux"
+	return api.ParseBuildPlatform(hostPlatform.Architecture)
 }
 
 func useRemoteCluster(ctx context.Context, cluster *api.KubernetesCluster, port int) (*GatewayClient, error) {

--- a/internal/build/buildkit/daemon.go
+++ b/internal/build/buildkit/daemon.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/client"
+	"github.com/containerd/errdefs"
 	buildkit "github.com/moby/buildkit/client"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/client"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/runtime/docker"
@@ -58,7 +58,7 @@ func RemoveBuildkitd(ctx context.Context) error {
 	// Ignore if the container is already removed.
 	ctr, err := dockerclient.ContainerInspect(ctx, DefaultContainerName)
 	if err != nil {
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return nil
 		} else {
 			return err
@@ -66,7 +66,7 @@ func RemoveBuildkitd(ctx context.Context) error {
 	}
 
 	// Remove container
-	opts := container.RemoveOptions{Force: true}
+	opts := client.ContainerRemoveOptions{Force: true}
 	if err := dockerclient.ContainerRemove(ctx, ctr.Name, opts); err != nil {
 		return fnerrors.InternalError("failed to remove the buildkitd container: %w", err)
 	}

--- a/internal/cli/cmd/buildbinary.go
+++ b/internal/cli/cmd/buildbinary.go
@@ -29,6 +29,7 @@ import (
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/parsing"
+	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/cfg"
@@ -124,7 +125,9 @@ func buildLocations(ctx context.Context, env cfg.Context, reg registry.Manager, 
 
 	var imgOpts binary.BuildImageOpts
 	imgOpts.UsePrebuilts = false
-	imgOpts.Platforms = []specs.Platform{docker.HostPlatform()}
+	hostPlatform := platform.RuntimePlatform()
+	hostPlatform.OS = "linux"
+	imgOpts.Platforms = []specs.Platform{hostPlatform}
 
 	var images []compute.Computable[Binary]
 	for _, pkg := range pkgs {

--- a/internal/cli/cmd/cluster/build.go
+++ b/internal/cli/cmd/cluster/build.go
@@ -44,7 +44,6 @@ import (
 	"namespacelabs.dev/foundation/internal/localexec"
 	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/internal/providers/nscloud/api"
-	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/std/tasks"
 	"namespacelabs.dev/go-ids"
 )
@@ -118,7 +117,9 @@ func NewBuildCmd() *cobra.Command {
 
 		if len(*platforms) == 0 {
 			if *dockerLoad {
-				*platforms = []string{platform.FormatPlatform(docker.HostPlatform())}
+				hostPlatform := platform.RuntimePlatform()
+				hostPlatform.OS = "linux"
+				*platforms = []string{platform.FormatPlatform(hostPlatform)}
 			} else {
 				*platforms = []string{"linux/amd64"}
 			}

--- a/internal/cli/cmd/cluster/expose.go
+++ b/internal/cli/cmd/cluster/expose.go
@@ -17,10 +17,10 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/errdefs"
 	gocni "github.com/containerd/go-cni"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -322,63 +322,64 @@ func selectDockerPorts(ctx context.Context, cluster *api.KubernetesCluster, filt
 	return buildContainersPortMap(ctx, data...)
 }
 
-func dockerFilterToContainers(ctx context.Context, docker *client.Client, filter containerFilter) ([]types.ContainerJSON, error) {
+func dockerFilterToContainers(ctx context.Context, docker *client.Client, filter containerFilter) ([]container.InspectResponse, error) {
 	if filter.all {
-		list, err := docker.ContainerList(ctx, container.ListOptions{})
+		list, err := docker.ContainerList(ctx, client.ContainerListOptions{})
 		if err != nil {
 			return nil, err
 		}
 
-		actual := make([]types.ContainerJSON, len(list))
-		for k, l := range list {
-			res, err := docker.ContainerInspect(ctx, l.ID)
+		actual := make([]container.InspectResponse, len(list.Items))
+		for k, l := range list.Items {
+			res, err := docker.ContainerInspect(ctx, l.ID, client.ContainerInspectOptions{})
 			if err != nil {
 				return nil, err
 			}
-			actual[k] = res
+			actual[k] = res.Container
 		}
 
 		return actual, nil
 	}
 
-	data, err := docker.ContainerInspect(ctx, filter.containerName)
+	data, err := docker.ContainerInspect(ctx, filter.containerName, client.ContainerInspectOptions{})
 	if err != nil {
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return nil, nil
 		}
 
 		return nil, err
 	}
 
-	return []types.ContainerJSON{data}, nil
+	return []container.InspectResponse{data.Container}, nil
 }
 
-func buildContainersPortMap(ctx context.Context, data ...types.ContainerJSON) ([]containerPort, error) {
+func buildContainersPortMap(ctx context.Context, data ...container.InspectResponse) ([]containerPort, error) {
 	exported := portMap{}
 	for _, data := range data {
 		internalName := parseContainerName(data.Name)
 
 		for port, mapping := range data.NetworkSettings.Ports {
+			portNum := port.Num()
 			if port.Proto() == "tcp" {
 				for _, m := range mapping {
-					if m.HostIP == "0.0.0.0" || m.HostIP == "::" {
+					if m.HostIP.IsUnspecified() {
 						parsedPort, err := strconv.ParseInt(m.HostPort, 10, 32)
 						if err != nil {
 							return nil, err
 						}
 
-						exported[port.Int()] = containerPort{
+						exported[int(portNum)] = containerPort{
 							ContainerID:   data.ID,
 							ContainerName: internalName,
-							ContainerPort: int32(port.Int()),
+							ContainerPort: int32(portNum),
 							ExportedPort:  int32(parsedPort),
 						}
 					} else {
-						fmt.Fprintf(console.Warnings(ctx), "%s: Skipping %d/%s exported to %s (unsupported)\n", data.Name, port.Int(), port.Proto(), m.HostIP)
+						fmt.Fprintf(console.Warnings(ctx), "%s: Skipping %d/%s exported to %s (unsupported)\n", data.Name, portNum, port.Proto(), m.HostIP)
 					}
 				}
 			} else {
-				fmt.Fprintf(console.Warnings(ctx), "%s: Skipping unsupported protocol %q, port %d\n", data.Name, port.Proto(), port.Int())
+				fmt.Fprintf(console.Warnings(ctx), "%s: Skipping unsupported protocol %q, port %d\n", data.Name, port.Proto(), portNum)
 			}
 		}
 	}

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -12,10 +12,9 @@ import (
 	"strings"
 	"time"
 
-	dockertypes "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/system"
 	"github.com/kr/text"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/moby/api/types/system"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 	"namespacelabs.dev/go-ids"
@@ -36,6 +35,7 @@ import (
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/parsing"
+	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/internal/runtime"
 	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/internal/runtime/kubernetes"
@@ -61,7 +61,7 @@ type DoctorResults struct {
 }
 
 type DoctorResults_DockerInfo struct {
-	dockertypes.Version
+	docker.ServerVersion
 	system.Info
 }
 
@@ -142,17 +142,17 @@ func NewDoctorCmd() *cobra.Command {
 			printDiagnostic(ctx, "Docker", dockerI, &errCount, func(w io.Writer, info DoctorResults_DockerInfo) {
 				info.ID = "" // Clear IDs.
 				results.DockerInfo = &info
-				fmt.Fprintf(w, "version=%s (commit=%s) for %s-%s\n", info.Version.Version, info.Version.GitCommit, info.Version.Os, info.Version.Arch)
-				fmt.Fprintf(w, "api version=%s (min=%s)\n", info.Version.APIVersion, info.Version.MinAPIVersion)
-				fmt.Fprintf(w, "kernel version=%s\n", info.Version.KernelVersion)
+				fmt.Fprintf(w, "version=%s (commit=%s) for %s-%s\n", info.ServerVersion.Version, info.ServerVersion.GitCommit, info.ServerVersion.Os, info.ServerVersion.Arch)
+				fmt.Fprintf(w, "api version=%s (min=%s)\n", info.ServerVersion.APIVersion, info.ServerVersion.MinAPIVersion)
+				fmt.Fprintf(w, "kernel version=%s\n", info.ServerVersion.KernelVersion)
 				fmt.Fprintf(w, "ncpu=%d mem_total=%d\n", info.Info.NCPU, info.Info.MemTotal)
 				fmt.Fprintf(w, "containers total=%d running=%d paused=%d stopped=%d images=%d\n", info.Info.Containers, info.Info.ContainersRunning,
 					info.Info.ContainersPaused, info.Info.ContainersStopped, info.Info.Images)
 				fmt.Fprintf(w, "driver=%s logging_driver=%s cgroup_driver=%s cgroup_version=%s\n", info.Info.Driver, info.Info.LoggingDriver,
 					info.Info.CgroupDriver, info.Info.CgroupVersion)
-				fmt.Fprintf(w, "containerd expected=%s present=%s\n", info.Info.ContainerdCommit.Expected, info.Info.ContainerdCommit.ID)
-				fmt.Fprintf(w, "runc expected=%s present=%s\n", info.Info.RuncCommit.Expected, info.Info.RuncCommit.ID)
-				fmt.Fprintf(w, "init expected=%s present=%s\n", info.Info.InitCommit.Expected, info.Info.InitCommit.ID)
+				fmt.Fprintf(w, "containerd present=%s\n", info.Info.ContainerdCommit.ID)
+				fmt.Fprintf(w, "runc present=%s\n", info.Info.RuncCommit.ID)
+				fmt.Fprintf(w, "init present=%s\n", info.Info.InitCommit.ID)
 				if len(info.Info.Warnings) > 0 {
 					fmt.Fprintln(w, "Warnings:")
 					for _, wn := range info.Info.Warnings {
@@ -174,7 +174,10 @@ func NewDoctorCmd() *cobra.Command {
 		if filterIncludes(testFilter, "docker-run") {
 			dockerRunI := runDiagnostic(ctx, "doctor.docker-run", func(ctx context.Context) (DoctorResults_DockerRun, error) {
 				t := time.Now()
-				image, err := compute.GetValue(ctx, oci.ResolveImage(pins.Image("hello-world"), docker.HostPlatform()).Image())
+				hostPlatform := platform.RuntimePlatform()
+				hostPlatform.OS = "linux"
+
+				image, err := compute.GetValue(ctx, oci.ResolveImage(pins.Image("hello-world"), hostPlatform).Image())
 				if err != nil {
 					return DoctorResults_DockerRun{}, err
 				}
@@ -212,7 +215,8 @@ func NewDoctorCmd() *cobra.Command {
 						if err != nil {
 							return DoctorResults_BuildkitResults{}, err
 						}
-						hostPlatform := docker.HostPlatform()
+						hostPlatform := platform.RuntimePlatform()
+						hostPlatform.OS = "linux"
 						state := llb.Scratch().File(llb.Mkfile("/hello", 0644, []byte("cachehit")))
 						conf := build.NewBuildTarget(&hostPlatform).WithSourceLabel("doctor.hello-world")
 						var r DoctorResults_BuildkitResults

--- a/internal/cli/cmd/images.go
+++ b/internal/cli/cmd/images.go
@@ -32,7 +32,7 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/fnfs"
 	"namespacelabs.dev/foundation/internal/parsing"
-	"namespacelabs.dev/foundation/internal/runtime/docker"
+	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/cfg"
 	"namespacelabs.dev/foundation/std/pkggraph"
@@ -258,9 +258,10 @@ func resolveImage(ctx context.Context, image string, env cfg.Context, pl *parsin
 		image = strings.TrimPrefix(image, "insecure:")
 	}
 
-	platform := docker.HostPlatform()
+	hostPlatform := platform.RuntimePlatform()
+	hostPlatform.OS = "linux"
 
-	return compute.GetValue(ctx, oci.ImageP(image, &platform, oci.RegistryAccess{InsecureRegistry: insecure}))
+	return compute.GetValue(ctx, oci.ImageP(image, &hostPlatform, oci.RegistryAccess{InsecureRegistry: insecure}))
 }
 
 func matchAny(files []string, path string) bool {

--- a/internal/prepare/k3d.go
+++ b/internal/prepare/k3d.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"namespacelabs.dev/foundation/framework/rpcerrors/multierr"
 	"namespacelabs.dev/foundation/internal/build/registry"
 	"namespacelabs.dev/foundation/internal/fnerrors"
@@ -126,7 +126,7 @@ type k3dPrepare struct {
 func (p *k3dPrepare) createOrRestartRegistry(ctx context.Context, registryName string) (string, error) {
 	registryCtr, err := p.dockerclient.ContainerInspect(ctx, registryName)
 	if err != nil {
-		if !client.IsErrNotFound(err) {
+		if !errdefs.IsNotFound(err) {
 			return "", err
 		}
 
@@ -141,7 +141,7 @@ func (p *k3dPrepare) createOrRestartRegistry(ctx context.Context, registryName s
 	}
 
 	if !registryCtr.State.Running {
-		if err := p.dockerclient.ContainerStart(ctx, registryName, container.StartOptions{}); err != nil {
+		if err := p.dockerclient.ContainerStart(ctx, registryName, client.ContainerStartOptions{}); err != nil {
 			return "", fnerrors.InternalError("failed to restart registry %q: %w", registryName, err)
 		}
 
@@ -203,10 +203,15 @@ func (p *k3dPrepare) createOrRestartCluster(ctx context.Context, clusterName str
 	return nil
 }
 
-func findPort(ctr types.ContainerJSON, port string) []nat.PortBinding {
+func findPort(ctr container.InspectResponse, port string) []network.PortBinding {
 	if ctr.NetworkSettings == nil {
 		return nil
 	}
 
-	return ctr.NetworkSettings.Ports[nat.Port(port)]
+	parsed, err := network.ParsePort(port)
+	if err != nil {
+		return nil
+	}
+
+	return ctr.NetworkSettings.Ports[parsed]
 }

--- a/internal/providers/k3d/k3dregistry.go
+++ b/internal/providers/k3d/k3dregistry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/moby/moby/api/types/network"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/artifacts/registry"
 	"namespacelabs.dev/foundation/internal/build/buildkit"
@@ -55,14 +56,19 @@ func Register() {
 				return nil, fnerrors.InternalError("missing network configuration in k3d registry container")
 			}
 
-			if len(inspected.NetworkSettings.Ports["5000/tcp"]) == 0 {
+			registryPort, err := network.ParsePort("5000/tcp")
+			if err != nil {
+				return nil, err
+			}
+
+			if len(inspected.NetworkSettings.Ports[registryPort]) == 0 {
 				return nil, fnerrors.InternalError("missing port configuration in k3d registry container")
 			}
 
 			return &k3dRegistry{
 				ContainerName:      conf.RegistryContainerName,
-				PublicPort:         inspected.NetworkSettings.Ports["5000/tcp"][0].HostPort,
-				ContainerIPAddress: inspected.NetworkSettings.Networks["bridge"].IPAddress,
+				PublicPort:         inspected.NetworkSettings.Ports[registryPort][0].HostPort,
+				ContainerIPAddress: inspected.NetworkSettings.Networks["bridge"].IPAddress.String(),
 			}, nil
 		})
 	})

--- a/internal/runtime/docker/client.go
+++ b/internal/runtime/docker/client.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -18,13 +19,12 @@ import (
 
 	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/connhelper"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/system"
-	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/system"
+	"github.com/moby/moby/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 )
@@ -32,20 +32,35 @@ import (
 // Client implements the Docker client, but only with the bits that Namespace requires.
 // It also performs Namespace-specific error handling
 type Client interface {
-	ServerVersion(ctx context.Context) (types.Version, error)
+	ServerVersion(ctx context.Context) (ServerVersion, error)
 	Info(ctx context.Context) (system.Info, error)
-	ContainerCreate(context.Context, *container.Config, *container.HostConfig, *network.NetworkingConfig, *specs.Platform, string) (container.CreateResponse, error)
-	ContainerAttach(ctx context.Context, container string, options container.AttachOptions) (types.HijackedResponse, error)
-	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
-	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
-	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
+	ContainerCreate(context.Context, *container.Config, *container.HostConfig, *network.NetworkingConfig, *specs.Platform, string) (client.ContainerCreateResult, error)
+	ContainerAttach(ctx context.Context, container string, options client.ContainerAttachOptions) (client.HijackedResponse, error)
+	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
+	ContainerStart(ctx context.Context, containerID string, options client.ContainerStartOptions) error
+	ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) error
 	ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
-	ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
-	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (image.LoadResponse, error)
+	ImageInspectWithRaw(ctx context.Context, imageID string) (image.InspectResponse, []byte, error)
+	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, source, target string) error
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	ClientVersion() string
 	Close() error
+}
+
+type ServerVersion struct {
+	Platform      client.PlatformInfo       `json:",omitempty"`
+	Version       string                    `json:",omitempty"`
+	APIVersion    string                    `json:",omitempty"`
+	MinAPIVersion string                    `json:",omitempty"`
+	GitCommit     string                    `json:",omitempty"`
+	GoVersion     string                    `json:",omitempty"`
+	Os            string                    `json:",omitempty"`
+	Arch          string                    `json:",omitempty"`
+	KernelVersion string                    `json:",omitempty"`
+	Experimental  bool                      `json:",omitempty"`
+	BuildTime     string                    `json:",omitempty"`
+	Components    []system.ComponentVersion `json:",omitempty"`
 }
 
 func clientConfiguration() *Configuration {
@@ -135,60 +150,82 @@ type wrappedClient struct {
 	cli *client.Client
 }
 
-func (w wrappedClient) ServerVersion(ctx context.Context) (types.Version, error) {
-	v, err := w.cli.ServerVersion(ctx)
-	return v, maybeReplaceErr(err)
+func (w wrappedClient) ServerVersion(ctx context.Context) (ServerVersion, error) {
+	v, err := w.cli.ServerVersion(ctx, client.ServerVersionOptions{})
+	converted := ServerVersion{
+		Platform:      v.Platform,
+		Version:       v.Version,
+		APIVersion:    v.APIVersion,
+		MinAPIVersion: v.MinAPIVersion,
+		Os:            v.Os,
+		Arch:          v.Arch,
+		Experimental:  v.Experimental,
+		Components:    v.Components,
+	}
+	return converted, maybeReplaceErr(err)
 }
 
 func (w wrappedClient) Info(ctx context.Context) (system.Info, error) {
-	v, err := w.cli.Info(ctx)
+	v, err := w.cli.Info(ctx, client.InfoOptions{})
+	return v.Info, maybeReplaceErr(err)
+}
+
+func (w wrappedClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (client.ContainerCreateResult, error) {
+	v, err := w.cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config:           config,
+		HostConfig:       hostConfig,
+		NetworkingConfig: networkingConfig,
+		Platform:         platform,
+		Name:             containerName,
+	})
 	return v, maybeReplaceErr(err)
 }
 
-func (w wrappedClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.CreateResponse, error) {
-	v, err := w.cli.ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, containerName)
-	return v, maybeReplaceErr(err)
-}
-
-func (w wrappedClient) ContainerAttach(ctx context.Context, container string, options container.AttachOptions) (types.HijackedResponse, error) {
+func (w wrappedClient) ContainerAttach(ctx context.Context, container string, options client.ContainerAttachOptions) (client.HijackedResponse, error) {
 	v, err := w.cli.ContainerAttach(ctx, container, options)
-	return v, maybeReplaceErr(err)
+	return v.HijackedResponse, maybeReplaceErr(err)
 }
 
-func (w wrappedClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
-	v, err := w.cli.ContainerInspect(ctx, containerID)
-	return v, maybeReplaceErr(err)
+func (w wrappedClient) ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error) {
+	v, err := w.cli.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	return v.Container, maybeReplaceErr(err)
 }
 
-func (w wrappedClient) ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error {
-	return maybeReplaceErr(w.cli.ContainerStart(ctx, containerID, options))
+func (w wrappedClient) ContainerStart(ctx context.Context, containerID string, options client.ContainerStartOptions) error {
+	_, err := w.cli.ContainerStart(ctx, containerID, options)
+	return maybeReplaceErr(err)
 }
 
-func (w wrappedClient) ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error {
-	return maybeReplaceErr(w.cli.ContainerRemove(ctx, containerID, options))
+func (w wrappedClient) ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) error {
+	_, err := w.cli.ContainerRemove(ctx, containerID, options)
+	return maybeReplaceErr(err)
 }
 
 func (w wrappedClient) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error) {
 	// XXX we assume wrapping errors is not necessary here as ContainerWait is not used in isolation.
-	return w.cli.ContainerWait(ctx, containerID, condition)
+	res := w.cli.ContainerWait(ctx, containerID, client.ContainerWaitOptions{Condition: condition})
+	return res.Result, res.Error
 }
 
-func (w wrappedClient) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
-	i, b, err := w.cli.ImageInspectWithRaw(ctx, imageID)
-	return i, b, maybeReplaceErr(err)
+func (w wrappedClient) ImageInspectWithRaw(ctx context.Context, imageID string) (image.InspectResponse, []byte, error) {
+	var raw bytes.Buffer
+	i, err := w.cli.ImageInspect(ctx, imageID, client.ImageInspectWithRawResponse(&raw))
+	return i.InspectResponse, raw.Bytes(), maybeReplaceErr(err)
 }
 
-func (w wrappedClient) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (image.LoadResponse, error) {
+func (w wrappedClient) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (io.ReadCloser, error) {
 	v, err := w.cli.ImageLoad(ctx, input, client.ImageLoadWithQuiet(quiet))
 	return v, maybeReplaceErr(err)
 }
 
 func (w wrappedClient) ImageTag(ctx context.Context, source, target string) error {
-	return maybeReplaceErr(w.cli.ImageTag(ctx, source, target))
+	_, err := w.cli.ImageTag(ctx, client.ImageTagOptions{Source: source, Target: target})
+	return maybeReplaceErr(err)
 }
 
 func (w wrappedClient) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
-	return maybeReplaceErr(w.cli.VolumeRemove(ctx, volumeID, force))
+	_, err := w.cli.VolumeRemove(ctx, volumeID, client.VolumeRemoveOptions{Force: force})
+	return maybeReplaceErr(err)
 }
 
 func (w wrappedClient) ClientVersion() string {

--- a/internal/runtime/docker/imageload.go
+++ b/internal/runtime/docker/imageload.go
@@ -82,8 +82,8 @@ func writeImage(ctx context.Context, client Client, tag name.Tag, img v1.Image) 
 	if err != nil {
 		return "", fnerrors.InvocationError("docker", "failed to load image: %w", err)
 	}
-	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
+	defer resp.Close()
+	b, err := io.ReadAll(resp)
 	response := string(b)
 	if err != nil {
 		return response, fnerrors.InvocationError("docker", "error reading load response body: %w", err)

--- a/internal/runtime/docker/install/persistent.go
+++ b/internal/runtime/docker/install/persistent.go
@@ -8,15 +8,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/netip"
+	"strconv"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
+	"github.com/containerd/errdefs"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/compute"
 	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/std/tasks"
 )
@@ -74,7 +77,7 @@ func (p PersistentSpec) Ensure(ctx context.Context, progress io.Writer) error {
 func (p PersistentSpec) start(ctx context.Context, cli docker.Client) error {
 	fmt.Fprintf(console.Debug(ctx), "Starting %s version %s\n", p.Name, p.Version)
 
-	if err := cli.ContainerStart(ctx, p.ContainerName, container.StartOptions{}); err != nil {
+	if err := cli.ContainerStart(ctx, p.ContainerName, client.ContainerStartOptions{}); err != nil {
 		return err
 	}
 
@@ -90,7 +93,10 @@ func (p PersistentSpec) install(ctx context.Context, cli docker.Client, progress
 	imageID.Repository = p.Image
 	imageID.Tag = p.Version
 
-	image, err := compute.GetValue(ctx, oci.ResolveImage(imageID.ImageRef(), docker.HostPlatform()).Image())
+	hostPlatform := platform.RuntimePlatform()
+	hostPlatform.OS = "linux"
+
+	image, err := compute.GetValue(ctx, oci.ResolveImage(imageID.ImageRef(), hostPlatform).Image())
 	if err != nil {
 		return err
 	}
@@ -114,17 +120,18 @@ func (p PersistentSpec) install(ctx context.Context, cli docker.Client, progress
 		Privileged:    p.Privileged,
 	}
 
-	host.PortBindings = map[nat.Port][]nat.PortBinding{}
+	host.PortBindings = network.PortMap{}
 
 	for hostPort, containerPort := range p.Ports {
-		parsed, err := nat.ParsePortSpec(fmt.Sprintf("127.0.0.1:%d:%d", hostPort, containerPort))
-		if err != nil {
-			return err
+		port, ok := network.PortFrom(uint16(containerPort), network.TCP)
+		if !ok {
+			return fmt.Errorf("invalid container port %d", containerPort)
 		}
 
-		for _, p := range parsed {
-			host.PortBindings[p.Port] = append(host.PortBindings[p.Port], p.Binding)
-		}
+		host.PortBindings[port] = append(host.PortBindings[port], network.PortBinding{
+			HostIP:   netip.MustParseAddr("127.0.0.1"),
+			HostPort: strconv.Itoa(hostPort),
+		})
 	}
 
 	for name, target := range p.Volumes {
@@ -135,7 +142,7 @@ func (p PersistentSpec) install(ctx context.Context, cli docker.Client, progress
 		host.NetworkMode = container.NetworkMode("host")
 	}
 
-	created, err := tasks.Return(ctx, tasks.Action("docker.container.create").Arg("name", p.ContainerName), func(ctx context.Context) (container.CreateResponse, error) {
+	created, err := tasks.Return(ctx, tasks.Action("docker.container.create").Arg("name", p.ContainerName), func(ctx context.Context) (client.ContainerCreateResult, error) {
 		return cli.ContainerCreate(ctx, config, host, &network.NetworkingConfig{}, nil, p.ContainerName)
 	})
 	if err != nil {
@@ -143,7 +150,7 @@ func (p PersistentSpec) install(ctx context.Context, cli docker.Client, progress
 	}
 
 	if err := tasks.Action("docker.container.start").Arg("name", p.ContainerName).Arg("id", created.ID).Run(ctx, func(ctx context.Context) error {
-		return cli.ContainerStart(ctx, created.ID, container.StartOptions{})
+		return cli.ContainerStart(ctx, created.ID, client.ContainerStartOptions{})
 	}); err != nil {
 		return err
 	}
@@ -156,8 +163,8 @@ func (p PersistentSpec) install(ctx context.Context, cli docker.Client, progress
 }
 
 func (p PersistentSpec) remove(ctx context.Context, cli docker.Client) error {
-	err := cli.ContainerRemove(ctx, p.ContainerName, container.RemoveOptions{RemoveVolumes: true, Force: true})
-	if client.IsErrNotFound(err) {
+	err := cli.ContainerRemove(ctx, p.ContainerName, client.ContainerRemoveOptions{RemoveVolumes: true, Force: true})
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	return err
@@ -166,7 +173,7 @@ func (p PersistentSpec) remove(ctx context.Context, cli docker.Client) error {
 func (p PersistentSpec) running(ctx context.Context, cli docker.Client) (*PersistentInformation, error) {
 	res, err := cli.ContainerInspect(ctx, p.ContainerName)
 	if err != nil {
-		if client.IsErrNotFound(err) {
+		if errdefs.IsNotFound(err) {
 			return &PersistentInformation{Installed: false}, nil
 		}
 

--- a/internal/runtime/docker/invoke.go
+++ b/internal/runtime/docker/invoke.go
@@ -11,15 +11,15 @@ import (
 	"io"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"strings"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/strslice"
-	"github.com/docker/docker/client"
-	dockernames "github.com/docker/docker/daemon/names"
-	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/strslice"
+	"github.com/moby/moby/client"
 	"github.com/muesli/cancelreader"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"namespacelabs.dev/foundation/framework/rpcerrors/multierr"
@@ -31,6 +31,8 @@ import (
 	"namespacelabs.dev/foundation/std/tasks"
 	"namespacelabs.dev/go-ids"
 )
+
+var restrictedDockerNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
 
 type ToolRuntime struct{}
 
@@ -63,14 +65,10 @@ func (r ToolRuntime) RunWithOpts(ctx context.Context, opts rtypes.RunToolOpts, o
 		})
 }
 
-func HostPlatform() specs.Platform {
+func (r ToolRuntime) HostPlatform(context.Context) (specs.Platform, error) {
 	p := platform.RuntimePlatform()
 	p.OS = "linux" // We always run on linux.
-	return p
-}
-
-func (r ToolRuntime) HostPlatform(context.Context) (specs.Platform, error) {
-	return HostPlatform(), nil
+	return p, nil
 }
 
 func runImpl(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) error {
@@ -194,7 +192,7 @@ func runImpl(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) error
 		label := strings.Join(opts.Command, "-")
 		label = strings.ReplaceAll(label, "/", "")
 
-		if dockernames.RestrictedNamePattern.MatchString(label) {
+		if restrictedDockerNamePattern.MatchString(label) {
 			// generate unique ID to avoid collisions
 			id := ids.NewRandomBase32ID(6)
 
@@ -213,19 +211,19 @@ func runImpl(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) error
 		created.ID, containerConfig.Image, containerConfig.Cmd)
 
 	compute.On(ctx).Cleanup(tasks.Action("docker.container.remove"), func(ctx context.Context) error {
-		if err := cli.ContainerRemove(ctx, created.ID, container.RemoveOptions{}); err != nil {
+		if err := cli.ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{}); err != nil {
 			// If the docker daemon is already removing the container, because
 			// e.g. it has returned from execution, then we may observe a
 			// conflict with `removal of container XYZ is already in progress`.
 			// We ignore that error here.
-			if !client.IsErrNotFound(err) && !errdefs.IsConflict(err) {
+			if !errdefs.IsNotFound(err) && !errdefs.IsConflict(err) {
 				return fnerrors.Newf("failed to remove container: %w", err)
 			}
 		}
 		return nil
 	})
 
-	resp, err := cli.ContainerAttach(ctx, created.ID, container.AttachOptions{
+	resp, err := cli.ContainerAttach(ctx, created.ID, client.ContainerAttachOptions{
 		Stream: true,
 		Stdin:  containerConfig.AttachStdin,
 		Stdout: containerConfig.AttachStdout,
@@ -235,7 +233,7 @@ func runImpl(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) error
 		return fnerrors.Newf("failed to attach to container: %w", err)
 	}
 
-	if err := cli.ContainerStart(ctx, created.ID, container.StartOptions{}); err != nil {
+	if err := cli.ContainerStart(ctx, created.ID, client.ContainerStartOptions{}); err != nil {
 		return fnerrors.Newf("failed to start container: %w", err)
 	}
 
@@ -317,7 +315,7 @@ func runImpl(ctx context.Context, opts rtypes.RunToolOpts, onStart func()) error
 			// code 0, we should still not return an error.
 			return fnerrors.ExitWithCode(fmt.Errorf("docker: container exit code %d", result.StatusCode), int(result.StatusCode))
 		case err := <-errs:
-			if client.IsErrNotFound(err) {
+			if errdefs.IsNotFound(err) {
 				// We schedule containers with AutoRemove so they might disappear before we get a chance to wait for them.
 				return nil
 			}

--- a/internal/runtime/docker/publish.go
+++ b/internal/runtime/docker/publish.go
@@ -10,6 +10,7 @@ import (
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/compute"
 	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/std/tasks"
 )
 
@@ -42,7 +43,10 @@ func (pi *publishImage) Compute(ctx context.Context, deps compute.Resolved) (oci
 
 	tasks.Attachments(ctx).AddResult("repository", tag.Repository)
 
-	img, err := resolvable.ImageForPlatform(HostPlatform())
+	hostPlatform := platform.RuntimePlatform()
+	hostPlatform.OS = "linux"
+
+	img, err := resolvable.ImageForPlatform(hostPlatform)
 	if err != nil {
 		return oci.ImageID{}, fnerrors.InternalError("docker: %w", err)
 	}

--- a/internal/sdk/gcloud/gcloud.go
+++ b/internal/sdk/gcloud/gcloud.go
@@ -19,6 +19,7 @@ import (
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/localexec"
+	"namespacelabs.dev/foundation/internal/parsing/platform"
 	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/internal/runtime/rtypes"
 	"namespacelabs.dev/foundation/internal/workspace/dirs"
@@ -48,7 +49,8 @@ func Run(ctx context.Context, io rtypes.IO, args ...string) error {
 		return fnerrors.InternalError("failed to create %q: %w", gcloudDir, err)
 	}
 
-	hostPlatform := docker.HostPlatform()
+	hostPlatform := platform.RuntimePlatform()
+	hostPlatform.OS = "linux"
 
 	const imageName = "gcr.io/google.com/cloudsdktool/google-cloud-cli:412.0.0-alpine"
 	imageRef := oci.ImageP(imageName, &hostPlatform, oci.RegistryAccess{PublicImage: true})

--- a/internal/sdk/k3d/k3d.go
+++ b/internal/sdk/k3d/k3d.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/api/types"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/mod/semver"
 	"namespacelabs.dev/foundation/internal/artifacts"
@@ -156,7 +155,7 @@ func ValidateDocker(ctx context.Context, cli docker.Client) error {
 	return nil
 }
 
-func validateVersions(ver types.Version) (bool, bool, string) {
+func validateVersions(ver docker.ServerVersion) (bool, bool, string) {
 	dockerOK := semver.Compare("v"+ver.Version, "v"+minimumDockerVer) >= 0
 	runcOK := false
 

--- a/internal/sdk/k3d/version_test.go
+++ b/internal/sdk/k3d/version_test.go
@@ -8,17 +8,18 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/moby/moby/api/types/system"
+	"namespacelabs.dev/foundation/internal/runtime/docker"
 )
 
 func TestDockerVersionParsing(t *testing.T) {
 	for _, test := range []struct {
-		ver types.Version
+		ver docker.ServerVersion
 		ok  bool
 	}{
-		{ver: types.Version{Version: "20.10.13"}, ok: false},
-		{ver: types.Version{Version: "20.10.13", Components: []types.ComponentVersion{{Name: "runc", Version: "1.0.3"}}}, ok: true},
-		{ver: types.Version{Version: "20.10.5+dfsg1", Components: []types.ComponentVersion{{Name: "runc", Version: "1.0.0~rc93+ds1"}}}, ok: true},
+		{ver: docker.ServerVersion{Version: "20.10.13"}, ok: false},
+		{ver: docker.ServerVersion{Version: "20.10.13", Components: []system.ComponentVersion{{Name: "runc", Version: "1.0.3"}}}, ok: true},
+		{ver: docker.ServerVersion{Version: "20.10.5+dfsg1", Components: []system.ComponentVersion{{Name: "runc", Version: "1.0.0~rc93+ds1"}}}, ok: true},
 	} {
 		dockerOK, runcOK, _ := validateVersions(test.ver)
 		if (dockerOK && runcOK) != test.ok {


### PR DESCRIPTION
## Summary
- replace first-party `github.com/docker/docker` Engine API/client imports with `github.com/moby/moby/api` and `github.com/moby/moby/client`
- adapt our Docker wrapper and call sites to Moby's newer option/result APIs and typed port maps
- inline the trivial Linux host platform behavior at call sites instead of depending on `docker.HostPlatform`

## Notes
- There are no first-party Go imports of `github.com/docker/docker` after this change.
- `github.com/docker/docker` remains in `go.mod` as an indirect dependency because upstream dependencies still reference it (for example go-containerregistry's daemon package and Docker buildx).

## Test plan
- `go test ./internal/cli/cmd ./cmd/nsc ./internal/cli/cmd/cluster ./internal/runtime/docker ./internal/runtime/docker/install ./internal/build/buildkit ./internal/sdk/k3d ./internal/prepare ./internal/providers/k3d`
- `go test ./internal/sdk/gcloud ./internal/build/binary/genbinary`
