### PR TITLE
base-image upload: add --from-file flag for local tar images

### DIFF
--- a/internal/cli/cmd/cluster/baseimage/upload_base_image.go
+++ b/internal/cli/cmd/cluster/baseimage/upload_base_image.go
@@ -55,6 +55,7 @@ func newUploadBaseImageCmd() *cobra.Command {
 		}
 
 		var img v1.Image
+		var index v1.ImageIndex
 
 		if *fromFile != "" {
 			fmt.Fprintf(console.Info(ctx), "Loading image from file: %s\n", *fromFile)
@@ -79,10 +80,24 @@ func newUploadBaseImageCmd() *cobra.Command {
 				return fmt.Errorf("failed to fetch %s: %w", sourceImage, err)
 			}
 
-			img, err = desc.Image()
-			if err != nil {
-				return fmt.Errorf("failed to load image from descriptor: %w", err)
+			switch {
+			case desc.MediaType.IsIndex():
+				index, err = desc.ImageIndex()
+				if err != nil {
+					return fmt.Errorf("failed to load image index from descriptor: %w", err)
+				}
+			case desc.MediaType.IsImage():
+				img, err = desc.Image()
+				if err != nil {
+					return fmt.Errorf("failed to load image from descriptor: %w", err)
+				}
+			default:
+				return fmt.Errorf("unsupported media type: %s", desc.MediaType)
 			}
+		}
+
+		if index != nil && len(*annotateWithDigest) > 0 {
+			return fmt.Errorf("--annotate-with-digest cannot be used with an image index source; use a single-platform image instead")
 		}
 
 		annotations, err := makeAnnotations(ctx, img, *annotateWithDigest)
@@ -107,13 +122,23 @@ func newUploadBaseImageCmd() *cobra.Command {
 			return err
 		}
 
-		annotated := mutate.Annotations(img, annotations).(v1.Image)
-		h, err := annotated.Digest()
-		if err != nil {
-			return err
-		}
-		if err := remote.Write(targetRef, annotated, remoteOpts...); err != nil {
-			return err
+		var h v1.Hash
+		if index != nil {
+			annotated := mutate.Annotations(index, annotations).(v1.ImageIndex)
+			if h, err = annotated.Digest(); err != nil {
+				return err
+			}
+			if err = remote.WriteIndex(targetRef, annotated, remoteOpts...); err != nil {
+				return err
+			}
+		} else {
+			annotated := mutate.Annotations(img, annotations).(v1.Image)
+			if h, err = annotated.Digest(); err != nil {
+				return err
+			}
+			if err := remote.Write(targetRef, annotated, remoteOpts...); err != nil {
+				return err
+			}
 		}
 
 		fmt.Fprintf(console.Info(ctx), "%s: %s@%s\n", colors.Ctx(ctx).Highlight.Apply("✔ Uploaded base image"), targetRef, h)

--- a/internal/cli/cmd/cluster/baseimage/upload_base_image.go
+++ b/internal/cli/cmd/cluster/baseimage/upload_base_image.go
@@ -7,12 +7,15 @@ package baseimage
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/spf13/cobra"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
@@ -25,40 +28,64 @@ func newUploadBaseImageCmd() *cobra.Command {
 	run := &cobra.Command{
 		Use:   "upload [source-image] [target-tag]",
 		Short: "Converts an existing image into a base image and uploads it to nscr.io",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.RangeArgs(1, 2),
 	}
 
 	annotateWithDigest := run.Flags().StringToString("annotate-with-digest", map[string]string{}, "Add an annotation to the base image with the digest of a specified path. Example: nix.store-digest=/nix")
 	dryRun := run.Flags().Bool("dry-run", false, "Pull source image and calculate annotations without pushing to nscr.io")
+	fromFile := run.Flags().String("from-file", "", "Load the source image from a local tar file (e.g. output of 'podman save' or 'docker save') instead of pulling from a remote registry")
 
 	run.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
-		sourceImage, err := oci.ParseImageID(args[0])
-		if err != nil {
-			return err
+		// When --from-file is set: upload [target-tag]
+		// Otherwise:              upload [source-image] [target-tag]
+		if *fromFile == "" && len(args) < 2 {
+			return fmt.Errorf("source-image argument is required when --from-file is not set")
 		}
+
+		targetArg := args[len(args)-1]
 
 		registry, err := getNSCRRegistry(ctx)
 		if err != nil {
 			return err
 		}
 
-		targetRef, err := name.NewTag(prependRegistryEp(registry, args[1]), name.StrictValidation)
+		targetRef, err := name.NewTag(prependRegistryEp(registry, targetArg), name.StrictValidation)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(console.Info(ctx), "Pulling image: %s\n", sourceImage)
+		var img v1.Image
 
-		desc, err := oci.FetchRemoteDescriptor(
-			ctx,
-			sourceImage.RepoAndDigest(),
-			oci.RegistryAccess{Keychain: api.DefaultKeychainWithFallback},
-		)
-		if err != nil {
-			return fmt.Errorf("failed to fetch %s: %w", sourceImage, err)
+		if *fromFile != "" {
+			fmt.Fprintf(console.Info(ctx), "Loading image from file: %s\n", *fromFile)
+			img, err = imageFromFile(*fromFile)
+			if err != nil {
+				return fmt.Errorf("failed to load image from %s: %w", *fromFile, err)
+			}
+		} else {
+			sourceImage, err := oci.ParseImageID(args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(console.Info(ctx), "Pulling image: %s\n", sourceImage)
+
+			desc, err := oci.FetchRemoteDescriptor(
+				ctx,
+				sourceImage.RepoAndDigest(),
+				oci.RegistryAccess{Keychain: api.DefaultKeychainWithFallback},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to fetch %s: %w", sourceImage, err)
+			}
+
+			img, err = desc.Image()
+			if err != nil {
+				return fmt.Errorf("failed to load image from descriptor: %w", err)
+			}
 		}
 
-		annotations, err := makeAnnotations(ctx, desc, *annotateWithDigest)
+		annotations, err := makeAnnotations(ctx, img, *annotateWithDigest)
 		if err != nil {
 			return err
 		}
@@ -80,38 +107,13 @@ func newUploadBaseImageCmd() *cobra.Command {
 			return err
 		}
 
-		var h v1.Hash
-		switch {
-		case desc.MediaType.IsIndex():
-			index, err := desc.ImageIndex()
-			if err != nil {
-				return err
-			}
-
-			annotated := mutate.Annotations(index, annotations).(v1.ImageIndex)
-			if h, err = annotated.Digest(); err != nil {
-				return err
-			}
-
-			if err = remote.WriteIndex(targetRef, annotated, remoteOpts...); err != nil {
-				return err
-			}
-		case desc.MediaType.IsImage():
-			img, err := desc.Image()
-			if err != nil {
-				return err
-			}
-
-			annotated := mutate.Annotations(img, annotations).(v1.Image)
-			if h, err = annotated.Digest(); err != nil {
-				return err
-			}
-
-			if err := remote.Write(targetRef, annotated, remoteOpts...); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unsupported image type: %s", desc.MediaType)
+		annotated := mutate.Annotations(img, annotations).(v1.Image)
+		h, err := annotated.Digest()
+		if err != nil {
+			return err
+		}
+		if err := remote.Write(targetRef, annotated, remoteOpts...); err != nil {
+			return err
 		}
 
 		fmt.Fprintf(console.Info(ctx), "%s: %s@%s\n", colors.Ctx(ctx).Highlight.Apply("✔ Uploaded base image"), targetRef, h)
@@ -121,12 +123,19 @@ func newUploadBaseImageCmd() *cobra.Command {
 	return run
 }
 
-func makeAnnotations(ctx context.Context, desc *remote.Descriptor, annotateWithDigest map[string]string) (map[string]string, error) {
-	img, err := desc.Image()
-	if err != nil {
+// imageFromFile loads an OCI image from a local tar file (docker/podman save format).
+// The opener re-opens the file on each call so layers are read from disk on demand
+// rather than buffered into memory.
+func imageFromFile(path string) (v1.Image, error) {
+	if _, err := os.Stat(path); err != nil {
 		return nil, err
 	}
+	return tarball.Image(func() (io.ReadCloser, error) {
+		return os.Open(path)
+	}, nil)
+}
 
+func makeAnnotations(ctx context.Context, img v1.Image, annotateWithDigest map[string]string) (map[string]string, error) {
 	annotations := map[string]string{
 		"nsc.base-image": "v1",
 	}


### PR DESCRIPTION
Add a --from-file flag to `nsc base-image upload` that loads the source image from a local tar file (docker/podman save format) instead of pulling from a remote registry.

This is useful for images built locally with Podman or Nix that are not pushed to any registry:

    podman save localhost/worker-image:latest -o worker-image.tar
    nsc base-image upload --from-file worker-image.tar worker-image:latest

When --from-file is used, only the target tag argument is required (the source-image argument is omitted). Without --from-file, the original two-argument form is unchanged.