### PR TITLE
nsc: add optional remote execution to bazel setup

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -49,6 +49,7 @@ func NewBazelCmd() *cobra.Command {
 
 	cmd.AddCommand(cache)
 	cmd.AddCommand(execution)
+	cmd.AddCommand(newSetupBazelCmd())
 
 	return cmd
 }

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -35,9 +35,18 @@ const (
 )
 
 func newSetupExecutionCmd() *cobra.Command {
+	return newSetupExecutionCmdWithRemoteFlag(false)
+}
+
+func newSetupBazelCmd() *cobra.Command {
+	return newSetupExecutionCmdWithRemoteFlag(true)
+}
+
+func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 	var bazelRcPath, output, bazelCommand, key string
 	var staticDur time.Duration
 	var static, enableRemoteAssetAPI bool
+	remote := true
 
 	return fncobra.Cmd(&cobra.Command{
 		Use:    "setup",
@@ -51,6 +60,9 @@ func newSetupExecutionCmd() *cobra.Command {
 		flags.BoolVar(&static, "static", false, "If specified, authenticate using a static bearer token in --remote_header against the public endpoints instead of issuing an mTLS client certificate.")
 		flags.BoolVar(&enableRemoteAssetAPI, "enable_remote_asset_api", false, "If specified, opt-in to the remote asset API and configure bazel's --experimental_remote_downloader.")
 		fncobra.DurationVar(flags, &staticDur, "static_token_duration", 4*time.Hour, "The minimum duration of the static token configured (requires --static).")
+		if includeRemoteFlag {
+			flags.BoolVar(&remote, "remote", true, "If false, configure remote caching and build events without remote execution.")
+		}
 	}).Do(func(ctx context.Context) error {
 		tok, err := fnapi.FetchToken(ctx)
 		if err != nil {
@@ -133,7 +145,7 @@ func newSetupExecutionCmd() *cobra.Command {
 		out.CredentialHelperDomains = res.CredentialHelperDomains
 
 		if bazelRcPath != "" {
-			data, err := toBazelExecutionConfig(ctx, out, bazelCommand)
+			data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote)
 			if err != nil {
 				return err
 			}
@@ -157,7 +169,7 @@ func newSetupExecutionCmd() *cobra.Command {
 			}
 
 			if bazelRcPath == "" {
-				data, err := toBazelExecutionConfig(ctx, out, bazelCommand)
+				data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote)
 				if err != nil {
 					return err
 				}
@@ -170,7 +182,11 @@ func newSetupExecutionCmd() *cobra.Command {
 				bazelRcPath = loc
 			}
 
-			fmt.Fprintf(console.Stdout(ctx), "Wrote bazelrc configuration for remote execution to %s.\n", bazelRcPath)
+			configuration := "remote execution"
+			if !remote {
+				configuration = "remote caching without remote execution"
+			}
+			fmt.Fprintf(console.Stdout(ctx), "Wrote bazelrc configuration for %s to %s.\n", configuration, bazelRcPath)
 
 			style := colors.Ctx(ctx)
 			fmt.Fprintf(console.Stdout(ctx), "\nStart using it by adding:\n")
@@ -196,15 +212,20 @@ type bazelRbeSetup struct {
 	CredentialHelperDomains []string      `json:"credential_helper_domains,omitempty"`
 }
 
-func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command string) ([]byte, error) {
+func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command string, remote bool) ([]byte, error) {
 	var buf bytes.Buffer
 
-	lines := []string{
-		fmt.Sprintf("--remote_executor=%s", out.SchedulerEndpoint),
-		fmt.Sprintf("--remote_cache=%s", out.StorageEndpoint),
-		"--spawn_strategy=remote",
-		"--genrule_strategy=remote",
-		fmt.Sprintf("--remote_local_fallback=%t", out.RemoteLocalFallback),
+	var lines []string
+	if remote {
+		lines = append(lines, fmt.Sprintf("--remote_executor=%s", out.SchedulerEndpoint))
+	}
+	lines = append(lines, fmt.Sprintf("--remote_cache=%s", out.StorageEndpoint))
+	if remote {
+		lines = append(lines,
+			"--spawn_strategy=remote",
+			"--genrule_strategy=remote",
+			fmt.Sprintf("--remote_local_fallback=%t", out.RemoteLocalFallback),
+		)
 	}
 
 	if out.ClientCert != "" {

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
@@ -18,7 +19,7 @@ func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
 		StorageEndpoint:    "grpcs://storage.example:443",
 		IngressAuthToken:   "tok123",
 		BuildEventEndpoint: "grpcs://api.us-east1.namespaceapis.com",
-	}, "build")
+	}, "build", true)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 		ClientKey:               "/tmp/client.key",
 		BuildEventEndpoint:      "grpcs://api.us-east1.namespaceapis.com",
 		CredentialHelperDomains: []string{"api.us-east1.namespaceapis.com"},
-	}, "build")
+	}, "build", true)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 		StorageEndpoint:   "grpcs://storage.example:444",
 		ClientCert:        "/tmp/client.cert",
 		ClientKey:         "/tmp/client.key",
