### PR TITLE
nsc: add build logs command

### DIFF
--- a/internal/cli/cmd/cluster/build.go
+++ b/internal/cli/cmd/cluster/build.go
@@ -333,6 +333,8 @@ func NewBuildCmd() *cobra.Command {
 		return nil
 	})
 
+	cmd.AddCommand(newBuildLogsCmd())
+
 	return cmd
 }
 

--- a/internal/cli/cmd/cluster/build_logs.go
+++ b/internal/cli/cmd/cluster/build_logs.go
@@ -1,0 +1,176 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	oldproto "github.com/golang/protobuf/proto"
+	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/progress/progressui"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"namespacelabs.dev/foundation/internal/cli/fncobra"
+	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/fnapi"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/foundation/internal/providers/nscloud/endpoint"
+	"namespacelabs.dev/integrations/nsc/grpcapi"
+)
+
+const streamBuildLogsMethod = "/nsl.vm.builds.GlobalBuildsService/StreamBuildLogs"
+
+// getBuildLogsRequest mirrors the request wire type for StreamBuildLogs.
+type getBuildLogsRequest struct {
+	BuildRef string `protobuf:"bytes,1,opt,name=build_ref,json=buildRef,proto3" json:"build_ref,omitempty"`
+}
+
+func (r *getBuildLogsRequest) Reset()         { *r = getBuildLogsRequest{} }
+func (r *getBuildLogsRequest) String() string { return oldproto.CompactTextString(r) }
+func (*getBuildLogsRequest) ProtoMessage()    {}
+
+func newBuildLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs <build-ref>",
+		Short: "Print logs for a build.",
+		Args:  cobra.ExactArgs(1),
+	}
+
+	output := cmd.Flags().StringP("output", "o", "plain", "Output format. Supported values: plain, json (BuildKit raw JSON, one object per line).")
+
+	cmd.RunE = fncobra.RunE(func(ctx context.Context, args []string) error {
+		if *output != "plain" && *output != "json" {
+			return fnerrors.BadInputError("unsupported output format %q, supported values: plain, json", *output)
+		}
+
+		recv, closeStream, err := openBuildLogsStream(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		defer closeStream()
+
+		return writeBuildLogs(ctx, console.Stdout(ctx), *output, recv)
+	})
+
+	return cmd
+}
+
+func openBuildLogsStream(ctx context.Context, buildRef string) (func() (string, error), func() error, error) {
+	token, err := fnapi.FetchToken(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resolved, err := fnapi.IssueBearerTokenFromToken(ctx, token)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	apiEndpoint, err := endpoint.ResolveRegionalEndpoint(ctx, resolved)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn, err := grpcapi.NewConnectionWithEndpoint(ctx, apiEndpoint, token)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	desc := &grpc.StreamDesc{ServerStreams: true}
+	stream, err := grpc.NewClientStream(ctx, desc, conn, streamBuildLogsMethod)
+	if err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+
+	if err := stream.SendMsg(&getBuildLogsRequest{BuildRef: buildRef}); err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+	if err := stream.CloseSend(); err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+
+	recv := func() (string, error) {
+		msg := &wrapperspb.StringValue{}
+		if err := stream.RecvMsg(msg); err != nil {
+			return "", err
+		}
+		return msg.Value, nil
+	}
+
+	return recv, conn.Close, nil
+}
+
+func writeBuildLogs(ctx context.Context, out io.Writer, output string, recv func() (string, error)) error {
+	var mode progressui.DisplayMode
+	switch output {
+	case "json":
+		mode = progressui.RawJSONMode
+	case "plain":
+		mode = progressui.PlainMode
+	default:
+		return fnerrors.BadInputError("unsupported output format %q, supported values: plain, json", output)
+	}
+
+	display, err := progressui.NewDisplay(out, mode)
+	if err != nil {
+		return err
+	}
+
+	statusCh := make(chan *client.SolveStatus)
+	recvErr := make(chan error, 1)
+	go func() {
+		defer close(statusCh)
+		received := false
+		for {
+			value, err := recv()
+			if isBuildLogsEOF(err, received) {
+				recvErr <- nil
+				return
+			}
+			if err != nil {
+				recvErr <- err
+				return
+			}
+			received = true
+
+			var status controlapi.StatusResponse
+			if err := json.Unmarshal([]byte(value), &status); err != nil {
+				recvErr <- fmt.Errorf("failed to decode build log entry: %w", err)
+				return
+			}
+
+			select {
+			case statusCh <- client.NewSolveStatus(&status):
+			case <-ctx.Done():
+				recvErr <- context.Cause(ctx)
+				return
+			}
+		}
+	}()
+
+	_, displayErr := display.UpdateFrom(ctx, statusCh)
+	if err := <-recvErr; err != nil {
+		return err
+	}
+	return displayErr
+}
+
+func isBuildLogsEOF(err error, received bool) bool {
+	if err == io.EOF {
+		return true
+	}
+
+	return received && status.Code(err) == codes.Internal && status.Convert(err).Message() == "server closed the stream without sending trailers"
+}

--- a/internal/cli/cmd/cluster/build_logs_test.go
+++ b/internal/cli/cmd/cluster/build_logs_test.go
@@ -1,0 +1,112 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	oldproto "github.com/golang/protobuf/proto"
+	oldtimestamp "github.com/golang/protobuf/ptypes/timestamp"
+	controlapi "github.com/moby/buildkit/api/services/control"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetBuildLogsRequestWireFormat(t *testing.T) {
+	got, err := oldproto.Marshal(&getBuildLogsRequest{BuildRef: "ref"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte{0x0a, 0x03, 'r', 'e', 'f'}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("unexpected wire encoding: got %x, want %x", got, want)
+	}
+}
+
+func TestWriteBuildLogsJSON(t *testing.T) {
+	serviceRecord, err := json.Marshal(&controlapi.StatusResponse{
+		Logs: []*controlapi.VertexLog{{
+			Vertex:    "sha256:abc",
+			Timestamp: &oldtimestamp.Timestamp{},
+			Stream:    1,
+			Msg:       []byte("hello\n"),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recv := buildLogReceiver([]string{string(serviceRecord)}, nil)
+	var out bytes.Buffer
+
+	if err := writeBuildLogs(context.Background(), &out, "json", recv); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := out.String(), "{\"logs\":[{\"vertex\":\"sha256:abc\",\"stream\":1,\"data\":\"aGVsbG8K\",\"timestamp\":\"1970-01-01T00:00:00Z\"}]}\n"; got != want {
+		t.Fatalf("unexpected output: got %q, want %q", got, want)
+	}
+}
+
+func TestWriteBuildLogsPlain(t *testing.T) {
+	recv := buildLogReceiver([]string{"{\"vertexes\":[]}"}, nil)
+
+	if err := writeBuildLogs(context.Background(), io.Discard, "plain", recv); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteBuildLogsPropagatesStreamError(t *testing.T) {
+	want := errors.New("stream failed")
+	recv := buildLogReceiver(nil, want)
+
+	if err := writeBuildLogs(context.Background(), io.Discard, "json", recv); !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestWriteBuildLogsAcceptsMissingTrailersAfterData(t *testing.T) {
+	missingTrailers := status.Error(codes.Internal, "server closed the stream without sending trailers")
+	recv := buildLogReceiver([]string{"{\"vertexes\":[]}"}, missingTrailers)
+	var out bytes.Buffer
+
+	if err := writeBuildLogs(context.Background(), &out, "json", recv); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := out.String(), "{}\n"; got != want {
+		t.Fatalf("unexpected output: got %q, want %q", got, want)
+	}
+}
+
+func TestWriteBuildLogsRejectsMissingTrailersWithoutData(t *testing.T) {
+	missingTrailers := status.Error(codes.Internal, "server closed the stream without sending trailers")
+	recv := buildLogReceiver(nil, missingTrailers)
+
+	if err := writeBuildLogs(context.Background(), io.Discard, "json", recv); !errors.Is(err, missingTrailers) {
+		t.Fatalf("got %v, want %v", err, missingTrailers)
+	}
+}
+
+func buildLogReceiver(values []string, finalErr error) func() (string, error) {
+	next := 0
+	return func() (string, error) {
+		if next < len(values) {
+			value := values[next]
+			next++
+			return value, nil
+		}
+		if finalErr != nil {
+			return "", finalErr
+		}
+		return "", io.EOF
+	}
+}


### PR DESCRIPTION
## Summary

- add `nsc build logs <build-ref>` backed by `GlobalBuildsService.StreamBuildLogs`
- support BuildKit plain progress output and BuildKit-compatible raw JSON with `-o json`
- accept the endpoint's missing-trailers termination only after log records have been received

## Testing

- `go test ./internal/cli/cmd/cluster`
- manually verified plain and JSON output against an existing build
