### PR TITLE
nsc: use public Bazel service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.0
 
 require (
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260710132230-2e3db39f86b8.1
-	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260710132230-2e3db39f86b8.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260710132230-2e3db39f86b8.1
+	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260712213844-83c43e91b37d.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260712213844-83c43e91b37d.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.20.0
@@ -157,6 +157,7 @@ require (
 )
 
 require (
+	buf.build/gen/go/bazel/bazel/protocolbuffers/go v1.36.11-20251112223041-697bc75dbe09.1 // indirect
 	cloud.google.com/go v0.121.6 // indirect
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
+buf.build/gen/go/bazel/bazel/protocolbuffers/go v1.36.11-20251112223041-697bc75dbe09.1 h1:1XnPNVAb9QgwVbG3nsdxDI2UuNBvOelFqhjqX1mWt48=
+buf.build/gen/go/bazel/bazel/protocolbuffers/go v1.36.11-20251112223041-697bc75dbe09.1/go.mod h1:botG+8yfIpysChg+Siu8ZZpjDt9ZM8bqc0TpJoKLaUA=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260710132230-2e3db39f86b8.1 h1:lYvTzzkA4u3zH8BxrUHKszNJuBJ+sqiFKdeYCqBGNsw=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260710132230-2e3db39f86b8.1/go.mod h1:XPkgH/znMAiRNt+1f684zk7o3SYJw8nHZ0ciVMDUGys=
-buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260710132230-2e3db39f86b8.1 h1:0aNSPaeuy87i4s/Xso0/hbUwc8mAJZqxFYICT456VKE=
-buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260710132230-2e3db39f86b8.1/go.mod h1:c3y6Ncy+gi1/e8XTyf15FfbMzuQqr1V9hIE2NnLl1Mo=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260710132230-2e3db39f86b8.1 h1:16poaI6rJYMDvwf5LYYZcBHkuvuipQkJN4UizbkLHUU=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260710132230-2e3db39f86b8.1/go.mod h1:Il2wpJNQB40Yj3Rmuhg5xKJPSXaZVwij+Q30d1PNuNY=
+buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260712213844-83c43e91b37d.1 h1:fnhzqIEfQ/z94uyv6Q3sxko7WJsWZDZQV1ea09MrzlE=
+buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260712213844-83c43e91b37d.1/go.mod h1:XWNY0GInuLgSvYTydIFlii8Zkzu7OTXESbks9ejhnrA=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260712213844-83c43e91b37d.1 h1:ovKw+lfR6inkQteZMhZAGib0Rvxv81KLu5WpfiPLAS4=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260712213844-83c43e91b37d.1/go.mod h1:rM1SQt83F9wfd5fTF5pl3r3UvzBokLmqa+ulh1iSp9M=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"google.golang.org/protobuf/encoding/protojson"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
@@ -46,12 +48,66 @@ func NewBazelCmd() *cobra.Command {
 		Hidden: true,
 	}
 	execution.AddCommand(newSetupExecutionCmd())
+	invocation := &cobra.Command{Use: "invocation", Short: "Bazel invocation related functionality."}
+	invocation.AddCommand(newBazelInvocationReportCmd())
 
 	cmd.AddCommand(cache)
 	cmd.AddCommand(execution)
+	cmd.AddCommand(invocation)
 	cmd.AddCommand(newSetupBazelCmd())
 
 	return cmd
+}
+
+func newBazelInvocationReportCmd() *cobra.Command {
+	return fncobra.Cmd(&cobra.Command{
+		Use:   "report [invocation-id]",
+		Short: "Stream a JSON report for a Bazel invocation.",
+		Args:  cobra.ExactArgs(1),
+	}).DoWithArgs(func(ctx context.Context, args []string) error {
+		tok, err := fnapi.FetchToken(ctx)
+		if err != nil {
+			return err
+		}
+
+		client, conn, err := newBazelServiceClient(ctx, tok)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		stream, err := client.StreamInvocationReport(ctx, &bazelv1beta.StreamInvocationReportRequest{InvocationId: args[0]})
+		if err != nil {
+			return fnerrors.Newf("failed to stream Bazel invocation report: %w", err)
+		}
+
+		for {
+			record, err := stream.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if err != nil {
+				return fnerrors.Newf("failed to receive Bazel invocation report: %w", err)
+			}
+
+			if err := writeBazelInvocationReportRecord(console.Stdout(ctx), record); err != nil {
+				return err
+			}
+		}
+	})
+}
+
+func writeBazelInvocationReportRecord(w io.Writer, record *bazelv1beta.StreamInvocationReportResponse) error {
+	encoded, err := (protojson.MarshalOptions{UseProtoNames: true}).Marshal(record)
+	if err != nil {
+		return fnerrors.InternalError("failed to encode Bazel invocation report record: %w", err)
+	}
+
+	if _, err := fmt.Fprintln(w, string(encoded)); err != nil {
+		return fnerrors.InternalError("failed to write Bazel invocation report record: %w", err)
+	}
+
+	return nil
 }
 
 // NewBazelCacheCmd returns a "bazel" command with setup directly

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -10,28 +10,26 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os/exec"
-	"strings"
 	"time"
 
+	bazelv1betagrpc "buf.build/gen/go/namespace/cloud/grpc/go/proto/namespace/cloud/integrations/bazel/v1beta/bazelv1betagrpc"
+	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
 	"namespacelabs.dev/foundation/internal/auth"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/integrations/nsc/grpcapi"
 )
 
 const (
 	bazelExecutionPathBase = "bazelrbe"
 	defaultBazelRbeCommand = "build"
-
-	// TODO: replace with a generated public-proto Connect client
-	bazelExecutionEnsureProcedure = "/namespace.private.bazel.BazelService/EnsureBazelExecutionCluster"
 )
 
 func newSetupExecutionCmd() *cobra.Command {
@@ -69,9 +67,9 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			return err
 		}
 
