### PR TITLE
nscloud: discover Windows guest metadata in ProgramData

### DIFF
--- a/internal/cli/cmd/cluster/metadata.go
+++ b/internal/cli/cmd/cluster/metadata.go
@@ -18,10 +18,6 @@ import (
 	"namespacelabs.dev/foundation/internal/providers/nscloud/metadata"
 )
 
-const (
-	defaultMetadataSpecFile = "/var/run/nsc/token.spec"
-)
-
 var supportedMetadataKeys = []string{"id"}
 
 func NewMetadataCmd() *cobra.Command {
@@ -54,7 +50,11 @@ func newReadCmd() *cobra.Command {
 		}
 
 		if spec == "" {
-			s, err := os.ReadFile(defaultMetadataSpecFile)
+			specFile, err := metadata.TokenSpecFile()
+			if err != nil {
+				return err
+			}
+			s, err := os.ReadFile(specFile)
 			if err != nil {
 				return fnerrors.Newf("failed to read metadata spec file: %w", err)
 			}

--- a/internal/fnapi/tokens.go
+++ b/internal/fnapi/tokens.go
@@ -71,6 +71,18 @@ func FetchToken(ctx context.Context) (*localauth.Token, error) {
 			if specified := os.Getenv("NSC_TOKEN_FILE"); specified != "" {
 				return localauth.LoadTokenFromPath(ctx, IssueTenantTokenFromSession, specified, time.Now())
 			}
+
+			defaultWorkloadToken, err := defaultWorkloadTokenPath()
+			if err != nil {
+				return nil, err
+			}
+			if defaultWorkloadToken != "" {
+				if _, err := os.Stat(defaultWorkloadToken); err == nil {
+					return localauth.LoadTokenFromPath(ctx, IssueTenantTokenFromSession, defaultWorkloadToken, time.Now())
+				} else if !os.IsNotExist(err) {
+					return nil, err
+				}
+			}
 		}
 
 		return localauth.LoadTenantToken(ctx, IssueTenantTokenFromSession)

--- a/internal/fnapi/workload_token_other.go
+++ b/internal/fnapi/workload_token_other.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build !windows
+
+package fnapi
+
+func defaultWorkloadTokenPath() (string, error) {
+	return "", nil
+}

--- a/internal/fnapi/workload_token_other.go
+++ b/internal/fnapi/workload_token_other.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 

--- a/internal/fnapi/workload_token_windows.go
+++ b/internal/fnapi/workload_token_windows.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package fnapi
+
+import "namespacelabs.dev/foundation/internal/providers/nscloud/metadata"
+
+func defaultWorkloadTokenPath() (string, error) {
+	return metadata.TokenFile()
+}

--- a/internal/fnapi/workload_token_windows.go
+++ b/internal/fnapi/workload_token_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 

--- a/internal/providers/nscloud/metadata/instancemd.go
+++ b/internal/providers/nscloud/metadata/instancemd.go
@@ -11,10 +11,6 @@ import (
 	"namespacelabs.dev/foundation/internal/fnerrors"
 )
 
-const (
-	defaultMetadataPath = "/var/run/nsc/metadata.json"
-)
-
 type InstanceMetadata struct {
 	Version          string `json:"version,omitempty"`
 	InstanceEndpoint string `json:"instance_endpoint,omitempty"`
@@ -26,10 +22,13 @@ type InstanceMetadata struct {
 }
 
 func InstanceMetadataFromFile() (InstanceMetadata, error) {
-	metadataPath := defaultMetadataPath
-
-	if specified := os.Getenv("NSC_METADATA_FILE"); specified != "" {
-		metadataPath = specified
+	metadataPath := os.Getenv("NSC_METADATA_FILE")
+	if metadataPath == "" {
+		var err error
+		metadataPath, err = MetadataFile()
+		if err != nil {
+			return InstanceMetadata{}, err
+		}
 	}
 
 	var md InstanceMetadata

--- a/internal/providers/nscloud/metadata/paths.go
+++ b/internal/providers/nscloud/metadata/paths.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func Directory() (string, error) {
+	if specified := os.Getenv("NSC_METADATA_DIR"); specified != "" {
+		return specified, nil
+	}
+	return defaultDirectory()
+}
+
+func MetadataFile() (string, error) {
+	return fileInDirectory("metadata.json")
+}
+
+func TokenFile() (string, error) {
+	return fileInDirectory("token.json")
+}
+
+func TokenSpecFile() (string, error) {
+	return fileInDirectory("token.spec")
+}
+
+func fileInDirectory(name string) (string, error) {
+	dir, err := Directory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
+}

--- a/internal/providers/nscloud/metadata/paths.go
+++ b/internal/providers/nscloud/metadata/paths.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 

--- a/internal/providers/nscloud/metadata/paths_other.go
+++ b/internal/providers/nscloud/metadata/paths_other.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//go:build !windows
+
+package metadata
+
+func defaultDirectory() (string, error) {
+	return "/var/run/nsc", nil
+}

--- a/internal/providers/nscloud/metadata/paths_other.go
+++ b/internal/providers/nscloud/metadata/paths_other.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 

--- a/internal/providers/nscloud/metadata/paths_test.go
+++ b/internal/providers/nscloud/metadata/paths_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 

--- a/internal/providers/nscloud/metadata/paths_test.go
+++ b/internal/providers/nscloud/metadata/paths_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package metadata
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFilesUseMetadataDirectoryOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("NSC_METADATA_DIR", dir)
+
+	metadataFile, err := MetadataFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(dir, "metadata.json"); metadataFile != want {
+		t.Fatalf("MetadataFile() = %q, want %q", metadataFile, want)
+	}
+
+	tokenFile, err := TokenFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(dir, "token.json"); tokenFile != want {
+		t.Fatalf("TokenFile() = %q, want %q", tokenFile, want)
+	}
+
+	tokenSpecFile, err := TokenSpecFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(dir, "token.spec"); tokenSpecFile != want {
+		t.Fatalf("TokenSpecFile() = %q, want %q", tokenSpecFile, want)
+	}
+}

--- a/internal/providers/nscloud/metadata/paths_windows.go
+++ b/internal/providers/nscloud/metadata/paths_windows.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package metadata
+
+import (
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func defaultDirectory() (string, error) {
+	programData, err := windows.KnownFolderPath(windows.FOLDERID_ProgramData, windows.KF_FLAG_DEFAULT)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(programData, "Namespace", "GuestAgent", "metadata"), nil
+}

--- a/internal/providers/nscloud/metadata/paths_windows.go
+++ b/internal/providers/nscloud/metadata/paths_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Namespace Labs Inc; All rights reserved.
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 


### PR DESCRIPTION
## Summary

- centralize Namespace Cloud guest metadata paths behind platform-specific helpers
- discover Windows guest metadata under the ProgramData known folder
- load the default Windows workload token when no explicit token is configured
- preserve existing Unix paths and support an NSC_METADATA_DIR override

## Testing

- `go test ./internal/providers/nscloud/metadata ./internal/fnapi ./internal/cli/cmd/cluster`
- Windows cross-compilation of the same packages with `GOOS=windows GOARCH=amd64 go test -c`