### PR TITLE
postgres: bound schema-apply lock acquisition with lock_timeout

### DIFF
--- a/library/oss/postgres/prepare/database/main.go
+++ b/library/oss/postgres/prepare/database/main.go
@@ -22,6 +22,11 @@ const (
 	providerPkg     = "namespacelabs.dev/foundation/library/oss/postgres"
 	connIdleTimeout = 15 * time.Minute
 
+	// schemaApplyLockTimeout bounds how long any statement in a schema apply waits to acquire a lock.
+	// With this, statements fails fast with lock_not_available (55P03),
+	// which is not retryable, so the apply fails loudly and the deploy can be re-run once any blocker clears.
+	schemaApplyLockTimeout = 10 * time.Second
+
 	caCertPath = "/tmp/ca.pem"
 )
 
@@ -82,6 +87,7 @@ func run(ctx context.Context, p *provider.Provider[*postgres.DatabaseIntent]) er
 		client := fmt.Sprintf("provider:%s", p.Intent.Name)
 		db, err := universepg.NewDatabaseFromConnectionUriWithOverrides(ctx, instance, instance.ConnectionUri, nil, client, &universepg.ConfigOverrides{
 			MaxConnIdleTime: connIdleTimeout,
+			LockTimeout:     schemaApplyLockTimeout,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to open connection: %w", err)

--- a/universe/db/postgres/resource.go
+++ b/universe/db/postgres/resource.go
@@ -46,6 +46,7 @@ type ConfigOverrides struct {
 	MaxConnIdleTime                 time.Duration
 	IdleInTransactionSessionTimeout time.Duration
 	StatementTimeout                time.Duration
+	LockTimeout                     time.Duration
 	ConnectTimeout                  time.Duration
 }
 
@@ -81,6 +82,10 @@ func NewDatabaseFromConnectionUriWithOverrides(ctx context.Context, db DBInstanc
 
 		if overrides.StatementTimeout > 0 {
 			config.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%d", overrides.StatementTimeout.Milliseconds())
+		}
+
+		if overrides.LockTimeout > 0 {
+			config.ConnConfig.RuntimeParams["lock_timeout"] = fmt.Sprintf("%d", overrides.LockTimeout.Milliseconds())
 		}
 
 		if overrides.ConnectTimeout > 0 {


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### postgres: bound schema-apply lock acquisition with lock_timeout

Add LockTimeout override and set it to 10s on the one-shot schema-apply.

With this, statements fails fast with lock_not_available (55P03),
which is not retryable, so the apply fails loudly and the deploy can be
re-run once any blocker clears.
Scoped to short-lived migration pool only, runtime queries unaffected

Amp-Thread-ID: https://ampcode.com/threads/T-019f057d-4300-74a0-9cdd-2c0edf5d733b
Co-authored-by: Amp <amp@ampcode.com>
<!-- pr-cli body end -->