-		authMode := bazelExecutionAuthModeMTLS
+		authMode := bazelv1beta.BazelExecutionAuthMode_BAZEL_EXECUTION_AUTH_MODE_MTLS
 		if static {
-			authMode = bazelExecutionAuthModeStatic
+			authMode = bazelv1beta.BazelExecutionAuthMode_BAZEL_EXECUTION_AUTH_MODE_STATIC
 		}
 
 		res, err := ensureBazelExecutionCluster(ctx, tok, key, authMode, enableRemoteAssetAPI)
@@ -79,18 +77,18 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			return fnerrors.Newf("failed to provision bazel execution cluster: %w", err)
 		}
 
-		if res.SchedulerEndpoint == "" || res.StorageEndpoint == "" {
-			return fnerrors.Newf("received incomplete response (scheduler=%q storage=%q)", res.SchedulerEndpoint, res.StorageEndpoint)
+		if res.GetSchedulerEndpoint() == "" || res.GetStorageEndpoint() == "" {
+			return fnerrors.Newf("received incomplete response (scheduler=%q storage=%q)", res.GetSchedulerEndpoint(), res.GetStorageEndpoint())
 		}
 
 		out := bazelRbeSetup{
-			SchedulerEndpoint:     res.SchedulerEndpoint,
-			StorageEndpoint:       res.StorageEndpoint,
-			RemoteAssetEndpoint:   res.RemoteAssetEndpoint,
-			Jobs:                  int32(res.Jobs),
-			RemoteTimeout:         time.Duration(res.RemoteTimeoutSeconds) * time.Second,
-			RemoteLocalFallback:   res.RemoteLocalFallback,
-			RemoteDownloadOutputs: res.RemoteDownloadOutputs,
+			SchedulerEndpoint:     res.GetSchedulerEndpoint(),
+			StorageEndpoint:       res.GetStorageEndpoint(),
+			RemoteAssetEndpoint:   res.GetRemoteAssetEndpoint(),
+			Jobs:                  int32(res.GetRecommendedBazelJobs()),
+			RemoteTimeout:         time.Duration(res.GetRecommendedBazelRemoteTimeoutSeconds()) * time.Second,
+			RemoteLocalFallback:   res.GetRecommendedBazelRemoteLocalFallback(),
+			RemoteDownloadOutputs: res.GetRecommendedBazelRemoteDownloadOutputs(),
 		}
 
 		if static {
@@ -141,8 +139,8 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 		// mode. The server only returns it (and the credential helper domains
 		// used to authenticate it in the default mTLS mode) when build event
 		// ingestion is enabled for the workspace.
-		out.BuildEventEndpoint = res.BuildEventEndpoint
-		out.CredentialHelperDomains = res.CredentialHelperDomains
+		out.BuildEventEndpoint = res.GetBuildEventEndpoint()
+		out.CredentialHelperDomains = res.GetCredentialHelperDomains()
 
 		if bazelRcPath != "" {
 			data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote)
@@ -303,82 +301,26 @@ func appendExecutionBuildEventCredentialHelper(ctx context.Context, buf *bytes.B
 	return nil
 }
 
-// BazelExecutionAuthMode mirrors the enum in
-// private/proto/service/bazel/service.proto. The server determines which
-// endpoints to return based on the requested mode.
-const (
-	bazelExecutionAuthModeMTLS   = "BAZEL_EXECUTION_AUTH_MODE_MTLS"
-	bazelExecutionAuthModeStatic = "BAZEL_EXECUTION_AUTH_MODE_STATIC"
-)
+func ensureBazelExecutionCluster(ctx context.Context, tok *auth.Token, key string, authMode bazelv1beta.BazelExecutionAuthMode, enableRemoteAssetAPI bool) (*bazelv1beta.EnsureClusterResponse, error) {
+	client, conn, err := newBazelServiceClient(ctx, tok)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
 
-type ensureBazelExecutionClusterRequest struct {
-	Key string `json:"key,omitempty"`
-	// AuthMode tells the server which authentication mode the client intends to
-	// use; it returns the matching endpoints. Static mode returns the public
-	// bearer-authenticated endpoints and never exposes the mTLS endpoints.
-	AuthMode string `json:"auth_mode,omitempty"`
-	// EnableRemoteAssetApi opts into the remote asset API; when set the server
-	// returns remote_asset_endpoint in the response.
-	EnableRemoteAssetApi bool `json:"enable_remote_asset_api,omitempty"`
+	req := &bazelv1beta.EnsureClusterRequest{}
+	req.SetKey(key)
+	req.SetAuthMode(authMode)
+	req.SetEnableRemoteAssetApi(enableRemoteAssetAPI)
+
+	return client.EnsureCluster(ctx, req)
 }
 
-// Fields mirror EnsureBazelExecutionClusterResponse in
-// private/proto/service/bazel/service.proto. The server marshals with
-// protojson (UseProtoNames=true), so the wire tags are snake_case.
-type ensureBazelExecutionClusterResponse struct {
-	SchedulerEndpoint       string   `json:"scheduler_endpoint,omitempty"`
-	StorageEndpoint         string   `json:"storage_endpoint,omitempty"`
-	RemoteAssetEndpoint     string   `json:"remote_asset_endpoint,omitempty"`
-	Jobs                    uint32   `json:"jobs,omitempty"`
-	RemoteTimeoutSeconds    uint32   `json:"remote_timeout_seconds,omitempty"`
-	RemoteLocalFallback     bool     `json:"remote_local_fallback,omitempty"`
-	RemoteDownloadOutputs   string   `json:"remote_download_outputs,omitempty"`
-	BuildEventEndpoint      string   `json:"build_event_endpoint,omitempty"`
-	CredentialHelperDomains []string `json:"credential_helper_domains,omitempty"`
-}
-
-// ensureBazelExecutionCluster posts to the private BazelService path on the
-// global API endpoint using the connect-json protocol. Once the public proto
-// has the same RPC, replace this with a generated Connect client (mirroring
-// fnapi.NewBazelCacheServiceClient).
-func ensureBazelExecutionCluster(ctx context.Context, tok *auth.Token, key, authMode string, enableRemoteAssetAPI bool) (*ensureBazelExecutionClusterResponse, error) {
-	bearer, err := tok.IssueToken(ctx, 5*time.Minute, false)
+func newBazelServiceClient(ctx context.Context, tok *auth.Token) (bazelv1betagrpc.BazelServiceClient, *grpc.ClientConn, error) {
+	conn, err := grpcapi.NewConnectionWithEndpoint(ctx, fnapi.GlobalEndpoint(), tok)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	body, err := json.Marshal(ensureBazelExecutionClusterRequest{Key: key, AuthMode: authMode, EnableRemoteAssetApi: enableRemoteAssetAPI})
-	if err != nil {
-		return nil, err
-	}
-
-	url := strings.TrimRight(fnapi.GlobalEndpoint(), "/") + bazelExecutionEnsureProcedure
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+bearer)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fnerrors.Newf("EnsureBazelExecutionCluster returned %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
-	}
-
-	out := &ensureBazelExecutionClusterResponse{}
-	if err := json.Unmarshal(raw, out); err != nil {
-		return nil, fnerrors.Newf("failed to parse response: %w", err)
-	}
-
-	return out, nil
+	return bazelv1betagrpc.NewBazelServiceClient(conn), conn, nil
 }

--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -5,6 +5,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -90,6 +91,32 @@ func TestMakeEnsureBazelCacheRequestWithRemoteAsset(t *testing.T) {
 	}
 	if got := msg.GetExperimentalCacheName(); got != "amp-test" {
 		t.Fatalf("unexpected experimental cache name: %q", got)
+	}
+}
+
+func TestWriteBazelInvocationReportRecord(t *testing.T) {
+	t.Parallel()
+
+	record := &bazelv1beta.StreamInvocationReportResponse{
+		BuildToolLogs: []*bazelv1beta.InvocationReportBuildToolLog{{
+			Name: "stdout",
+			Text: "build complete",
+		}},
+	}
+	var output bytes.Buffer
+	if err := writeBazelInvocationReportRecord(&output, record); err != nil {
+		t.Fatalf("writeBazelInvocationReportRecord: %v", err)
+	}
+
+	got := output.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("record is not newline terminated: %q", got)
+	}
+	if !strings.Contains(got, `"build_tool_logs"`) {
+		t.Fatalf("record does not use protobuf field names: %q", got)
+	}
+	if strings.Contains(got, `"buildToolLogs"`) {
+		t.Fatalf("record uses lowerCamelCase JSON field names: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use the generated public `BazelService.EnsureCluster` RPC for Bazel execution setup.
- Add `nsc bazel invocation report`, streaming one underscore-named JSON record per line.
- Update the generated Namespace Cloud gRPC and protobuf dependencies.

## Validation

- `go test ./internal/cli/cmd/cluster -count=1`
- `go build -o /tmp/nsc-bazel-service ./cmd/nsc`
- `go run golang.org/x/tools/cmd/goimports -d --format-only internal/cli/cmd/cluster/bazel.go internal/cli/cmd/cluster/bazel_rbe.go internal/cli/cmd/cluster/bazel_test.go`
- `go mod tidy && git diff --exit-code`
- Ran `nsc bazel execution setup` and completed cached and forced-uncached Abseil `//absl/...` builds against the resulting cluster.