### PR TITLE
nsc: add github job describe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module namespacelabs.dev/foundation
 go 1.26.0
 
 require (
-	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260610154328-540a8ce9853d.1
+	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260703113640-89c8e7ec839f.1
 	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260610154328-540a8ce9853d.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260623071207-0391158f5cec.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260703113640-89c8e7ec839f.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260610154328-540a8ce9853d.1 h1:BMQ7VNoTTpLstAIzGzYJFbNtOTEO7m3qcfnMr/k7x6k=
-buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260610154328-540a8ce9853d.1/go.mod h1:hvHz7jMtG0TUy5XmDQcxhXNhMElaj0SU5TOSpx5HFyQ=
+buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260703113640-89c8e7ec839f.1 h1:ueEREvyudmkiq3AuyEUZHJh9AARUwUC+yTD9xNLfwL4=
+buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260703113640-89c8e7ec839f.1/go.mod h1:dCgMu4k1pYCfTklcM9RXu85YvlbX3lvL/Is/Z5x7K1k=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260610154328-540a8ce9853d.1 h1:Nxs0ekOZSf4+yzTT0+KO9dFAmmHiPvf8N/7TruOB+WI=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260610154328-540a8ce9853d.1/go.mod h1:S5jbhx/UZDUUajqANfQAjXL/qeEYMIY8VJsubujburI=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260623071207-0391158f5cec.1 h1:iVj1+NtQo1x66y4xbeqyVXWwSBZ1Rz19kK+wICD1+Ic=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260623071207-0391158f5cec.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260703113640-89c8e7ec839f.1 h1:AQOYECjB60GZB3qmJ50P/vFWTjxOA3Wr9TqXepIjw0Y=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260703113640-89c8e7ec839f.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/cli/cmd/cluster/github/jobs.go
+++ b/internal/cli/cmd/cluster/github/jobs.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
 	"time"
 
 	v1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/github/v1beta"
@@ -24,11 +26,13 @@ import (
 
 func NewJobsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "jobs",
-		Short: "Manage GitHub Actions jobs.",
+		Use:     "job",
+		Aliases: []string{"jobs"},
+		Short:   "Manage GitHub Actions jobs.",
 	}
 
 	cmd.AddCommand(newJobsListCmd())
+	cmd.AddCommand(newJobsDescribeCmd())
 
 	return cmd
 }
@@ -151,6 +155,99 @@ func newJobsListCmd() *cobra.Command {
 	return cmd
 }
 
+func newJobsDescribeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <job-id>",
+		Short: "Show details for a specific GitHub Actions job, including the instance it ran on.",
+		Args:  cobra.ExactArgs(1),
+	}
+
+	output := cmd.Flags().StringP("output", "o", "plain", "One of plain or json.")
+
+	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
+		jobID, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			return fnerrors.Newf("invalid job id %q: must be a number", args[0])
+		}
+
+		job, err := describeJob(ctx, jobID)
+		if err != nil {
+			return err
+		}
+
+		stdout := console.Stdout(ctx)
+
+		if *output == "json" {
+			enc := json.NewEncoder(stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(transformJobForOutput(job)); err != nil {
+				return fnerrors.InternalError("failed to encode job as JSON output: %w", err)
+			}
+			return nil
+		}
+
+		printJobDetails(stdout, job)
+		return nil
+	})
+
+	return cmd
+}
+
+func printJobDetails(stdout io.Writer, job *v1beta.Job) {
+	status := job.Conclusion
+	if status == "" {
+		if job.StartedAt != nil {
+			status = "running"
+		} else {
+			status = "pending"
+		}
+	}
+
+	fmt.Fprintf(stdout, "\nJob %d\n\n", job.JobId)
+	fmt.Fprintf(stdout, "Repository:   %s\n", job.Repository)
+	fmt.Fprintf(stdout, "Workflow:     %s\n", job.WorkflowName)
+	fmt.Fprintf(stdout, "Job:          %s\n", job.JobName)
+	fmt.Fprintf(stdout, "Status:       %s\n", status)
+	fmt.Fprintf(stdout, "Sender:       %s\n", job.SenderLogin)
+
+	if job.Ref != "" {
+		fmt.Fprintf(stdout, "Ref:          %s\n", job.Ref)
+	}
+	if job.Profile != nil && job.Profile.Tag != "" {
+		fmt.Fprintf(stdout, "Profile:      %s\n", job.Profile.Tag)
+	}
+	if job.JobUrl != "" {
+		fmt.Fprintf(stdout, "URL:          %s\n", job.JobUrl)
+	}
+
+	if job.CreatedAt != nil {
+		fmt.Fprintf(stdout, "Created At:   %s\n", job.CreatedAt.AsTime().Format(time.RFC3339))
+	}
+	if job.StartedAt != nil {
+		fmt.Fprintf(stdout, "Started At:   %s\n", job.StartedAt.AsTime().Format(time.RFC3339))
+	}
+	if job.CompletedAt != nil {
+		fmt.Fprintf(stdout, "Completed At: %s\n", job.CompletedAt.AsTime().Format(time.RFC3339))
+	}
+
+	if job.Runner != nil {
+		fmt.Fprintf(stdout, "\nRunner:\n")
+		if job.Runner.InstanceId != "" {
+			fmt.Fprintf(stdout, "  Instance ID:    %s\n", job.Runner.InstanceId)
+		}
+		if job.Runner.ContainerName != "" {
+			fmt.Fprintf(stdout, "  Container Name: %s\n", job.Runner.ContainerName)
+		}
+		if job.Runner.RunnerName != "" {
+			fmt.Fprintf(stdout, "  Runner Name:    %s\n", job.Runner.RunnerName)
+		}
+		if job.Runner.RunnerId != 0 {
+			fmt.Fprintf(stdout, "  Runner ID:      %d\n", job.Runner.RunnerId)
+		}
+	}
+	fmt.Fprintln(stdout)
+}
+
 func listJobs(ctx context.Context, req *v1beta.ListJobsRequest) ([]*v1beta.Job, error) {
 	client, err := fnapi.NewJobsServiceClient(ctx)
 	if err != nil {
@@ -163,6 +260,22 @@ func listJobs(ctx context.Context, req *v1beta.ListJobsRequest) ([]*v1beta.Job, 
 	}
 
 	return res.Msg.Jobs, nil
+}
+
+func describeJob(ctx context.Context, jobID int64) (*v1beta.Job, error) {
+	client, err := fnapi.NewJobsServiceClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.DescribeJob(ctx, connect.NewRequest(&v1beta.DescribeJobRequest{
+		JobId: jobID,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Msg.Job, nil
 }
 
 func transformJobs(jobs []*v1beta.Job) []map[string]any {


### PR DESCRIPTION
Adds `nsc github job describe <job-id>`.
Renames `nsc github jobs` to `job` (keeps `jobs` as an alias).
