### PR TITLE
build/binary: support direct server-side push from BuildKit

### DIFF
--- a/internal/artifacts/oci/annotate.go
+++ b/internal/artifacts/oci/annotate.go
@@ -14,13 +14,29 @@ import (
 )
 
 func AnnotateImage(src NamedImage, anns map[string]string) compute.Computable[Image] {
-	return &annotateImage{src: src, anns: anns}
+	return AnnotateImageOpts(AnnotateImageOptions{}, src, anns)
+}
+
+type AnnotateImageOptions struct {
+	// NoCache, when set, marks the annotated image as non-cacheable. Use
+	// when the annotated result is destined for a registry; otherwise the
+	// cache write forces every layer of the underlying image to be pulled.
+	NoCache bool
+}
+
+func AnnotateImageOpts(opts AnnotateImageOptions, src NamedImage, anns map[string]string) compute.Computable[Image] {
+	return &annotateImage{src: src, anns: anns, noCache: opts.NoCache}
 }
 
 type annotateImage struct {
-	src  NamedImage
-	anns map[string]string
+	src     NamedImage
+	anns    map[string]string
+	noCache bool
 	compute.LocalScoped[Image]
+}
+
+func (al *annotateImage) Output() compute.Output {
+	return compute.Output{NotCacheable: al.noCache}
 }
 
 func (al *annotateImage) Action() *tasks.ActionEvent {

--- a/internal/artifacts/oci/makeindex.go
+++ b/internal/artifacts/oci/makeindex.go
@@ -26,13 +26,30 @@ type ImageWithPlatform struct {
 }
 
 func MakeImageIndex(images ...ImageWithPlatform) compute.Computable[ResolvableImage] {
-	return &makeImageIndex{images: images}
+	return MakeImageIndexOpts(MakeImageIndexOptions{}, images...)
+}
+
+type MakeImageIndexOptions struct {
+	// NoCache, when set, marks the resulting index as non-cacheable. Use
+	// when the index is destined for a registry and persisting it in the
+	// local content cache would force every constituent image's layers to
+	// be fetched from the source registry.
+	NoCache bool
+}
+
+func MakeImageIndexOpts(opts MakeImageIndexOptions, images ...ImageWithPlatform) compute.Computable[ResolvableImage] {
+	return &makeImageIndex{images: images, noCache: opts.NoCache}
 }
 
 type makeImageIndex struct {
-	images []ImageWithPlatform
+	images  []ImageWithPlatform
+	noCache bool
 
 	compute.LocalScoped[ResolvableImage]
+}
+
+func (al *makeImageIndex) Output() compute.Output {
+	return compute.Output{NotCacheable: al.noCache}
 }
 
 func (al *makeImageIndex) Inputs() *compute.In {

--- a/internal/artifacts/oci/mergeimage.go
+++ b/internal/artifacts/oci/mergeimage.go
@@ -18,6 +18,18 @@ import (
 var MergeOptimizer func(images []NamedImage) compute.Computable[Image]
 
 func MergeImageLayers(images ...NamedImage) compute.Computable[Image] {
+	return MergeImageLayersOpts(MergeImageLayersOptions{}, images...)
+}
+
+type MergeImageLayersOptions struct {
+	// NoCache, when set, marks the merged image as non-cacheable. Use when
+	// the merged result is destined for a registry and persisting it in the
+	// local content cache would force every constituent layer to be fetched
+	// from the source registry.
+	NoCache bool
+}
+
+func MergeImageLayersOpts(opts MergeImageLayersOptions, images ...NamedImage) compute.Computable[Image] {
 	if MergeOptimizer != nil {
 		optimized := MergeOptimizer(images)
 		if optimized != nil {
@@ -25,12 +37,17 @@ func MergeImageLayers(images ...NamedImage) compute.Computable[Image] {
 		}
 	}
 
-	return &mergeImages{images: images}
+	return &mergeImages{images: images, noCache: opts.NoCache}
 }
 
 type mergeImages struct {
-	images []NamedImage
+	images  []NamedImage
+	noCache bool
 	compute.LocalScoped[Image]
+}
+
+func (al *mergeImages) Output() compute.Output {
+	return compute.Output{NotCacheable: al.noCache}
 }
 
 func (al *mergeImages) Action() *tasks.ActionEvent {

--- a/internal/build/binary/binary.go
+++ b/internal/build/binary/binary.go
@@ -61,6 +61,10 @@ type PreparedImage struct {
 type BuildImageOpts struct {
 	UsePrebuilts bool
 	Platforms    []specs.Platform
+	// PublishName, when set, instructs the underlying BuildKit builder to push
+	// the resulting image directly to the named repository (server-side),
+	// rather than transferring the image back to the client.
+	PublishName compute.Computable[oci.RepositoryWithParent]
 }
 
 // Returns a Prepared.
@@ -100,6 +104,7 @@ func PlanBinary(ctx context.Context, pl pkggraph.PackageLoader, env cfg.Context,
 		Spec:          spec,
 		Workspace:     loc.Module,
 		Platforms:     platforms,
+		PublishName:   opts.PublishName,
 	}
 
 	return &Prepared{

--- a/internal/build/binary/filesfrom.go
+++ b/internal/build/binary/filesfrom.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/moby/buildkit/client/llb"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/build"
+	"namespacelabs.dev/foundation/internal/build/buildkit"
 	"namespacelabs.dev/foundation/internal/compute"
 	"namespacelabs.dev/foundation/internal/fnfs"
 	"namespacelabs.dev/foundation/internal/fnfs/memfs"
@@ -26,6 +28,43 @@ type filesFrom struct {
 }
 
 func (m filesFrom) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
+	// Fast path: when the source is a prebuilt image, perform the copy inside
+	// BuildKit so the source layers are fetched server-side. This avoids
+	// streaming the source image through the client, and lets the resulting
+	// image be direct-pushed when conf.PublishName() is set.
+	if imgid, ok := build.IsPrebuilt(m.spec); ok && conf.TargetPlatform() != nil {
+		return m.buildViaBuildkit(ctx, env, conf, imgid)
+	}
+
+	// Fallback: legacy in-memory copy. Required when the source is not a
+	// fixed image reference (e.g. another binary in the workspace), or when
+	// the build target has no platform.
+	return m.buildInMemory(ctx, env, conf)
+}
+
+func (m filesFrom) buildViaBuildkit(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration, imgid oci.ImageID) (compute.Computable[oci.Image], error) {
+	src := llb.Image(imgid.RepoAndDigest(),
+		llb.WithCustomNamef("files_from(%s)", imgid))
+
+	state := llb.Scratch()
+	for _, path := range m.files {
+		dest := filepath.Join(m.targetDir, path)
+		state = state.File(
+			llb.Copy(src, path, dest, &llb.CopyInfo{
+				CreateDestPath: true,
+				AllowWildcard:  true,
+			}),
+			llb.WithCustomNamef("COPY %s -> %s", path, dest),
+		)
+	}
+
+	return buildkit.BuildImage(ctx,
+		buildkit.DeferClient(env.Configuration(), conf.TargetPlatform()),
+		conf,
+		state)
+}
+
+func (m filesFrom) buildInMemory(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
 	inner, err := m.spec.BuildImage(ctx, env, conf)
 	if err != nil {
 		return nil, err

--- a/internal/build/binary/merge.go
+++ b/internal/build/binary/merge.go
@@ -36,7 +36,12 @@ func (m MergeSpecs) BuildImage(ctx context.Context, env pkggraph.SealedContext, 
 		images[k] = oci.MakeNamedImage(m.Descriptions[k], image)
 	}
 
-	return oci.MergeImageLayers(images...), nil
+	// When the build is destined for a registry, skip the local content
+	// cache for the merged result. Otherwise the cache write forces every
+	// constituent layer to be pulled to disk from the source registry.
+	return oci.MergeImageLayersOpts(oci.MergeImageLayersOptions{
+		NoCache: conf.PublishName() != nil,
+	}, images...), nil
 }
 
 func (m MergeSpecs) PlatformIndependent() bool { return m.platformIndependent }

--- a/internal/build/binary/stamp.go
+++ b/internal/build/binary/stamp.go
@@ -37,7 +37,12 @@ func (m StampImage) BuildImage(ctx context.Context, env pkggraph.SealedContext, 
 	}
 
 	named := oci.MakeNamedImage(m.Src.Description(), im)
-	return oci.AnnotateImage(named, anns), nil
+	return oci.AnnotateImageOpts(oci.AnnotateImageOptions{
+		// Skip the local content cache when the build is destined for a
+		// registry, otherwise caching this wrapper forces all layers of the
+		// underlying image to be downloaded.
+		NoCache: conf.PublishName() != nil,
+	}, named, anns), nil
 }
 
 func (m StampImage) PlatformIndependent() bool { return m.Src.PlatformIndependent() }

--- a/internal/build/buildkit/buildimage.go
+++ b/internal/build/buildkit/buildimage.go
@@ -47,6 +47,18 @@ type reqToImage struct {
 	targetName compute.Computable[oci.RepositoryWithParent]
 }
 
+func (l *reqToImage) Output() compute.Output {
+	out := l.baseRequest.Output()
+	if l.targetName != nil {
+		// When BuildKit pushes the image server-side, the returned oci.Image
+		// is a reference into the destination registry. Persisting it in the
+		// local content cache would force us to download all layers, which
+		// defeats the purpose of the direct-push optimization.
+		out.NotCacheable = true
+	}
+	return out
+}
+
 func (l *reqToImage) Action() *tasks.ActionEvent {
 	ev := tasks.Action("buildkit.build-image")
 

--- a/internal/build/multiplatform/multiplatform.go
+++ b/internal/build/multiplatform/multiplatform.go
@@ -118,7 +118,12 @@ func prepareImage(ctx context.Context, env pkggraph.SealedContext, plan build.Pl
 		})
 	}
 
-	img := oci.MakeImageIndex(iwp...)
+	// When the build is destined for a registry, skip the local content
+	// cache for the assembled index. Otherwise the cache write forces every
+	// per-platform image's layers to be pulled to disk.
+	img := oci.MakeImageIndexOpts(oci.MakeImageIndexOptions{
+		NoCache: plan.PublishName != nil,
+	}, iwp...)
 
 	return img, nil
 }

--- a/internal/cli/cmd/buildbinary.go
+++ b/internal/cli/cmd/buildbinary.go
@@ -30,6 +30,7 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/parsing"
 	"namespacelabs.dev/foundation/internal/parsing/platform"
+	"namespacelabs.dev/foundation/internal/providers/nscloud/api"
 	"namespacelabs.dev/foundation/internal/runtime/docker"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/cfg"
@@ -59,6 +60,7 @@ func NewBuildBinaryCmd() *cobra.Command {
 			flags.BoolVar(&buildOpts.outputPrebuilts, "output_prebuilts", false, "If true, also outputs a prebuilt configuration which can be embedded in your workspace configuration.")
 			flags.StringVar(&buildOpts.outputPath, "output_to", "", "If set, a list of all binaries is emitted to the specified file.")
 			flags.StringVar(&userTag, "tag", "", "Which tag to attach to each of the built images.")
+			flags.BoolVar(&buildOpts.pushDirectly, "push_directly", false, "If true, the BuildKit builder pushes the resulting image directly to the target repository server-side, skipping the round-trip through this client. Recommended when used with --build_in_nscloud. Not compatible with --docker.")
 		}).
 		With(
 			fncobra.ParseEnv(&env),
@@ -77,6 +79,7 @@ type buildOpts struct {
 	publishToDocker bool
 	outputPrebuilts bool
 	outputPath      string
+	pushDirectly    bool
 }
 
 const orchTool = "namespacelabs.dev/foundation/orchestration/server/tool"
@@ -84,6 +87,10 @@ const orchTool = "namespacelabs.dev/foundation/orchestration/server/tool"
 func buildLocations(ctx context.Context, env cfg.Context, reg registry.Manager, userTag string, locs fncobra.Locations, baseRepository []string, opts buildOpts) error {
 	if opts.outputPrebuilts && len(baseRepository) == 0 {
 		return fnerrors.Newf("at least one repository has to be set when updating prebuilts")
+	}
+
+	if opts.pushDirectly && opts.publishToDocker {
+		return fnerrors.Newf("--push_directly is incompatible with --docker")
 	}
 
 	pl := parsing.NewPackageLoader(env)
@@ -123,19 +130,61 @@ func buildLocations(ctx context.Context, env cfg.Context, reg registry.Manager, 
 
 	sealedCtx := pkggraph.MakeSealedContext(env, pl.Seal())
 
-	var imgOpts binary.BuildImageOpts
-	imgOpts.UsePrebuilts = false
+	var baseImgOpts binary.BuildImageOpts
+	baseImgOpts.UsePrebuilts = false
 	hostPlatform := platform.RuntimePlatform()
 	hostPlatform.OS = "linux"
-	imgOpts.Platforms = []specs.Platform{hostPlatform}
+	baseImgOpts.Platforms = []specs.Platform{hostPlatform}
+
+	// When --push_directly is set the keychain is forwarded into the BuildKit
+	// session so the remote builder can authenticate against the target
+	// registry. For the regular client-side push path we keep the keychain
+	// empty: the registry access used by oci.PublishResolvable already
+	// composes registered domain keychains with the local Docker config.
+	staticAccess := oci.RegistryAccess{}
+	if opts.pushDirectly {
+		// Match nsc build: resolve namespace registry credentials via the
+		// nscloud API and fall back to the local Docker configuration for
+		// everything else.
+		staticAccess.Keychain = api.DefaultKeychainWithFallback
+	}
 
 	var images []compute.Computable[Binary]
 	for _, pkg := range pkgs {
-		var resolvables []compute.Computable[oci.ResolvableImage]
+		var repositories []compute.Computable[oci.RepositoryWithParent]
+		for _, bp := range baseRepository {
+			repositories = append(repositories, registry.StaticRepository(nil, filepath.Join(bp, pkg.PackageName().String()), staticAccess))
+		}
+
+		if len(repositories) == 0 {
+			repositories = append(repositories, reg.AllocateName(pkg.PackageName().String(), userTag))
+		}
 
 		// TODO: allow to choose what binary to build within a package.
 		for _, b := range pkg.Binaries {
-			bin, err := binary.Plan(ctx, pkg, b.Name, sealedCtx, assets.AvailableBuildAssets{}, imgOpts)
+			if opts.pushDirectly {
+				// Plan once per target repository, so the underlying BuildKit
+				// builder can push directly (server-side) to each target.
+				for _, repository := range repositories {
+					imgOpts := baseImgOpts
+					imgOpts.PublishName = repository
+
+					bin, err := binary.Plan(ctx, pkg, b.Name, sealedCtx, assets.AvailableBuildAssets{}, imgOpts)
+					if err != nil {
+						return err
+					}
+
+					image, err := bin.Image(ctx, sealedCtx)
+					if err != nil {
+						return err
+					}
+
+					images = append(images, fromImage(pkg.PackageName(), oci.PublishResolvable(repository, image, nil)))
+				}
+				continue
+			}
+
+			bin, err := binary.Plan(ctx, pkg, b.Name, sealedCtx, assets.AvailableBuildAssets{}, baseImgOpts)
 			if err != nil {
 				return err
 			}
@@ -143,19 +192,6 @@ func buildLocations(ctx context.Context, env cfg.Context, reg registry.Manager, 
 			image, err := bin.Image(ctx, sealedCtx)
 			if err != nil {
 				return err
-			}
-
-			resolvables = append(resolvables, image)
-		}
-
-		for _, image := range resolvables {
-			var repositories []compute.Computable[oci.RepositoryWithParent]
-			for _, bp := range baseRepository {
-				repositories = append(repositories, registry.StaticRepository(nil, filepath.Join(bp, pkg.PackageName().String()), oci.RegistryAccess{}))
-			}
-
-			if len(repositories) == 0 {
-				repositories = append(repositories, reg.AllocateName(pkg.PackageName().String(), userTag))
 			}
 
 			for _, repository := range repositories {


### PR DESCRIPTION
Add a --push_directly flag to 'ns build-binary' that lets the BuildKit builder push the resulting image straight to the target repository server-side, skipping the round-trip through the client. Plumb a PublishName through BuildImageOpts and the build pipeline, and mark annotate/merge/index results as non-cacheable when destined for a registry to avoid pulling every layer into the local content cache.