### PR TITLE
cli/cluster: add --use_public_api to nsc create

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -76,9 +76,62 @@ func NewCreateCmd() *cobra.Command {
 	_ = cmd.Flags().Bool("compute_api", true, "Whether to use the Compute API.")
 	cmd.Flags().MarkHidden("compute_api")
 
+	// Opt-in to the public compute API path (see create_publicapi.go).
+	// usePublicAPIDefault is the single source of truth for the default: flipping
+	// it to true makes the public path the default, and --no_use_public_api the
+	// way to opt back out. Both flags stay hidden while this is experimental.
+	const usePublicAPIDefault = false
+	usePublicAPIFlag := cmd.Flags().Bool("use_public_api", usePublicAPIDefault, "Use the public compute API to create the instance.")
+	noUsePublicAPIFlag := cmd.Flags().Bool("no_use_public_api", false, "Do not use the public compute API to create the instance.")
+	cmd.Flags().MarkHidden("use_public_api")
+	cmd.Flags().MarkHidden("no_use_public_api")
+	cmd.MarkFlagsMutuallyExclusive("use_public_api", "no_use_public_api")
+
 	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
 		if *unusedEphemeral {
 			fmt.Fprintf(console.Warnings(ctx), "--ephemeral has been removed and does impact the creation request (try --machine_type instead)")
+		}
+
+		// The default lives in the flag's default value; --no_use_public_api
+		// inverts it. Mutual exclusivity guarantees at most one is set.
+		usePublicAPI := *usePublicAPIFlag
+		if cmd.Flags().Changed("no_use_public_api") {
+			usePublicAPI = !*noUsePublicAPIFlag
+		}
+
+		if usePublicAPI {
+			if err := ensurePublicAPISupportsFlags(cmd); err != nil {
+				return err
+			}
+
+			cluster, err := createInstanceViaPublicAPI(ctx, createInstanceFlags{
+				machineType: *machineType,
+				features:    *features,
+				bare:        *bare,
+				labels:      *labels,
+				purpose:     *purpose,
+				selectors:   *selectors,
+				ingress:     *ingress,
+				sshKey:      *userSshey,
+				enable:      *enable,
+				volumes:     *volumes,
+				duration:    *duration,
+			}, *waitTimeout)
+			if err != nil {
+				return err
+			}
+
+			if *waitKubeSystem {
+				if err := ctl.WaitKubeSystem(ctx, cluster.Cluster); err != nil {
+					return err
+				}
+			}
+
+			if err := writeInstanceOutputFiles(ctx, cluster, *legacyOutputPath, *cidfile, *outputRegistryPath, *outputJsonPath); err != nil {
+				return err
+			}
+
+			return printInstanceCreated(ctx, *output, cluster)
 		}
 
 		opts := api.CreateInstanceOpts{
@@ -237,106 +290,124 @@ func NewCreateCmd() *cobra.Command {
 			}
 		}
 
-		if *legacyOutputPath != "" {
-			if err := os.WriteFile(*legacyOutputPath, []byte(cluster.ClusterId), 0644); err != nil {
-				return fnerrors.Newf("failed to write %q: %w", *legacyOutputPath, err)
-			}
+		if err := writeInstanceOutputFiles(ctx, cluster, *legacyOutputPath, *cidfile, *outputRegistryPath, *outputJsonPath); err != nil {
+			return err
 		}
 
-		if *cidfile != "" {
-			if err := os.WriteFile(*cidfile, []byte(cluster.ClusterId), 0644); err != nil {
-				return fnerrors.Newf("failed to write %q: %w", *cidfile, err)
-			}
-		}
-
-		if *outputRegistryPath != "" {
-			reg, err := api.GetImageRegistry(ctx, api.Methods)
-			if err != nil {
-				return fnerrors.Newf("failed to fetch registry: %w", err)
-			}
-
-			if err := os.WriteFile(*outputRegistryPath, []byte(reg.NSCR.EndpointAddress), 0644); err != nil {
-				return fnerrors.Newf("failed to write %q: %w", *outputRegistryPath, err)
-			}
-		}
-
-		if *outputJsonPath != "" {
-			if cluster.Cluster == nil {
-				return fnerrors.New("no instance information available with no wait timeout")
-			}
-
-			// Clear out secrets from output.
-			copy := *cluster.Cluster
-			copy.SshPrivateKey = nil
-			copy.CertificateAuthorityData = nil
-			copy.ClientCertificateData = nil
-			copy.ClientKeyData = nil
-
-			serialized, err := json.MarshalIndent(copy, "", "  ")
-			if err != nil {
-				return fnerrors.Newf("failed to serialize: %v", err)
-			}
-
-			if err := os.WriteFile(*outputJsonPath, serialized, 0644); err != nil {
-				return fnerrors.Newf("failed to write %q: %w", *outputJsonPath, err)
-			}
-		}
-
-		switch *output {
-		case "json":
-			enc := json.NewEncoder(console.Stdout(ctx))
-			enc.SetIndent("", "  ")
-
-			out := createOutput{
-				ClusterId:  cluster.ClusterId,
-				InstanceId: cluster.ClusterId,
-			}
-
-			if cluster.Cluster != nil {
-				out.ClusterUrl = cluster.Cluster.AppURL
-				out.IngressDomain = cluster.Cluster.IngressDomain
-				out.ApiEndpoint = cluster.Cluster.ApiEndpoint
-			}
-
-			if err := enc.Encode(out); err != nil {
-				return fnerrors.InternalError("failed to encode instance as JSON output: %w", err)
-			}
-
-		default:
-			if *output != "plain" {
-				fmt.Fprintf(console.Warnings(ctx), "defaulting output to plain\n")
-			}
-
-			printNewEnv(ctx, cluster.ClusterId, cluster.Cluster.AppURL)
-
-			if api.ClusterService(cluster.Cluster, "kubernetes") != nil {
-				stdout := console.Stdout(ctx)
-				style := colors.Ctx(ctx)
-				fmt.Fprintln(stdout)
-				fmt.Fprintf(stdout, "  As a next step, try one of:\n\n")
-				fmt.Fprintf(stdout, "    $ nsc kubectl %s get pod -A\n\n", cluster.ClusterId)
-				fmt.Fprintf(stdout, "    $ nsc kubeconfig write %s\n", cluster.ClusterId)
-				fmt.Fprintf(stdout, "      %s\n", style.Comment.Apply("<follow instructions>"))
-				fmt.Fprintf(stdout, "    $ kubectl get pod -A\n\n")
-				fmt.Fprintf(stdout, "  You can also connect to a shell in the new environment:\n\n")
-				fmt.Fprintf(stdout, "    $ nsc ssh %s\n\n", cluster.ClusterId)
-			}
-
-			if cluster.Cluster != nil && len(cluster.Cluster.TlsBackedPort) > 0 {
-				stdout := console.Stdout(ctx)
-				fmt.Fprintln(stdout)
-				fmt.Fprintf(stdout, "  (Experimental) TLS backend ports:\n\n")
-				for _, port := range cluster.Cluster.TlsBackedPort {
-					fmt.Fprintf(stdout, "    %s (%s/%d)\n", port.ServerName, port.Name, port.Port)
-				}
-				fmt.Fprintln(stdout)
-			}
-		}
-
-		return nil
+		return printInstanceCreated(ctx, *output, cluster)
 	})
 
 	return cmd
