### PR TITLE
release: add Windows build for the nsc bundle

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,6 +62,21 @@ builds:
       - amd64
       - arm64
 
+  - id: windows-nsc
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/nsc
+    binary: nsc
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X namespacelabs.dev/foundation/internal/cli/version.Tag=v{{.Version}}
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
   - id: linux-docker-credential-nsc
     env:
       - CGO_ENABLED=0
@@ -88,6 +103,21 @@ builds:
       - -s -w -X namespacelabs.dev/foundation/internal/cli/version.Tag=v{{.Version}}
     goos:
       - darwin
+    goarch:
+      - amd64
+      - arm64
+
+  - id: windows-docker-credential-nsc
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/docker-credential-nsc
+    binary: docker-credential-nsc
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X namespacelabs.dev/foundation/internal/cli/version.Tag=v{{.Version}}
+    goos:
+      - windows
     goarch:
       - amd64
       - arm64
@@ -122,6 +152,21 @@ builds:
       - amd64
       - arm64
 
+  - id: windows-bazel-credential-nsc
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/bazel-credential-nsc
+    binary: bazel-credential-nsc
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X namespacelabs.dev/foundation/internal/cli/version.Tag=v{{.Version}}
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: ns
     builds:
@@ -137,7 +182,13 @@ archives:
       - macos-nsc
       - macos-docker-credential-nsc
       - macos-bazel-credential-nsc
+      - windows-nsc
+      - windows-docker-credential-nsc
+      - windows-bazel-credential-nsc
     name_template: "nsc_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 # signs:
 #   - signature: "${artifact}_macos.dmg"

--- a/framework/console/termios/termios_unix.go
+++ b/framework/console/termios/termios_unix.go
@@ -22,6 +22,12 @@ func IsTerm(fd uintptr) bool {
 	return true
 }
 
