### PR TITLE
servercore: lameduck native gRPC servers

### DIFF
--- a/std/go/grpc/drain.go
+++ b/std/go/grpc/drain.go
@@ -5,12 +5,18 @@
 package grpc
 
 import (
+	"maps"
+	"sync"
+
 	"namespacelabs.dev/foundation/std/go/core"
 )
 
 var (
 	DrainFunc        func()
 	DrainFuncsByName = map[string]func(){}
+
+	lameduckMu      sync.Mutex
+	lameduckStarted bool
 
 	// LameduckFuncsByName are invoked after MarkShutdownStarted and before any
 	// drain function. Their purpose is to signal to clients that the server is
@@ -49,9 +55,36 @@ func SetNamedDrainFunc(name string, f func()) {
 // Listen (e.g. by the foundation framework itself once the http server has
 // been constructed).
 func SetNamedLameduckFunc(name string, f func()) {
+	lameduckMu.Lock()
 	if _, ok := LameduckFuncsByName[name]; ok {
+		lameduckMu.Unlock()
 		panic("lameduck func was already set")
 	}
 
 	LameduckFuncsByName[name] = f
+	runNow := lameduckStarted
+	lameduckMu.Unlock()
+
+	// Listener handlers may finish initialization concurrently with signal
+	// handling. If lameduck has already started, run newly registered hooks
+	// immediately so the listener cannot miss the shutdown phase.
+	if runNow {
+		core.ZLog.Info().Str("name", name).Msg("running late lameduck func")
+		f()
+	}
+}
+
+// BeginLameduck marks the start of the lameduck phase and returns a stable
+// snapshot of the registered functions. Functions registered after this call
+// are invoked immediately by SetNamedLameduckFunc.
+func BeginLameduck() map[string]func() {
+	lameduckMu.Lock()
+	defer lameduckMu.Unlock()
+
+	if lameduckStarted {
+		return nil
+	}
+
+	lameduckStarted = true
+	return maps.Clone(LameduckFuncsByName)
 }

--- a/std/go/grpc/drain_test.go
+++ b/std/go/grpc/drain_test.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package grpc
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLameduckRegistrationConcurrentWithStart(t *testing.T) {
+	lameduckMu.Lock()
+	originalFuncs := LameduckFuncsByName
+	originalStarted := lameduckStarted
+	LameduckFuncsByName = map[string]func(){}
+	lameduckStarted = false
+	lameduckMu.Unlock()
+
+	t.Cleanup(func() {
+		lameduckMu.Lock()
+		LameduckFuncsByName = originalFuncs
+		lameduckStarted = originalStarted
+		lameduckMu.Unlock()
+	})
+
+	var calls atomic.Int32
+	start := make(chan struct{})
+	var funcs map[string]func()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		SetNamedLameduckFunc("test", func() { calls.Add(1) })
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		funcs = BeginLameduck()
+	}()
+
+	close(start)
+	wg.Wait()
+
+	for _, f := range funcs {
+		f()
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected lameduck function to run once, got %d", got)
+	}
+}

--- a/std/go/grpc/servercore/listener.go
+++ b/std/go/grpc/servercore/listener.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -358,12 +359,45 @@ func NewHttp2CapableServer(mux http.Handler, opts HTTPOptions) *http.Server {
 }
 
 func ListenAndGracefullyShutdownGRPC(ctx context.Context, label string, srv *grpc.Server, lis net.Listener) error {
+	gracefulStop := newGRPCGracefulStop(srv)
+
+	gogrpc.SetNamedLameduckFunc("servercore.grpc."+label, func() {
+		gracefulStop.start()
+	})
+
 	return listenAndGracefullyShutdown(ctx, label, func() error {
 		return srv.Serve(lis)
 	}, func() error {
-		srv.GracefulStop()
+		gracefulStop.wait()
 		return nil
 	})
+}
+
+type grpcGracefulStop struct {
+	srv       *grpc.Server
+	startOnce sync.Once
+	done      chan struct{}
+}
+
+func newGRPCGracefulStop(srv *grpc.Server) *grpcGracefulStop {
+	return &grpcGracefulStop{srv: srv, done: make(chan struct{})}
+}
+
+func (s *grpcGracefulStop) start() {
+	// GracefulStop closes the listener and sends GOAWAY to active transports,
+	// but blocks until in-flight RPCs finish. Run it in the background so other
+	// lameduck and drain functions are not blocked.
+	s.startOnce.Do(func() {
+		go func() {
+			s.srv.GracefulStop()
+			close(s.done)
+		}()
+	})
+}
+
+func (s *grpcGracefulStop) wait() {
+	s.start()
+	<-s.done
 }
 
 func ListenAndGracefullyShutdownHTTP(ctx context.Context, label string, srv *http.Server, lis net.Listener) error {

--- a/std/go/grpc/servercore/listener_test.go
+++ b/std/go/grpc/servercore/listener_test.go
@@ -12,10 +12,14 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"golang.org/x/net/http2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // TestNewHttp2CapableServer_GoawayOnShutdown verifies that
@@ -149,6 +153,123 @@ func TestNewHttp2CapableServer_GoawayOnShutdown(t *testing.T) {
 			t.Errorf("Serve returned: %v", err)
 		}
 	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return")
+	}
+}
+
+type blockingHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+
+	started chan struct{}
+	finish  chan struct{}
+	calls   atomic.Int32
+}
+
+func (s *blockingHealthServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if s.calls.Add(1) == 1 {
+		close(s.started)
+	}
+
+	select {
+	case <-s.finish:
+		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestGRPCLameduckSendsGoawayWithoutInterruptingInflightRPC(t *testing.T) {
+	srv := grpc.NewServer()
+	health := &blockingHealthServer{
+		started: make(chan struct{}),
+		finish:  make(chan struct{}),
+	}
+	grpc_health_v1.RegisterHealthServer(srv, health)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer lis.Close()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	defer conn.Close()
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	inflightErr := make(chan error, 1)
+	go func() {
+		_, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		inflightErr <- err
+	}()
+
+	select {
+	case <-health.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight RPC did not start")
+	}
+
+	gracefulStop := newGRPCGracefulStop(srv)
+	lameduckReturned := make(chan struct{})
+	go func() {
+		gracefulStop.start()
+		close(lameduckReturned)
+	}()
+	select {
+	case <-lameduckReturned:
+	case <-time.After(time.Second):
+		t.Fatal("lameduck blocked on the in-flight RPC")
+	}
+
+	// Give GOAWAY time to reach the client, then verify that it does not
+	// dispatch another RPC on the draining transport.
+	time.Sleep(200 * time.Millisecond)
+	retryCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := client.Check(retryCtx, &grpc_health_v1.HealthCheckRequest{}); err == nil {
+		t.Fatal("RPC unexpectedly succeeded after lameduck")
+	}
+	if got := health.calls.Load(); got != 1 {
+		t.Fatalf("expected only the in-flight RPC to reach the server, got %d calls", got)
+	}
+
+	shutdownReturned := make(chan struct{})
+	go func() {
+		gracefulStop.wait()
+		close(shutdownReturned)
+	}()
+	select {
+	case <-shutdownReturned:
+		t.Fatal("shutdown returned before the in-flight RPC finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(health.finish)
+	select {
+	case err := <-inflightErr:
+		if err != nil {
+			t.Fatalf("in-flight RPC failed during lameduck: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight RPC did not finish")
+	}
+	select {
+	case <-shutdownReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown did not return")
+	}
+
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Fatalf("Serve returned: %v", err)
+		}
+	case <-time.After(2 * time.Second):
 		t.Fatal("Serve did not return")
 	}
 }

--- a/std/go/grpc/servercore/registrar.go
+++ b/std/go/grpc/servercore/registrar.go
@@ -17,6 +17,11 @@ import (
 type Registrar interface {
 	grpc.ServiceRegistrar
 
+	// GRPCRegistrar returns a service registrar scoped to a named gRPC
+	// listener configuration. It can be used to register the same service on
+	// the package's default listener and on additional named listeners.
+	GRPCRegistrar(listenerConfiguration string) grpc.ServiceRegistrar
+
 	Handle(path string, p http.Handler) *mux.Route
 	PathPrefix(path string) *mux.Route
 	RegisterListener(func(context.Context, net.Listener) error)
@@ -85,6 +90,14 @@ type scopedServer struct {
 
 func (s *scopedServer) RegisterService(desc *grpc.ServiceDesc, impl interface{}) {
 	s.parent.registerService(s.pkg, s.configurationName, desc, impl)
+}
+
+func (s *scopedServer) GRPCRegistrar(listenerConfiguration string) grpc.ServiceRegistrar {
+	return &scopedServer{
+		pkg:               s.pkg,
+		configurationName: listenerConfiguration,
+		parent:            s.parent,
+	}
 }
 
 func (s *scopedServer) Handle(path string, p http.Handler) *mux.Route {

--- a/std/go/grpc/servercore/registrar_test.go
+++ b/std/go/grpc/servercore/registrar_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package servercore
+
+import (
+	"testing"
+
+	"google.golang.org/grpc"
+	"namespacelabs.dev/foundation/std/go/core"
+)
+
+type registrarTestService interface{}
+
+func TestGRPCRegistrarRegistersServiceOnNamedListener(t *testing.T) {
+	defaultServer := grpc.NewServer()
+	namedServer := grpc.NewServer()
+	server := &ServerImpl{
+		srv: map[string][]*grpc.Server{
+			"":        {defaultServer},
+			"private": {namedServer},
+		},
+	}
+	registrar := server.Scope(&core.Package{PackageName: "test"})
+
+	desc := &grpc.ServiceDesc{
+		ServiceName: "test.Service",
+		HandlerType: (*registrarTestService)(nil),
+	}
+	implementation := struct{}{}
+
+	registrar.RegisterService(desc, implementation)
+	registrar.GRPCRegistrar("private").RegisterService(desc, implementation)
+
+	if _, ok := defaultServer.GetServiceInfo()[desc.ServiceName]; !ok {
+		t.Fatal("service was not registered on the default listener")
+	}
+	if _, ok := namedServer.GetServiceInfo()[desc.ServiceName]; !ok {
+		t.Fatal("service was not registered on the named listener")
+	}
+}

--- a/std/go/grpc/servercore/sigterm.go
+++ b/std/go/grpc/servercore/sigterm.go
@@ -64,7 +64,7 @@ func handleGracefulShutdown(ctx context.Context, finishShutdown func()) {
 		t := time.Now()
 		core.MarkShutdownStarted()
 
-		runShutdownPhases(nsgrpc.LameduckFuncsByName, nsgrpc.DrainFunc, nsgrpc.DrainFuncsByName)
+		runShutdownPhases(nsgrpc.BeginLameduck(), nsgrpc.DrainFunc, nsgrpc.DrainFuncsByName)
 
 		delta := time.Since(t)
 		if delta < readinessPropagationDelay {


### PR DESCRIPTION
## Summary

- Start native gRPC graceful shutdown during lameduck so pooled clients receive GOAWAY before final shutdown.
- Make lameduck registration safe when listener initialization races with shutdown.
- Allow a service to register on an additional named gRPC listener through `Registrar.GRPCRegistrar`.

## API

`Registrar.GRPCRegistrar(listenerName)` returns a `grpc.ServiceRegistrar` for a Foundation-managed named listener, allowing one service implementation to be registered on multiple listeners.

## Validation

- `go test ./std/go/server ./std/go/grpc/...`
- `go test -race ./std/go/grpc ./std/go/grpc/servercore`
- `go vet ./std/go/server ./std/go/grpc/...`
- `pre-commit run --files std/go/grpc/drain.go std/go/grpc/drain_test.go std/go/grpc/servercore/listener.go std/go/grpc/servercore/listener_test.go std/go/grpc/servercore/registrar.go std/go/grpc/servercore/registrar_test.go std/go/grpc/servercore/sigterm.go`