+}
+
+// writeInstanceOutputFiles writes the optional instance output files requested
+// via flags (--output_to, --cidfile, --output_registry_to, --output_json_to).
+// It is shared by the public and private create paths.
+func writeInstanceOutputFiles(ctx context.Context, cluster *api.CreateClusterResult, outputToPath, cidfile, outputRegistryPath, outputJsonPath string) error {
+	if outputToPath != "" {
+		if err := os.WriteFile(outputToPath, []byte(cluster.ClusterId), 0644); err != nil {
+			return fnerrors.Newf("failed to write %q: %w", outputToPath, err)
+		}
+	}
+
+	if cidfile != "" {
+		if err := os.WriteFile(cidfile, []byte(cluster.ClusterId), 0644); err != nil {
+			return fnerrors.Newf("failed to write %q: %w", cidfile, err)
+		}
+	}
+
+	if outputRegistryPath != "" {
+		reg, err := api.GetImageRegistry(ctx, api.Methods)
+		if err != nil {
+			return fnerrors.Newf("failed to fetch registry: %w", err)
+		}
+
+		if err := os.WriteFile(outputRegistryPath, []byte(reg.NSCR.EndpointAddress), 0644); err != nil {
+			return fnerrors.Newf("failed to write %q: %w", outputRegistryPath, err)
+		}
+	}
+
+	if outputJsonPath != "" {
+		if cluster.Cluster == nil {
+			return fnerrors.New("no instance information available with no wait timeout")
+		}
+
+		// Clear out secrets from output.
+		copy := *cluster.Cluster
+		copy.SshPrivateKey = nil
+		copy.CertificateAuthorityData = nil
+		copy.ClientCertificateData = nil
+		copy.ClientKeyData = nil
+
+		serialized, err := json.MarshalIndent(copy, "", "  ")
+		if err != nil {
+			return fnerrors.Newf("failed to serialize: %v", err)
+		}
+
+		if err := os.WriteFile(outputJsonPath, serialized, 0644); err != nil {
+			return fnerrors.Newf("failed to write %q: %w", outputJsonPath, err)
+		}
+	}
+
+	return nil
+}
+
+// printInstanceCreated renders the success output for a newly created (and
+// waited-for) instance. It is shared by the public and private create paths so
+// both emit identical messages.
+func printInstanceCreated(ctx context.Context, output string, cluster *api.CreateClusterResult) error {
+	switch output {
+	case "json":
+		enc := json.NewEncoder(console.Stdout(ctx))
+		enc.SetIndent("", "  ")
+
+		out := createOutput{
+			ClusterId:  cluster.ClusterId,
+			InstanceId: cluster.ClusterId,
+		}
+
+		if cluster.Cluster != nil {
+			out.ClusterUrl = cluster.Cluster.AppURL
+			out.IngressDomain = cluster.Cluster.IngressDomain
+			out.ApiEndpoint = cluster.Cluster.ApiEndpoint
+		}
+
+		if err := enc.Encode(out); err != nil {
+			return fnerrors.InternalError("failed to encode instance as JSON output: %w", err)
+		}
+
+	default:
+		if output != "plain" {
+			fmt.Fprintf(console.Warnings(ctx), "defaulting output to plain\n")
+		}
+
+		printNewEnv(ctx, cluster.ClusterId, cluster.Cluster.AppURL)
+
+		if api.ClusterService(cluster.Cluster, "kubernetes") != nil {
+			stdout := console.Stdout(ctx)
+			style := colors.Ctx(ctx)
+			fmt.Fprintln(stdout)
+			fmt.Fprintf(stdout, "  As a next step, try one of:\n\n")
+			fmt.Fprintf(stdout, "    $ nsc kubectl %s get pod -A\n\n", cluster.ClusterId)
+			fmt.Fprintf(stdout, "    $ nsc kubeconfig write %s\n", cluster.ClusterId)
+			fmt.Fprintf(stdout, "      %s\n", style.Comment.Apply("<follow instructions>"))
+			fmt.Fprintf(stdout, "    $ kubectl get pod -A\n\n")
+			fmt.Fprintf(stdout, "  You can also connect to a shell in the new environment:\n\n")
+			fmt.Fprintf(stdout, "    $ nsc ssh %s\n\n", cluster.ClusterId)
+		}
+
+		if cluster.Cluster != nil && len(cluster.Cluster.TlsBackedPort) > 0 {
+			stdout := console.Stdout(ctx)
+			fmt.Fprintln(stdout)
+			fmt.Fprintf(stdout, "  (Experimental) TLS backend ports:\n\n")
+			for _, port := range cluster.Cluster.TlsBackedPort {
+				fmt.Fprintf(stdout, "    %s (%s/%d)\n", port.ServerName, port.Name, port.Port)
+			}
+			fmt.Fprintln(stdout)
+		}
+	}
+
+	return nil
 }
 
 func ParseImageSelectors(selectors []string) ([]*api.LabelEntry, error) {

--- a/internal/cli/cmd/cluster/create_publicapi.go
+++ b/internal/cli/cmd/cluster/create_publicapi.go
@@ -1,0 +1,323 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	computev1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/compute/v1beta"
+	expcompute "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/experimental/compute"
+	"buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/stdlib"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/foundation/internal/providers/nscloud/api"
+	"namespacelabs.dev/foundation/internal/providers/nscloud/api/private"
+)
+
+// This file implements the public compute API path for `nsc create`, gated
+// behind --use_public_api. It is intentionally self-contained: instead of the
+// private InstanceService (api.CreateAndWaitCluster), it reserves an instance
+// through the public ReservationService.ReserveInstance API and waits for it to
+// become ready. Once the legacy private path is removed, deleting the else
+// branch in NewCreateCmd and promoting this path is all that is required.
+
+const methodReserveInstance = "namespace.experimental.compute.ReservationService/ReserveInstance"
+
+// reservationFulfillmentWindow caps how long the server is asked to keep trying
+// to fulfill a reservation. The effective deadline is never later than the
+// client-side wait (waitTimeout), so the server never keeps working after we
+// have given up.
+const reservationFulfillmentWindow = 15 * time.Minute
+
+// publicAPIUnsupportedFlags lists `nsc create` flags the public compute API path
+// does not map yet. Setting any of them together with --use_public_api is an
+// error rather than a silent no-op. Remove entries as mappings are added.
+var publicAPIUnsupportedFlags = []string{
+	"unique_tag",
+	"available_secrets",
+	"internal_extra",
+	"experimental",
+	"experimental_from",
+	"experimental_instance_features",
+	"experimental_additional_workload_permissions",
+}
+
+// ensurePublicAPISupportsFlags fails if the caller explicitly set a flag the
+// public compute API path cannot honor, so its meaning is never silently
+// dropped.
+func ensurePublicAPISupportsFlags(cmd *cobra.Command) error {
+	var set []string
+	for _, name := range publicAPIUnsupportedFlags {
+		if cmd.Flags().Changed(name) {
+			set = append(set, "--"+name)
+		}
+	}
+
+	if len(set) > 0 {
+		return fnerrors.Newf("--use_public_api does not support %s yet", strings.Join(set, ", "))
+	}
+
+	return nil
+}
+
+// createInstanceFlags is the subset of `nsc create` flags that the public
+// compute API path understands. It mirrors the creation-related flags of
+// `nsc create`.
+type createInstanceFlags struct {
+	machineType string
+	features    []string
+	bare        bool
+	labels      map[string]string
+	purpose     string
+	selectors   []string
+	ingress     string
+	sshKey      string
+	enable      []string
+	volumes     []string
+	duration    time.Duration
+}
+
+// createInstanceViaPublicAPI reserves an instance through the public compute
+// ReservationService.ReserveInstance API, waits for the reservation to be
+// fulfilled and the instance to become ready, and returns the cluster result.
+// It is the public-API counterpart to the legacy api.CreateAndWaitCluster path.
+func createInstanceViaPublicAPI(ctx context.Context, flags createInstanceFlags, waitTimeout time.Duration) (*api.CreateClusterResult, error) {
+	// Reservations are asynchronous, so unlike the legacy path this one cannot
+	// return an instance without waiting for fulfillment. Require a bounded wait
+	// so we can always cancel a reservation we stop waiting for.
+	if waitTimeout <= 0 {
+		return nil, fnerrors.Newf("--use_public_api requires a positive --wait_timeout, as it must wait for the instance to be created")
+	}
+
+	instanceReq, err := buildCreateInstanceRequest(flags)
+	if err != nil {
+		return nil, err
+	}
+
+	// Bound the whole reserve+wait sequence by waitTimeout, matching the legacy
+	// path where waitTimeout bounds instance readiness.
+	ctx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+
+	// The reservation deadline must not outlive our own wait: otherwise the
+	// server could still fulfill it (creating an instance) after we have given
+	// up, leaving an instance the caller cannot track. Cap it at the fulfillment
+	// window, but never beyond our wait budget.
+	reservationDeadline := time.Now().Add(reservationFulfillmentWindow)
+	if d, ok := ctx.Deadline(); ok && d.Before(reservationDeadline) {
+		reservationDeadline = d
+	}
+
+	req := &expcompute.ReserveInstanceRequest{
+		CreateInstanceReq:   instanceReq,
+		ReservationDeadline: timestamppb.New(reservationDeadline),
+	}
+
+	resp := &expcompute.ReserveInstanceResponse{}
+	if err := callReservation(ctx, methodReserveInstance, req, resp); err != nil {
+		return nil, fnerrors.Newf("failed to reserve instance: %w", err)
+	}
+
+	reservationID := resp.GetReservationId()
+
+	instanceID, err := waitReservation(ctx, reservationID)
+	if err != nil {
+		// We gave up before the reservation was fulfilled; cancel it best-effort
+		// so the server does not create an instance we can no longer track.
+		cancelReservationBestEffort(ctx, reservationID)
+		return nil, err
+	}
+
+	// The readiness stream must target the instance's own API endpoint, so
+	// resolve it before waiting for readiness.
+	info, err := api.GetCluster(ctx, api.Methods, instanceID)
+	if err != nil {
+		return nil, fnerrors.Newf("failed to fetch instance %s: %w", instanceID, err)
+	}
+
+	var apiEndpoint string
+	if info.Cluster != nil {
+		apiEndpoint = info.Cluster.ApiEndpoint
+	}
+
+	// ctx already bounds this by the remaining wait budget; waitTimeout is the
+	// upper bound, whichever is shorter wins.
+	return api.WaitClusterReady(ctx, api.Methods, instanceID, waitTimeout, api.WaitClusterOpts{
+		WaitKind:    "kubernetes",
+		ApiEndpoint: apiEndpoint,
+	})
+}
+
+// cancelReservationBestEffort cancels a not-yet-fulfilled reservation, ignoring
+// errors. It uses a detached context so cancellation still runs after the
+// creation context has expired.
+func cancelReservationBestEffort(ctx context.Context, reservationID string) {
+	if reservationID == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+
+	_ = callReservation(ctx, methodCancelReservation, &expcompute.CancelReservationRequest{ReservationId: reservationID}, &expcompute.CancelReservationResponse{})
+}
+
+// buildCreateInstanceRequest translates the CLI flags into a public compute
+// CreateInstanceRequest, mirroring how the legacy path builds
+// api.CreateInstanceOpts.
+func buildCreateInstanceRequest(flags createInstanceFlags) (*computev1beta.CreateInstanceRequest, error) {
+	req := &computev1beta.CreateInstanceRequest{
+		DocumentedPurpose: flags.purpose,
+	}
+
+	exp := &computev1beta.CreateInstanceRequest_ExperimentalFeatures{
+		PrivateFeature: flags.features,
+	}
+
+	// Shape.
+	var shape *computev1beta.InstanceShape
+	if flags.machineType != "" {
+		os, arch, vcpu, memoryMB, err := ParseMachineTypeShape(flags.machineType)
+		if err != nil {
+			return nil, err
+		}
+
+		shape = &computev1beta.InstanceShape{
+			VirtualCpu:      vcpu,
+			MemoryMegabytes: memoryMB,
+			MachineArch:     arch,
+			Os:              os,
+		}
+	}
+
+	for _, s := range flags.selectors {
+		k, v, ok := strings.Cut(s, "=")
+		if !ok {
+			return nil, fnerrors.Newf("invalid selector %q: expected key=value", s)
+		}
+
+		if shape == nil {
+			shape = &computev1beta.InstanceShape{}
+		}
+
+		shape.Selectors = append(shape.Selectors, &stdlib.Label{Name: k, Value: v})
+	}
+
+	req.Shape = shape
+
+	// Labels.
+	labels := flags.labels
+	if len(labels) == 0 {
+		labels = map[string]string{"nsc.source": "nsc"}
+	}
+
+	labelKeys := maps.Keys(labels)
+	slices.Sort(labelKeys)
+	for _, key := range labelKeys {
+		req.Labels = append(req.Labels, &stdlib.Label{Name: key, Value: labels[key]})
+	}
+
+	// SSH keys.
+	keys, err := parseAuthorizedKeys(flags.sshKey)
+	if err != nil {
+		return nil, err
+	}
+	exp.AuthorizedSshKeys = keys
+
+	// Volumes.
+	for _, def := range flags.volumes {
+		spec, err := ParseVolumeFlag(def)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Volumes = append(req.Volumes, &computev1beta.VolumeRequest{
+			MountPoint:      spec.MountPoint,
+			Tag:             spec.Tag,
+			SizeMb:          spec.SizeMb,
+			PersistencyKind: volumePersistencyKind(spec.PersistencyKind),
+		})
+	}
+
+	if flags.bare {
+		exp.PrivateFeature = append(exp.PrivateFeature, "EXP_DISABLE_KUBERNETES")
+	}
+
+	// Default to single-node Kubernetes on Linux, matching `nsc create`.
+	if !flags.bare && !strings.HasPrefix(flags.machineType, "mac") && !strings.HasPrefix(flags.machineType, "windows") {
+		req.FeatureConfiguration = &computev1beta.CreateInstanceRequest_FeatureConfiguration{
+			EnableKubernetesVersion: private.K3sVersion,
+		}
+	}
+
+	for _, feat := range flags.enable {
+		parts := strings.SplitN(feat, ":", 2)
+		switch parts[0] {
+		case "kubernetes":
+			if len(parts) != 2 {
+				return nil, fnerrors.Newf("expected Kubernetes version spec %q", feat)
+			}
+
+			if req.FeatureConfiguration == nil {
+				req.FeatureConfiguration = &computev1beta.CreateInstanceRequest_FeatureConfiguration{}
+			}
+			req.FeatureConfiguration.EnableKubernetesVersion = parts[1]
+
+		case "kubernetes-max-pods":
+			if len(parts) != 2 {
+				return nil, fnerrors.Newf("expected kubernetes-max-pods value %q", feat)
+			}
+
+			n, err := strconv.ParseInt(parts[1], 10, 32)
+			if err != nil {
+				return nil, fnerrors.Newf("invalid kubernetes-max-pods value %q: %w", parts[1], err)
+			}
+
+			if req.FeatureConfiguration == nil {
+				return nil, fnerrors.Newf("kubernetes-max-pods requires Kubernetes to be enabled")
+			}
+			req.FeatureConfiguration.KubernetesMaxPods = int32(n)
+
+		default:
+			return nil, fnerrors.Newf("unknown feature option %q", parts[0])
+		}
+	}
+
+	switch flags.ingress {
+	case "":
+		// nothing to do
+
+	case "wildcard":
+		exp.EnableWildcardDomain = true
+
+	default:
+		return nil, fnerrors.Newf("unknown ingress option %q", flags.ingress)
+	}
+
+	if flags.duration > 0 {
+		req.Deadline = timestamppb.New(time.Now().Add(flags.duration))
+	}
+
+	req.Experimental = exp
+
+	return req, nil
+}
+
+func volumePersistencyKind(kind api.VolumeSpec_PersistencyKind) computev1beta.VolumeRequest_PersistencyKind {
+	switch kind {
+	case api.VolumeSpec_PERSISTENT:
+		return computev1beta.VolumeRequest_PERSISTENT
+	case api.VolumeSpec_CACHE:
+		return computev1beta.VolumeRequest_CACHE
+	default:
+		return computev1beta.VolumeRequest_PERSISTENCY_UNKNOWN
+	}
+}