+// EnableVirtualTerminalProcessing is a no-op outside Windows, where terminals
+// interpret ANSI escape sequences natively.
+func EnableVirtualTerminalProcessing(fd uintptr) error {
+	return nil
+}
+
 func TermSize(fd uintptr) (WinSize, error) {
 	uws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
 	if err != nil {

--- a/framework/console/termios/termios_windows.go
+++ b/framework/console/termios/termios_windows.go
@@ -7,6 +7,7 @@ package termios
 import (
 	"os"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/term"
 )
 
@@ -17,6 +18,24 @@ func TermSize(fd uintptr) (WinSize, error) {
 
 func IsTerm(fd uintptr) bool {
 	return term.IsTerminal(int(fd))
+}
+
+// EnableVirtualTerminalProcessing enables ANSI escape sequence interpretation on
+// the given Windows console handle. Without it, escapes are printed verbatim on
+// legacy consoles and older PowerShell hosts.
+func EnableVirtualTerminalProcessing(fd uintptr) error {
+	handle := windows.Handle(fd)
+
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return err
+	}
+
+	if mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
+		return nil
+	}
+
+	return windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
 }
 
 func NotifyWindowSize(ch chan<- os.Signal) {

--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	namespacelabs.dev/go-filenotify v0.0.0-20220511192020-53ea11be7eaa
 	namespacelabs.dev/go-ids v0.0.0-20221124082625-9fc72ee06af7
 	namespacelabs.dev/integrations v0.0.11-0.20260331003432-a64bf395356c
-	namespacelabs.dev/releaser v0.0.0-20260426204818-9c7ef100ea90
+	namespacelabs.dev/releaser v0.0.0-20260707112236-b7f1d113499e
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1313,8 +1313,8 @@ namespacelabs.dev/go-ids v0.0.0-20221124082625-9fc72ee06af7 h1:8NlnfPlzDSJr8TYV/
 namespacelabs.dev/go-ids v0.0.0-20221124082625-9fc72ee06af7/go.mod h1:J+Sd+ngeffnCsaO/M7zgs2bR8Klq/ZBhS0+bbnDEH2M=
 namespacelabs.dev/integrations v0.0.11-0.20260331003432-a64bf395356c h1:fK2ONyaaT2Mv+fGuIW0CRfsRDCoiwJ/apXAj75TkydE=
 namespacelabs.dev/integrations v0.0.11-0.20260331003432-a64bf395356c/go.mod h1:dF38n489mT8w1Gy1J3ilBZZFUnjUY9qYEY6kPRB3n8M=
-namespacelabs.dev/releaser v0.0.0-20260426204818-9c7ef100ea90 h1:q+6pxQjW9Yswd5Dej+xahZRVZaPtPcm7oYSTTHz7xak=
-namespacelabs.dev/releaser v0.0.0-20260426204818-9c7ef100ea90/go.mod h1:1ufMKQTcPoPq8AcTedghfOFalJeW+rA7EwFExwtHPxo=
+namespacelabs.dev/releaser v0.0.0-20260707112236-b7f1d113499e h1:WO/9O66twDY1d8iuFxdHFsqb5l7WryTtElSorpfNHfs=
+namespacelabs.dev/releaser v0.0.0-20260707112236-b7f1d113499e/go.mod h1:1ufMKQTcPoPq8AcTedghfOFalJeW+rA7EwFExwtHPxo=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=

--- a/install/install_nsc.ps1
+++ b/install/install_nsc.ps1
@@ -1,0 +1,169 @@
+# Copyright 2022 Namespace Labs Inc; All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Installs the Namespace nsc CLI (and its credential helpers) on Windows.
+
+.DESCRIPTION
+    Downloads the windows release archive for nsc, extracts it, copies the
+    executables into an install directory and ensures that directory is on the
+    user's PATH.
+
+.PARAMETER Version
+    Version to install (for example 0.0.530). Defaults to the latest release.
+
+.PARAMETER Dir
+    Directory to install the executables into. Overrides NS_ROOT and
+    NS_INSTALL_DIR. Defaults to %LOCALAPPDATA%\ns\bin.
+
+.PARAMETER DryRun
+    Print the actions that would be taken without downloading or installing.
+
+.EXAMPLE
+    ./install_nsc.ps1
+
+.EXAMPLE
+    ./install_nsc.ps1 -Version 0.0.530 -Dir C:\tools\ns
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$Dir,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# Speeds up Invoke-WebRequest downloads considerably.
+$ProgressPreference = 'SilentlyContinue'
+
+$toolName = 'nsc'
+$dockerCredHelperName = 'docker-credential-nsc'
+$bazelCredHelperName = 'bazel-credential-nsc'
+
+function Get-Architecture {
+    $procArch = $env:PROCESSOR_ARCHITECTURE
+    # 32-bit process on a 64-bit host reports x86; the real arch is in
+    # PROCESSOR_ARCHITEW6432.
+    if ($procArch -eq 'x86' -and $env:PROCESSOR_ARCHITEW6432) {
+        $procArch = $env:PROCESSOR_ARCHITEW6432
+    }
+
+    switch ($procArch) {
+        'AMD64' { return 'amd64' }
+        'ARM64' { return 'arm64' }
+        default { return $null }
+    }
+}
+
+function Add-ToUserPath {
+    param([string]$Directory)
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $entries = @()
+    if ($userPath) {
+        $entries = @($userPath -split ';' | Where-Object { $_ -ne '' })
+    }
+
+    if ($entries -notcontains $Directory) {
+        $newPath = (@($entries) + $Directory) -join ';'
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+        Write-Host "Added $Directory to your user PATH. Restart your terminal for it to take effect."
+    }
+
+    # Make it available in the current session too.
+    if (($env:Path -split ';') -notcontains $Directory) {
+        $env:Path = "$env:Path;$Directory"
+    }
+}
+
+Write-Host "Executing Namespace's installation script..."
+
+$architecture = Get-Architecture
+if (-not $architecture) {
+    Write-Error "Unsupported platform architecture '$($env:PROCESSOR_ARCHITECTURE)'. Available only on amd64 and arm64 currently."
+    exit 1
+}
+
+Write-Host "Detected windows/$architecture as the host platform"
+
+# Resolve the install directory.
+if ($Dir) {
+    $binDir = $Dir
+} elseif ($env:NS_ROOT) {
+    $binDir = Join-Path $env:NS_ROOT 'bin'
+} elseif ($env:NS_INSTALL_DIR) {
+    $binDir = $env:NS_INSTALL_DIR
+} else {
+    $binDir = Join-Path $env:LOCALAPPDATA 'ns\bin'
+}
+
+# Resolve the version to install.
+if (-not $Version) {
+    Write-Host "Querying latest version..."
+    $body = "{`"$toolName`":{}}"
+    $response = Invoke-WebRequest -Method Post -ContentType 'application/json' `
+        -Body $body -Uri 'https://get.namespace.so/nsl.versions.VersionsService/GetLatest' `
+        -UseBasicParsing
+    if ($response.Content -match '"version"\s*:\s*"([^"]+)"') {
+        $Version = $Matches[1] -replace '^v', ''
+    }
+
+    if (-not $Version) {
+        Write-Error "Failed to query latest version"
+        exit 1
+    }
+
+    Write-Host "Latest version: $Version"
+}
+
+$archive = "${toolName}_${Version}_windows_${architecture}.zip"
+$downloadUri = "https://get.namespace.so/packages/$toolName/v$Version/$archive"
+
+Write-Host "Downloading and installing Namespace $Version from $downloadUri"
+
+if ($DryRun) {
+    Write-Host "DRY RUN: would download $downloadUri"
+    Write-Host "DRY RUN: would install $toolName, $dockerCredHelperName and $bazelCredHelperName to $binDir"
+    Write-Host "DRY RUN: would ensure $binDir is on your PATH"
+    Write-Host "Installation complete (dry run)"
+    return
+}
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("nsc-install-" + [System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+try {
+    $zipPath = Join-Path $tempDir $archive
+
+    $headers = @{}
+    if ($env:CI) {
+        $headers['CI'] = $env:CI
+    }
+
+    Invoke-WebRequest -Uri $downloadUri -OutFile $zipPath -UserAgent 'install_nsc.ps1' -Headers $headers -UseBasicParsing
+    Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+    if (-not (Test-Path $binDir)) {
+        New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+    }
+
+    foreach ($bin in @($toolName, $dockerCredHelperName, $bazelCredHelperName)) {
+        $exe = "$bin.exe"
+        $src = Join-Path $tempDir $exe
+        $dst = Join-Path $binDir $exe
+        Copy-Item -Path $src -Destination $dst -Force
+        Write-Host "[OK] Installed $exe to $dst"
+    }
+} finally {
+    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Add-ToUserPath $binDir
+
+Write-Host "Installation complete"

--- a/internal/cli/cmd/cluster/buildkit.go
+++ b/internal/cli/cmd/cluster/buildkit.go
@@ -40,6 +40,7 @@ func NewBuildkitCmd() *cobra.Command {
 		Short:  "Buildkit-related functionality.",
 		Hidden: true,
 	}
+	fncobra.MarkAsNotSupportedOnWindows(cmd)
 
 	cmd.AddCommand(newBuildctlCmd())
 	cmd.AddCommand(newBuildkitProxy())

--- a/internal/cli/cmd/cluster/docker.go
+++ b/internal/cli/cmd/cluster/docker.go
@@ -40,12 +40,14 @@ func NewDockerCmd() *cobra.Command {
 		Use:   "docker",
 		Short: "Docker-related functionality.",
 	}
+	fncobra.MarkAsNotSupportedOnWindows(cmd)
 
 	cmd.AddCommand(newDockerAttachCmd())     // nsc docker attach-context
 	cmd.AddCommand(newDockerRemoteCmd())     // nsc docker remote
 	cmd.AddCommand(newDockerLoginCmd(false)) // nsc docker login
 
 	buildx := &cobra.Command{Use: "buildx", Short: "Docker Buildx related functionality."}
+	fncobra.MarkAsNotSupportedOnWindows(buildx)
 	buildx.AddCommand(newSetupBuildxCmd())
 	buildx.AddCommand(newCleanupBuildxCommand())
 	buildx.AddCommand(newWireBuildxCommand(true))

--- a/internal/cli/cmd/cluster/execscoped.go
+++ b/internal/cli/cmd/cluster/execscoped.go
@@ -28,6 +28,7 @@ func NewExecScoped() *cobra.Command {
 		Short: "Runs the specified command (e.g. a script) with the corresponding environment variables set, based on the services selected (e.g. DOCKER_HOST, KUBECONFIG).",
 		Args:  cobra.MinimumNArgs(1),
 	}
+	fncobra.MarkAsNotSupportedOnWindows(cmd)
 
 	service := cmd.Flags().StringSlice("service", nil, "Which services to inject, any of: docker, kubernetes")
 

--- a/internal/cli/fncobra/main.go
+++ b/internal/cli/fncobra/main.go
@@ -144,6 +144,14 @@ func doMain(opts MainOpts) (colors.Style, error) {
 
 		ctx := cmd.Context()
 
+		// Abort early for commands that are not yet supported on the current
+		// platform (e.g. Windows). The annotation is only ever set on those
+		// platforms, so this is a no-op everywhere else.
+		if isUnsupportedOnWindows(cmd) {
+			fmt.Fprintln(console.Stderr(ctx), notSupportedOnWindowsMessage)
+			os.Exit(1)
+		}
+
 		// Don't run version checks for commands that opt out (e.g. update, check).
 		if opts.NotifyOnNewVersion && cmd.Annotations["ns.skip-version-check"] == "" {
 			DeferCheckVersion(ctx, opts.Name)
@@ -382,6 +390,22 @@ func ensureFnConfig() {
 func StandardConsole() (*os.File, bool) {
 	isStdoutTerm := termios.IsTerm(os.Stdout.Fd())
 	isStderrTerm := termios.IsTerm(os.Stderr.Fd())
+
+	// On Windows, ANSI escapes are only interpreted when virtual terminal
+	// processing is enabled on the console. Enable it; if that fails (e.g. a
+	// legacy console), treat the stream as non-terminal so we don't emit raw
+	// escape sequences. This is a no-op on other platforms.
+	if isStdoutTerm {
+		if err := termios.EnableVirtualTerminalProcessing(os.Stdout.Fd()); err != nil {
+			isStdoutTerm = false
+		}
+	}
+	if isStderrTerm {
+		if err := termios.EnableVirtualTerminalProcessing(os.Stderr.Fd()); err != nil {
+			isStderrTerm = false
+		}
+	}
+
 	return os.Stderr, isStdoutTerm && isStderrTerm
 }
 

--- a/internal/cli/fncobra/notsupported.go
+++ b/internal/cli/fncobra/notsupported.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package fncobra
+
+import "github.com/spf13/cobra"
+
+// unsupportedOnWindowsAnnotation marks a command that does not yet work on
+// Windows. It is only ever set on Windows (see MarkAsNotSupportedOnWindows);
+// commands carrying it, directly or via a parent, abort early in the root
+// PersistentPreRunE.
+const unsupportedOnWindowsAnnotation = "ns.unsupported-on-windows"
+
+// notSupportedOnWindowsMessage is shown when a command flagged as unsupported on
+// Windows is invoked.
+const notSupportedOnWindowsMessage = "This command is not yet supported on Windows."
+
+// isUnsupportedOnWindows reports whether the command, or any of its ancestors,
+// has been marked as unsupported on Windows.
+func isUnsupportedOnWindows(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Annotations[unsupportedOnWindowsAnnotation] == "true" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/cli/fncobra/notsupported_other.go
+++ b/internal/cli/fncobra/notsupported_other.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build !windows
+
+package fncobra
+
+import "github.com/spf13/cobra"
+
+// MarkAsNotSupportedOnWindows is a no-op on non-Windows platforms.
+func MarkAsNotSupportedOnWindows(cmd *cobra.Command) {}

--- a/internal/cli/fncobra/notsupported_windows.go
+++ b/internal/cli/fncobra/notsupported_windows.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build windows
+
+package fncobra
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// MarkAsNotSupportedOnWindows flags a command as not yet supported on Windows.
+// The command (and its subcommands) is hidden from help output and aborts with
+// a warning when invoked.
+//
+// Runnable commands abort via the root PersistentPreRunE (see isUnsupportedOnWindows).
+// Parent commands (those with subcommands but no Run/RunE) are not "runnable",
+// so cobra short-circuits them to their help output before PersistentPreRunE
+// runs. We therefore replace their help output too, so that invoking the bare
+// command (e.g. `nsc docker`) or passing `--help` reports the unsupported status
+// and aborts. The help func is inherited by subcommands, covering the whole tree.
+func MarkAsNotSupportedOnWindows(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+
+	cmd.Annotations[unsupportedOnWindowsAnnotation] = "true"
+	cmd.Hidden = true
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, _ []string) {
+		fmt.Fprintln(cmd.ErrOrStderr(), notSupportedOnWindowsMessage)
+		os.Exit(1)
+	})
+}


### PR DESCRIPTION
## Summary

Adds a Windows release for the `nsc` bundle.

- Produce `windows/amd64` and `windows/arm64` builds for `nsc`, `docker-credential-nsc`, and `bazel-credential-nsc`, include them in the `nsc` archive (packaged as `zip`), and publish them through the release pipeline.
- Add a PowerShell installer (`install/install_nsc.ps1`).
- Enable Windows virtual terminal processing so styled CLI output renders correctly in PowerShell / console hosts.
- Hide and gracefully block commands that depend on Unix sockets and are not yet supported on Windows (`nsc docker`, `nsc docker buildx`, `nsc buildkit`, `nsc exec-scoped`) via `fncobra.MarkAsNotSupportedOnWindows`; no-op on other platforms.

## Test plan

- `go build ./cmd/...` and cross-compile `GOOS=windows GOARCH=amd64` for `nsc` and both credential helpers.
- `go vet` on the changed packages.
- Manually verified on a Windows instance: installer runs, `nsc.exe` works, blocked commands print the not-supported message and are hidden from help, and colored output renders.