### PR TITLE
nsc: add Bazel revocable token support

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -29,6 +29,7 @@ import (
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/workspace/dirs"
+	"namespacelabs.dev/integrations/api"
 )
 
 const bazelCachePathBase = "bazelcache"
@@ -54,6 +55,7 @@ func NewBazelCmd() *cobra.Command {
 	cmd.AddCommand(cache)
 	cmd.AddCommand(execution)
 	cmd.AddCommand(invocation)
+	cmd.AddCommand(newBazelCreateTokenCmd())
 	cmd.AddCommand(newSetupBazelCmd())
 
 	return cmd
@@ -126,7 +128,7 @@ func NewBazelCacheCmd() *cobra.Command {
 const defaultBazelCommand = "build"
 
 func newSetupCacheCmd() *cobra.Command {
-	var bazelRcPath, output, certPath, bazelCommand string
+	var bazelRcPath, output, certPath, bazelCommand, tokenFile string
 	var experimentalCacheName string
 	var sendBuildEvents, useAbsoluteCredHelperPath, static, experimentalDirect, enableRemoteAssetAPI bool
 	var version int64
@@ -141,6 +143,7 @@ func newSetupCacheCmd() *cobra.Command {
 		flags.StringVar(&certPath, "cred_path", "", "If specified, write credentials to this directory. Using this flag also ensures stable file names for all emitted credentials.")
 		flags.BoolVar(&sendBuildEvents, "send_build_events", false, "If specified, send build events to the build event service.")
 		flags.BoolVar(&useAbsoluteCredHelperPath, "use_absolute_credentialhelper_path", false, "If specified, use an absolute path to the credential helper binary.")
+		flags.StringVar(&tokenFile, "token", "", "Use the bearer token stored at this location for authentication instead of the default. Implies --static.")
 		flags.BoolVar(&static, "static", false, "If specified, use a static bearer token in --remote_header instead of a credential helper.")
 		flags.BoolVar(&experimentalDirect, "experimental_direct", false, "If specified, configure Bazel to connect directly to the cache endpoint with a freshly issued client certificate.")
 		flags.StringVar(&experimentalCacheName, "experimental_cache_name", "", "If specified, request a named experimental Bazel cache backing instance.")
@@ -154,10 +157,22 @@ func newSetupCacheCmd() *cobra.Command {
 		flags.MarkHidden("send_build_events")
 		flags.MarkHidden("version")
 	}).Do(func(ctx context.Context) error {
-		client, err := fnapi.NewBazelCacheServiceClient(ctx)
-		if err != nil {
-			return err
+		var tokenSource api.TokenSource
+		if tokenFile != "" {
+			loaded, err := loadTokenFromFile(tokenFile)
+			if err != nil {
+				return fnerrors.Newf("failed to load token from file: %w", err)
+			}
+			tokenSource = loaded
+			static = true
+		} else {
+			loaded, err := fnapi.FetchToken(ctx)
+			if err != nil {
+				return err
+			}
+			tokenSource = loaded
 		}
+		client := fnapi.NewBazelCacheServiceClientWithToken(tokenSource)
 
 		if experimentalDirect && static {
 			return fnerrors.Newf("--experimental_direct may not be used with --static")
@@ -318,7 +333,7 @@ func newSetupCacheCmd() *cobra.Command {
 				return fnerrors.Newf("--static requires HTTPS cache endpoint but it was not provided")
 			}
 
-			token, err := fnapi.IssueToken(ctx, staticDur)
+			token, err := tokenSource.IssueToken(ctx, staticDur, false)
 			if err != nil {
 				return fnerrors.Newf("failed to issue bearer token: %w", err)
 			}

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -18,12 +18,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
-	"namespacelabs.dev/foundation/internal/auth"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/integrations/api"
 	"namespacelabs.dev/integrations/nsc/grpcapi"
 )
 
@@ -41,7 +41,7 @@ func newSetupBazelCmd() *cobra.Command {
 }
 
 func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
-	var bazelRcPath, output, bazelCommand, key string
+	var bazelRcPath, output, bazelCommand, key, tokenFile string
 	var staticDur time.Duration
 	var static, enableRemoteAssetAPI bool
 	remote := true
@@ -55,6 +55,7 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 		flags.StringVarP(&output, "output", "o", "plain", "One of plain or json.")
 		flags.StringVar(&bazelCommand, "command", defaultBazelRbeCommand, "The bazel command to use in the generated bazelrc (e.g., 'build' or 'common').")
 		flags.StringVar(&key, "key", "", "Stable identifier that disambiguates multiple parallel execution clusters for the same workspace. Defaults to 'default'.")
+		flags.StringVar(&tokenFile, "token", "", "Use the bearer token stored at this location for authentication instead of the default. Implies --static.")
 		flags.BoolVar(&static, "static", false, "If specified, authenticate using a static bearer token in --remote_header against the public endpoints instead of issuing an mTLS client certificate.")
 		flags.BoolVar(&enableRemoteAssetAPI, "enable_remote_asset_api", false, "If specified, opt-in to the remote asset API and configure bazel's --experimental_remote_downloader.")
 		fncobra.DurationVar(flags, &staticDur, "static_token_duration", 4*time.Hour, "The minimum duration of the static token configured (requires --static).")
@@ -62,9 +63,20 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			flags.BoolVar(&remote, "remote", true, "If false, configure remote caching and build events without remote execution.")
 		}
 	}).Do(func(ctx context.Context) error {
-		tok, err := fnapi.FetchToken(ctx)
-		if err != nil {
-			return err
+		var tok api.TokenSource
+		if tokenFile != "" {
+			loaded, err := loadTokenFromFile(tokenFile)
+			if err != nil {
+				return fnerrors.Newf("failed to load token from file: %w", err)
+			}
+			tok = loaded
+			static = true
+		} else {
+			loaded, err := fnapi.FetchToken(ctx)
+			if err != nil {
+				return err
+			}
+			tok = loaded
 		}
 
 		authMode := bazelv1beta.BazelExecutionAuthMode_BAZEL_EXECUTION_AUTH_MODE_MTLS
@@ -301,7 +313,7 @@ func appendExecutionBuildEventCredentialHelper(ctx context.Context, buf *bytes.B
 	return nil
 }
 
-func ensureBazelExecutionCluster(ctx context.Context, tok *auth.Token, key string, authMode bazelv1beta.BazelExecutionAuthMode, enableRemoteAssetAPI bool) (*bazelv1beta.EnsureClusterResponse, error) {
+func ensureBazelExecutionCluster(ctx context.Context, tok api.TokenSource, key string, authMode bazelv1beta.BazelExecutionAuthMode, enableRemoteAssetAPI bool) (*bazelv1beta.EnsureClusterResponse, error) {
 	client, conn, err := newBazelServiceClient(ctx, tok)
 	if err != nil {
 		return nil, err
@@ -316,7 +328,7 @@ func ensureBazelExecutionCluster(ctx context.Context, tok *auth.Token, key strin
 	return client.EnsureCluster(ctx, req)
 }
 
-func newBazelServiceClient(ctx context.Context, tok *auth.Token) (bazelv1betagrpc.BazelServiceClient, *grpc.ClientConn, error) {
+func newBazelServiceClient(ctx context.Context, tok api.TokenSource) (bazelv1betagrpc.BazelServiceClient, *grpc.ClientConn, error) {
 	conn, err := grpcapi.NewConnectionWithEndpoint(ctx, fnapi.GlobalEndpoint(), tok)
 	if err != nil {
 		return nil, nil, err

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -151,6 +151,9 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	if remote.DefValue != "true" {
 		t.Fatalf("--remote default = %q, want true", remote.DefValue)
 	}
+	if setup.Flags().Lookup("token") == nil {
+		t.Fatal("bazel setup is missing --token")
+	}
 
 	executionSetup, _, err := cmd.Find([]string{"execution", "setup"})
 	if err != nil {
@@ -158,5 +161,8 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	}
 	if executionSetup.Flags().Lookup("remote") != nil {
 		t.Fatal("bazel execution setup must not expose --remote")
+	}
+	if executionSetup.Flags().Lookup("token") == nil {
+		t.Fatal("bazel execution setup is missing --token")
 	}
 }

--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -11,8 +11,90 @@ import (
 	"testing"
 	"time"
 
+	iamv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/iam/v1beta"
 	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
 )
+
+func TestNewBazelCreateTokenCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewBazelCmd()
+	createToken, _, err := cmd.Find([]string{"create-token"})
+	if err != nil {
+		t.Fatalf("Find(create-token): %v", err)
+	}
+
+	for name, wantDefault := range map[string]string{
+		"token":      "token.json",
+		"expires_in": "2160h0m0s",
+		"scope":      "user",
+	} {
+		flag := createToken.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("bazel create-token is missing --%s", name)
+		}
+		if flag.DefValue != wantDefault {
+			t.Fatalf("--%s default = %q, want %q", name, flag.DefValue, wantDefault)
+		}
+	}
+	if createToken.Flags().Lookup("name") != nil {
+		t.Fatal("bazel create-token must not expose --name")
+	}
+}
+
+func TestBazelCacheSetupAcceptsToken(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewBazelCmd()
+	setup, _, err := cmd.Find([]string{"cache", "setup"})
+	if err != nil {
+		t.Fatalf("Find(cache setup): %v", err)
+	}
+	if setup.Flags().Lookup("token") == nil {
+		t.Fatal("bazel cache setup is missing --token")
+	}
+}
+
+func TestNewBazelTokenRequest(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour)
+	req, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "user")
+	if err != nil {
+		t.Fatalf("newBazelTokenRequest: %v", err)
+	}
+	if req.GetName() != "rbe-ci-token" {
+		t.Fatalf("token name = %q, want rbe-ci-token", req.GetName())
+	}
+	if req.GetScope() != iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE {
+		t.Fatalf("token scope = %v, want user scope", req.GetScope())
+	}
+
+	grants := req.GetAccess().GetGrants()
+	if len(grants) != 2 {
+		t.Fatalf("grant count = %d, want 2", len(grants))
+	}
+	assertGrant := func(got *iamv1beta.Permission, resourceType, action string) {
+		t.Helper()
+		if got.GetResourceType() != resourceType || got.GetResourceId() != "*" || len(got.GetActions()) != 1 || got.GetActions()[0] != action {
+			t.Fatalf("unexpected grant: %v", got)
+		}
+	}
+	assertGrant(grants[0], "bazel/execution", "ensure")
+	assertGrant(grants[1], "ingress", "access")
+
+	tenantReq, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "tenant")
+	if err != nil {
+		t.Fatalf("newBazelTokenRequest tenant scope: %v", err)
+	}
+	if tenantReq.GetScope() != iamv1beta.RevokableToken_TENANT_SCOPE {
+		t.Fatalf("token scope = %v, want tenant scope", tenantReq.GetScope())
+	}
+
+	if _, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "invalid"); err == nil {
+		t.Fatal("expected invalid token scope error")
+	}
+}
 
 func TestBaseBazelSetup(t *testing.T) {
 	t.Parallel()

--- a/internal/cli/cmd/cluster/createtoken.go
+++ b/internal/cli/cmd/cluster/createtoken.go
@@ -116,6 +116,83 @@ func newCreateCacheTokenCmd(cfg createTokenConfig) *cobra.Command {
 	})
 }
 
+func newBazelCreateTokenCmd() *cobra.Command {
+	var tokenFile, scope string
+	var expiresIn time.Duration
+
+	return fncobra.Cmd(&cobra.Command{
+		Use:   "create-token",
+		Short: "Create a revocable token for Bazel remote execution.",
+	}).WithFlags(func(flags *pflag.FlagSet) {
+		flags.StringVar(&tokenFile, "token", "token.json", "Write token to this file in JSON format.")
+		fncobra.DurationVar(flags, &expiresIn, "expires_in", 90*24*time.Hour, "Duration until the token expires.")
+		flags.StringVar(&scope, "scope", "user", "Set the scope of the generated access token. Valid options: tenant, user. Tokens with user scope are bound to the tenant membership of the current user.")
+	}).Do(func(ctx context.Context) error {
+		expiresAt := time.Now().Add(expiresIn)
+		tokenName := fmt.Sprintf("bazel-execution-%s", ids.NewRandomBase32ID(4))
+		req, err := newBazelTokenRequest(tokenName, expiresAt, scope)
+		if err != nil {
+			return err
+		}
+
+		tokenSource, err := auth.LoadDefaults()
+		if err != nil {
+			return fnerrors.InvocationError("bazel", "failed to get authentication token: %w", err)
+		}
+
+		iamClient, err := iam.NewClient(ctx, tokenSource)
+		if err != nil {
+			return fnerrors.InvocationError("bazel", "failed to create IAM client: %w", err)
+		}
+		defer iamClient.Close()
+
+		resp, err := iamClient.Tokens.CreateRevokableToken(ctx, req)
+		if err != nil {
+			return fnerrors.InvocationError("bazel", "failed to create token: %w", err)
+		}
+
+		if err := writeTokenToFile(tokenFile, resp.BearerToken); err != nil {
+			return fnerrors.InvocationError("bazel", "failed to write token to file: %w", err)
+		}
+
+		fmt.Fprintf(console.Stdout(ctx), "Token ID:    %s\n", resp.Token.GetTokenId())
+		fmt.Fprintf(console.Stdout(ctx), "Name:        %s\n", resp.Token.GetName())
+		fmt.Fprintf(console.Stdout(ctx), "Expires At:  %s\n", expiresAt.Format(time.RFC3339))
+		fmt.Fprintf(console.Stdout(ctx), "\nWrote token contents to %q\n\n", tokenFile)
+		fmt.Fprintln(console.Stdout(ctx), "Set up Bazel remote execution with:")
+
+		style := colors.Ctx(ctx)
+		fmt.Fprintf(console.Stdout(ctx), "  %s\n", style.Highlight.Apply(fmt.Sprintf("nsc bazel execution setup --token %s --bazelrc=namespace.bazelrc", tokenFile)))
+
+		return nil
+	})
+}
+
+func newBazelTokenRequest(name string, expiresAt time.Time, scope string) (*iamv1beta.CreateRevokableTokenRequest, error) {
+	req := &iamv1beta.CreateRevokableTokenRequest{
+		Name:        name,
+		Description: "Bazel remote execution access token",
+		ExpiresAt:   timestamppb.New(expiresAt),
+		Access: &iamv1beta.AccessPolicy{
+			Grants: []*iamv1beta.Permission{
+				{ResourceType: "bazel/execution", ResourceId: "*", Actions: []string{"ensure"}},
+				{ResourceType: "ingress", ResourceId: "*", Actions: []string{"access"}},
+			},
+		},
+	}
+
+	switch scope {
+	case "tenant":
+		req.Scope = iamv1beta.RevokableToken_TENANT_SCOPE
+	case "user":
+		req.Scope = iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE
+	default:
+		return nil, fnerrors.BadInputError("invalid token scope %q (valid values: tenant, user)", scope)
+	}
+
+	return req, nil
+}
+
 func writeTokenToFile(path string, bearerToken string) error {
 	tokenData := map[string]string{
 		"bearer_token": bearerToken,

--- a/internal/fnapi/bazel.go
+++ b/internal/fnapi/bazel.go
@@ -10,6 +10,7 @@ import (
 
 	"buf.build/gen/go/namespace/cloud/connectrpc/go/proto/namespace/cloud/integrations/bazel/v1beta/bazelv1betaconnect"
 	"connectrpc.com/connect"
+	"namespacelabs.dev/integrations/api"
 )
 
 func NewBazelCacheServiceClient(ctx context.Context) (bazelv1betaconnect.BazelCacheServiceClient, error) {
@@ -18,11 +19,13 @@ func NewBazelCacheServiceClient(ctx context.Context) (bazelv1betaconnect.BazelCa
 		return nil, err
 	}
 
-	client := bazelv1betaconnect.NewBazelCacheServiceClient(
+	return NewBazelCacheServiceClientWithToken(tok), nil
+}
+
+func NewBazelCacheServiceClientWithToken(tok api.TokenSource) bazelv1betaconnect.BazelCacheServiceClient {
+	return bazelv1betaconnect.NewBazelCacheServiceClient(
 		http.DefaultClient,
 		GlobalEndpoint(),
 		connect.WithInterceptors(newAuthInterceptor(tok)),
 	)
-
-	return client, nil
 }


### PR DESCRIPTION
Adds a Bazel create-token command and token-file authentication for Bazel setup commands.