--- a/internal/cli/cmd/cluster/machinetype.go
+++ b/internal/cli/cmd/cluster/machinetype.go
@@ -32,3 +32,32 @@ func ParseMachineType(machineType string) (vcpu int32, memoryMB int32, err error
 
 	return int32(cpu), int32(memoryGB * 1024), nil
 }
+
+// ParseMachineTypeShape parses a machine type string in the format
+// "[os/arch:]<cpu>x<memoryGB>" (e.g. "4x8" or "linux/arm64:2x8") and returns the
+// operating system, architecture, vCPU count, and memory in megabytes. The
+// "os/arch:" prefix is optional; when omitted, os and arch are returned empty
+// and the server picks defaults.
+func ParseMachineTypeShape(machineType string) (os, arch string, vcpu, memoryMB int32, err error) {
+	shape := machineType
+	if prefix, rest, ok := strings.Cut(machineType, ":"); ok {
+		o, a, ok := strings.Cut(prefix, "/")
+		if !ok || o == "" || a == "" {
+			return "", "", 0, 0, fnerrors.Newf("invalid machine_type format: expected '[os/arch:]<cpu>x<memGB>' (e.g. 'linux/arm64:2x8'), got %q", machineType)
+		}
+
+		// Legacy alias: "mac/silicon" is an alias for "macos/arm64".
+		if o == "mac" && a == "silicon" {
+			o, a = "macos", "arm64"
+		}
+
+		os, arch, shape = o, a, rest
+	}
+
+	vcpu, memoryMB, err = ParseMachineType(shape)
+	if err != nil {
+		return "", "", 0, 0, err
+	}
+
+	return os, arch, vcpu, memoryMB, nil
+}

