### PR TITLE
nsc: retry Bazel provisioning

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -318,9 +318,9 @@ func newSetupCacheCmd() *cobra.Command {
 
 		msg := makeEnsureBazelCacheRequest(version, experimentalDirect, enableRemoteAssetAPI, experimentalCacheName)
 
-		req := connect.NewRequest(msg)
-
-		resp, err := client.EnsureBazelCache(ctx, req)
+		resp, err := retryBazelProvisioning(ctx, func() (*connect.Response[bazelv1beta.EnsureBazelCacheResponse], error) {
+			return client.EnsureBazelCache(ctx, connect.NewRequest(msg))
+		})
 		if err != nil {
 			return fnerrors.Newf("failed to provision bazel cache: %w", err)
 		}

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -15,9 +15,13 @@ import (
 
 	bazelv1betagrpc "buf.build/gen/go/namespace/cloud/grpc/go/proto/namespace/cloud/integrations/bazel/v1beta/bazelv1betagrpc"
 	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
+	"connectrpc.com/connect"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
@@ -28,8 +32,10 @@ import (
 )
 
 const (
-	bazelExecutionPathBase = "bazelrbe"
-	defaultBazelRbeCommand = "build"
+	bazelExecutionPathBase      = "bazelrbe"
+	defaultBazelRbeCommand      = "build"
+	bazelProvisioningMaxRetries = 3
+	bazelProvisioningRetryWait  = 200 * time.Millisecond
 )
 
 func newSetupExecutionCmd() *cobra.Command {
@@ -326,7 +332,43 @@ func ensureBazelExecutionCluster(ctx context.Context, tok api.TokenSource, key s
 	req.SetAuthMode(authMode)
 	req.SetEnableRemoteAssetApi(enableRemoteAssetAPI)
 
-	return client.EnsureCluster(ctx, req)
+	return retryBazelProvisioning(ctx, func() (*bazelv1beta.EnsureClusterResponse, error) {
+		return client.EnsureCluster(ctx, req)
+	})
+}
+
+func retryBazelProvisioning[T any](ctx context.Context, call func() (T, error)) (T, error) {
+	return retryBazelProvisioningWithBackoff(ctx, backoff.NewConstantBackOff(bazelProvisioningRetryWait), call)
+}
+
+func retryBazelProvisioningWithBackoff[T any](ctx context.Context, b backoff.BackOff, call func() (T, error)) (T, error) {
+	var result T
+	err := backoff.Retry(func() error {
+		value, err := call()
+		if err == nil {
+			result = value
+			return nil
+		}
+		if !retryableBazelProvisioningError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, backoff.WithMaxRetries(backoff.WithContext(b, ctx), bazelProvisioningMaxRetries))
+	return result, err
+}
+
+func retryableBazelProvisioningError(err error) bool {
+	switch connect.CodeOf(err) {
+	case connect.CodeUnavailable, connect.CodeAborted, connect.CodeDeadlineExceeded:
+		return true
+	}
+
+	switch status.Code(err) {
+	case codes.Unavailable, codes.Aborted, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
 }
 
 func newBazelServiceClient(ctx context.Context, tok api.TokenSource) (bazelv1betagrpc.BazelServiceClient, *grpc.ClientConn, error) {

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -6,9 +6,15 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	"connectrpc.com/connect"
+	"github.com/cenkalti/backoff/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
@@ -195,4 +201,56 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	if executionSetup.Flags().Lookup("disable_build_events") == nil {
 		t.Fatal("bazel execution setup is missing --disable_build_events")
 	}
+}
+
+func TestRetryBazelProvisioning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retries transient failures", func(t *testing.T) {
+		attempts := 0
+		result, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (string, error) {
+			attempts++
+			if attempts <= bazelProvisioningMaxRetries {
+				return "", status.Error(codes.Unavailable, "rolling out")
+			}
+			return "ready", nil
+		})
+		if err != nil {
+			t.Fatalf("retryBazelProvisioningWithBackoff: %v", err)
+		}
+		if result != "ready" {
+			t.Fatalf("result = %q, want ready", result)
+		}
+		if attempts != bazelProvisioningMaxRetries+1 {
+			t.Fatalf("attempts = %d, want %d", attempts, bazelProvisioningMaxRetries+1)
+		}
+	})
+
+	t.Run("stops after maximum retries", func(t *testing.T) {
+		attempts := 0
+		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (struct{}, error) {
+			attempts++
+			return struct{}{}, connect.NewError(connect.CodeUnavailable, errors.New("rolling out"))
+		})
+		if connect.CodeOf(err) != connect.CodeUnavailable {
+			t.Fatalf("error code = %v, want unavailable", connect.CodeOf(err))
+		}
+		if attempts != bazelProvisioningMaxRetries+1 {
+			t.Fatalf("attempts = %d, want %d", attempts, bazelProvisioningMaxRetries+1)
+		}
+	})
+
+	t.Run("does not retry permanent failures", func(t *testing.T) {
+		attempts := 0
+		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (struct{}, error) {
+			attempts++
+			return struct{}{}, status.Error(codes.InvalidArgument, "invalid")
+		})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("error code = %v, want invalid argument", status.Code(err))
+		}
+		if attempts != 1 {
+			t.Fatalf("attempts = %d, want 1", attempts)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Retries transient Bazel cache and execution-cluster provisioning failures up to three times.
- Returns permanent provisioning failures without retrying.

## Validation

- `go test ./internal/cli/cmd/cluster -run 'Bazel|RetryBazel' -count=1`
- `git diff --check`