### PR TITLE
nsc/cluster: add branch and conclusion to instance report CSV

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260610154328-540a8ce9853d.1
 	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260610154328-540a8ce9853d.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260610154328-540a8ce9853d.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260623071207-0391158f5cec.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260610154328-540a8ce985
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260610154328-540a8ce9853d.1/go.mod h1:hvHz7jMtG0TUy5XmDQcxhXNhMElaj0SU5TOSpx5HFyQ=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260610154328-540a8ce9853d.1 h1:Nxs0ekOZSf4+yzTT0+KO9dFAmmHiPvf8N/7TruOB+WI=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260610154328-540a8ce9853d.1/go.mod h1:S5jbhx/UZDUUajqANfQAjXL/qeEYMIY8VJsubujburI=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260610154328-540a8ce9853d.1 h1:50Tn2lQ0DVEofbV6nXtWFtGooZ3wgk+KomsVhJJmazI=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260610154328-540a8ce9853d.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260623071207-0391158f5cec.1 h1:iVj1+NtQo1x66y4xbeqyVXWwSBZ1Rz19kK+wICD1+Ic=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260623071207-0391158f5cec.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/cli/cmd/cluster/generatereport.go
+++ b/internal/cli/cmd/cluster/generatereport.go
@@ -218,6 +218,8 @@ func NewGenerateReportCmd() *cobra.Command {
 			"job_completed_at",
 			"profile",
 			"repository",
+			"branch",
+			"conclusion",
 		}
 
 		csvWriter.Write(header)
@@ -267,6 +269,8 @@ func entryToRecords(entry *computev1beta.InstanceReportEntry) []string {
 		tsToString(githubJob.GetJobCompletedAt()),
 		githubJob.GetProfile(),
 		githubJob.GetRepository(),
+		githubJob.GetBranch(),
+		githubJob.GetConclusion(),
 	}
 	return cols
 }


### PR DESCRIPTION
## Summary

- Adds `branch` and `conclusion` columns to `nsc instance report` CSV output.
- Bumps the cloud protobuf bindings to the version that exposes the new `GitHubJob.branch` and `GitHubJob.conclusion` fields (BSR commit `0391158f5cec`).

## Validation

- `go build ./internal/cli/cmd/cluster/`