-	}, "build")
+	}, "build", true)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -85,5 +86,77 @@ func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 	got := string(config)
 	if strings.Contains(got, "--bes_backend") || strings.Contains(got, "credential_helper") {
 		t.Fatalf("must not configure build events when no endpoint is returned: %q", got)
+	}
+}
+
+func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
+	t.Parallel()
+
+	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		SchedulerEndpoint:     "grpcs://scheduler.example:443",
+		StorageEndpoint:       "grpcs://storage.example:443",
+		IngressAuthToken:      "tok123",
+		RemoteLocalFallback:   true,
+		RemoteDownloadOutputs: "minimal",
+		RemoteTimeout:         5 * time.Minute,
+		Jobs:                  32,
+		BuildEventEndpoint:    "grpcs://api.us-east1.namespaceapis.com",
+	}, "build", false)
+	if err != nil {
+		t.Fatalf("toBazelExecutionConfig: %v", err)
+	}
+
+	got := string(config)
+	for _, want := range []string{
+		"build --remote_cache=grpcs://storage.example:443\n",
+		"build --remote_header=x-nsc-ingress-auth=Bearer\\ tok123\n",
+		"build --remote_download_outputs=minimal\n",
+		"build --jobs=32\n",
+		"build --remote_timeout=300\n",
+		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing config line %q in %q", want, got)
+		}
+	}
+
+	for _, unwanted := range []string{
+		"--remote_executor=",
+		"--spawn_strategy=remote",
+		"--genrule_strategy=remote",
+		"--remote_local_fallback=",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("remote execution config %q present in %q", unwanted, got)
+		}
+	}
+}
+
+func TestNewBazelCmdSetupAlias(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewBazelCmd()
+	setup, _, err := cmd.Find([]string{"setup"})
+	if err != nil {
+		t.Fatalf("finding bazel setup: %v", err)
+	}
+	if !setup.Hidden {
+		t.Fatal("bazel setup must be hidden")
+	}
+
+	remote := setup.Flags().Lookup("remote")
+	if remote == nil {
+		t.Fatal("bazel setup is missing --remote")
+	}
+	if remote.DefValue != "true" {
+		t.Fatalf("--remote default = %q, want true", remote.DefValue)
+	}
+
+	executionSetup, _, err := cmd.Find([]string{"execution", "setup"})
+	if err != nil {
+		t.Fatalf("finding bazel execution setup: %v", err)
+	}
+	if executionSetup.Flags().Lookup("remote") != nil {
+		t.Fatal("bazel execution setup must not expose --remote")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a hidden `nsc bazel setup` command with remote execution enabled by default.
- Supports `--remote=false` to configure remote caching and build events without adding remote execution flags to the generated bazelrc.

## Validation

- `go test ./internal/cli/cmd/cluster -count=1`
- `go build -o /tmp/nsc-foundation ./cmd/nsc`
- Verified the hidden command and `--remote` default through the built CLI help output.