--- a/internal/providers/nscloud/api/private/instance.go
+++ b/internal/providers/nscloud/api/private/instance.go
@@ -18,8 +18,10 @@ import (
 )
 
 var (
+	K3sVersion = "1.32"
+
 	K3sCfg = map[string]any{
-		"kubernetes_version": "1.32",
+		"kubernetes_version": K3sVersion,
 	}
 )
 


### PR DESCRIPTION
Start moving `nsc create` onto the public compute API.

Adds a hidden `--use_public_api` flag (default **false**) with a `--no_use_public_api` counterpart, so the default can be flipped in a single line later. When enabled, `nsc create` creates the instance through the public compute `ReservationService.ReserveInstance` API (waiting for the reservation to be fulfilled and the instance to become ready) instead of the legacy private `InstanceService` (`api.CreateAndWaitCluster`).

This reuses the logic that was implemented for the (now-dropped) `nsc reservation create` command — see #1868.

### Clean split for trivial legacy removal
The public path is fully self-contained in `create_publicapi.go`. Removing the legacy path later means deleting the `else`/fall-through in `NewCreateCmd` and promoting the public branch; the shared output helpers stay.

### Correctness safeguards
- The reservation deadline never outlives the client-side wait, and a reservation we stop waiting for is cancelled best-effort, so we never leave an untracked instance.
- `--use_public_api` requires a positive `--wait_timeout` (the reservation flow is async and must wait for an instance).
- Explicitly-set `nsc create` flags the public path does not map yet (`--unique_tag`, `--available_secrets`, `--internal_extra`, `--experimental*`) are rejected rather than silently dropped. Remove entries from `publicAPIUnsupportedFlags` as mappings are added.

### Shared behavior
Output and side-effect files are shared between both paths via the extracted `writeInstanceOutputFiles` and `printInstanceCreated` helpers; the JSON/plain output is byte-for-byte identical to legacy `nsc create`.

### Verification
- build + `go vet` clean; hidden flags absent from `--help`; mutual-exclusivity, unsupported-flag, and `wait_timeout=0` guards all error correctly.
- Live `nsc create --use_public_api` (plain and `-o json`) created ready instances with output identical to legacy `nsc create`; both destroyed.

Amp-Thread-ID: https://ampcode.com/threads/T-019f1880-ac56-7349-b5df-36566f7fc069