### PR TITLE
release: publish the Windows PowerShell installer

### DIFF
--- a/tools/release-tigris/main.go
+++ b/tools/release-tigris/main.go
@@ -71,8 +71,9 @@ func runInstallers(ctx context.Context, args []string) error {
 		Endpoint:  *endpoint,
 		KeyPrefix: foundationKeyPrefix,
 		Installers: map[string]string{
-			"install/install.sh":     "install/install.sh",
-			"install/install_nsc.sh": "install/install_nsc.sh",
+			"install/install.sh":      "install/install.sh",
+			"install/install_nsc.sh":  "install/install_nsc.sh",
+			"install/install_nsc.ps1": "install/install_nsc.ps1",
 		},
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #1864. Uploads `install/install_nsc.ps1` alongside the shell installers so the Windows one-liner resolves:

```powershell
irm https://get.namespace.so/cloud/install_nsc.ps1 | iex
```

## Test plan

- `go build ./tools/release-tigris/...`