### PR TITLE
cli/scratch: support image selectors for ssh

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -148,13 +148,9 @@ func NewCreateCmd() *cobra.Command {
 		}
 
 		if len(*selectors) > 0 {
-			sels := []*api.LabelEntry{}
-			for _, s := range *selectors {
-				k, v, ok := strings.Cut(s, "=")
-				if !ok {
-					return fmt.Errorf("invalid selector %q: expected key=value", s)
-				}
-				sels = append(sels, &api.LabelEntry{Name: k, Value: v})
+			sels, err := ParseImageSelectors(*selectors)
+			if err != nil {
+				return err
 			}
 			opts.Experimental["image_selectors"] = sels
 		}
@@ -341,6 +337,18 @@ func NewCreateCmd() *cobra.Command {
 	})
 
 	return cmd
+}
+
+func ParseImageSelectors(selectors []string) ([]*api.LabelEntry, error) {
+	sels := []*api.LabelEntry{}
+	for _, s := range selectors {
+		k, v, ok := strings.Cut(s, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid selector %q: expected key=value", s)
+		}
+		sels = append(sels, &api.LabelEntry{Name: k, Value: v})
+	}
+	return sels, nil
 }
 
 func ParseVolumeFlag(def string) (api.VolumeSpec, error) {

--- a/internal/cli/cmd/scratch/ssh.go
+++ b/internal/cli/cmd/scratch/ssh.go
@@ -29,6 +29,7 @@ func NewSshCmd() *cobra.Command {
 	forcePty := cmd.Flags().BoolP("force-pty", "t", false, "Force pseudo-terminal allocation.")
 	disablePty := cmd.Flags().BoolP("disable-pty", "T", false, "Disable pseudo-terminal allocation.")
 	machineType := cmd.Flags().String("machine_type", "", "Specify the machine type.")
+	selectors := cmd.Flags().StringSlice("selectors", nil, "Select platform/base image based on specific properties (prop1=value1,prop2=value2).")
 	waitTimeout := fncobra.Duration(cmd.Flags(), "wait_timeout", 2*time.Minute, "For how long to wait until the instance becomes ready.")
 
 	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
@@ -54,6 +55,14 @@ func NewSshCmd() *cobra.Command {
 				WaitKind:       "kubernetes",
 			},
 			Duration: 5 * time.Minute, // Initial duration, will be kept alive during SSH session
+		}
+
+		if len(*selectors) > 0 {
+			sels, err := cluster.ParseImageSelectors(*selectors)
+			if err != nil {
+				return err
+			}
+			opts.Experimental = map[string]any{"image_selectors": sels}
 		}
 
 		clusterResp, err := api.CreateAndWaitCluster(ctx, api.Methods, *waitTimeout, opts)


### PR DESCRIPTION
## Summary
- add --selectors to nsc scratch ssh
- reuse the instance create selector parser
- forward selectors as image_selectors in the create-instance request

## Test
- go test ./internal/cli/cmd/scratch ./internal/cli/cmd/cluster