### PR TITLE
nsc: list Bazel invocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.0
 
 require (
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260710132230-2e3db39f86b8.1
-	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260712213844-83c43e91b37d.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260712213844-83c43e91b37d.1
+	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260717182942-d535342a07ff.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260717182942-d535342a07ff.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.20.0
@@ -157,7 +157,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/bazel/bazel/protocolbuffers/go v1.36.11-20251112223041-697bc75dbe09.1 // indirect
+	buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1 // indirect
 	cloud.google.com/go v0.121.6 // indirect
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-buf.build/gen/go/bazel/bazel/protocolbuffers/go v1.36.11-20251112223041-697bc75dbe09.1 h1:1XnPNVAb9QgwVbG3nsdxDI2UuNBvOelFqhjqX1mWt48=
-buf.build/gen/go/bazel/bazel/protocolbuffers/go v1.36.11-20251112223041-697bc75dbe09.1/go.mod h1:botG+8yfIpysChg+Siu8ZZpjDt9ZM8bqc0TpJoKLaUA=
+buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1 h1:0dFwGad+AGt34eoyYRYRddrt/sTYHo3YO5TMFKyepmE=
+buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1/go.mod h1:h9DLLqhUERXx+6lPKgrJxRAG03mCRRAv6VEJnmUnQGk=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260710132230-2e3db39f86b8.1 h1:lYvTzzkA4u3zH8BxrUHKszNJuBJ+sqiFKdeYCqBGNsw=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260710132230-2e3db39f86b8.1/go.mod h1:XPkgH/znMAiRNt+1f684zk7o3SYJw8nHZ0ciVMDUGys=
-buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260712213844-83c43e91b37d.1 h1:fnhzqIEfQ/z94uyv6Q3sxko7WJsWZDZQV1ea09MrzlE=
-buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260712213844-83c43e91b37d.1/go.mod h1:XWNY0GInuLgSvYTydIFlii8Zkzu7OTXESbks9ejhnrA=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260712213844-83c43e91b37d.1 h1:ovKw+lfR6inkQteZMhZAGib0Rvxv81KLu5WpfiPLAS4=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260712213844-83c43e91b37d.1/go.mod h1:rM1SQt83F9wfd5fTF5pl3r3UvzBokLmqa+ulh1iSp9M=
+buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260717182942-d535342a07ff.1 h1:iAfJJQruDlINb561UWvJcLro2z/jhqtdldQCd4t8i/k=
+buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260717182942-d535342a07ff.1/go.mod h1:6n8kuc1dDn90xkcSkC8RvWgVRDZD8ieon1yRWhkj9Sc=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260717182942-d535342a07ff.1 h1:XV66zgWFTEPyv1vPA9eKiryt5LW2kQa9N+wsDHkMoMo=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260717182942-d535342a07ff.1/go.mod h1:Sq0KOCy7xpul1cCYq/55WryE9Nke8fQsext30EBZp7o=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -20,12 +20,15 @@ import (
 
 	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
 	"connectrpc.com/connect"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
+	"namespacelabs.dev/foundation/internal/console/tui"
 	"namespacelabs.dev/foundation/internal/fnapi"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/workspace/dirs"
@@ -50,6 +53,7 @@ func NewBazelCmd() *cobra.Command {
 	}
 	execution.AddCommand(newSetupExecutionCmd())
 	invocation := &cobra.Command{Use: "invocation", Short: "Bazel invocation related functionality."}
+	invocation.AddCommand(newBazelInvocationListCmd())
 	invocation.AddCommand(newBazelInvocationReportCmd())
 
 	cmd.AddCommand(cache)
@@ -59,6 +63,135 @@ func NewBazelCmd() *cobra.Command {
 	cmd.AddCommand(newSetupBazelCmd())
 
 	return cmd
+}
+
+func newBazelInvocationListCmd() *cobra.Command {
+	var output string
+	var maxEntries int32
+	var since time.Duration
+
+	return fncobra.Cmd(&cobra.Command{
+		Use:   "list",
+		Short: "List recent Bazel invocations.",
+		Args:  cobra.NoArgs,
+	}).WithFlags(func(flags *pflag.FlagSet) {
+		flags.StringVarP(&output, "output", "o", "plain", "One of plain or json.")
+		flags.Int32Var(&maxEntries, "max_entries", 50, "Maximum number of invocations to return (up to 100).")
+		fncobra.DurationVar(flags, &since, "since", 0, "Only list invocations started within this duration.")
+	}).Do(func(ctx context.Context) error {
+		if output != "plain" && output != "json" {
+			return fnerrors.Newf("unsupported output format %q, supported values: plain, json", output)
+		}
+		if maxEntries <= 0 || maxEntries > 100 {
+			return fnerrors.Newf("--max_entries must be between 1 and 100")
+		}
+		if since < 0 {
+			return fnerrors.Newf("--since must not be negative")
+		}
+
+		tok, err := fnapi.FetchToken(ctx)
+		if err != nil {
+			return err
+		}
+
+		client, conn, err := newBazelServiceClient(ctx, tok)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		req := &bazelv1beta.ListInvocationsRequest{}
+		req.SetMaxEntries(maxEntries)
+		if since > 0 {
+			req.SetNotOlderThan(timestamppb.New(time.Now().Add(-since)))
+		}
+
+		response, err := client.ListInvocations(ctx, req)
+		if err != nil {
+			return fnerrors.Newf("failed to list Bazel invocations: %w", err)
+		}
+
+		return writeBazelInvocationList(ctx, response, output)
+	})
+}
+
+type bazelInvocationView struct {
+	InvocationID string `json:"invocation_id"`
+	StartedAt    string `json:"started_at"`
+	CompletedAt  string `json:"completed_at,omitempty"`
+}
+
+func writeBazelInvocationList(ctx context.Context, response *bazelv1beta.ListInvocationsResponse, output string) error {
+	invocations := response.GetInvocations()
+
+	if output == "json" {
+		return writeBazelInvocationListJSON(console.Stdout(ctx), invocations)
+	}
+
+	if len(invocations) == 0 {
+		if _, err := fmt.Fprintln(console.Stdout(ctx), "No Bazel invocations found."); err != nil {
+			return fnerrors.InternalError("failed to write Bazel invocations: %w", err)
+		}
+		return nil
+	}
+
+	cols := []tui.Column{
+		{Key: "invocation_id", Title: "Invocation ID", MinWidth: 10, MaxWidth: 36},
+		{Key: "started_at", Title: "Started", MinWidth: 10, MaxWidth: 20},
+		{Key: "completed_at", Title: "Completed", MinWidth: 10, MaxWidth: 20},
+	}
+
+	return tui.StaticTable(ctx, cols, bazelInvocationRows(invocations))
+}
+
+func writeBazelInvocationListJSON(w io.Writer, invocations []*bazelv1beta.InvocationListEntry) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(bazelInvocationViews(invocations)); err != nil {
+		return fnerrors.InternalError("failed to encode Bazel invocations: %w", err)
+	}
+	return nil
+}
+
+func bazelInvocationViews(invocations []*bazelv1beta.InvocationListEntry) []bazelInvocationView {
+	views := make([]bazelInvocationView, 0, len(invocations))
+	for _, invocation := range invocations {
+		view := bazelInvocationView{
+			InvocationID: invocation.GetInvocationId(),
+			StartedAt:    formatBazelInvocationTime(invocation.GetStartedAt()),
+		}
+		if invocation.GetCompletedAt() != nil {
+			view.CompletedAt = formatBazelInvocationTime(invocation.GetCompletedAt())
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+func bazelInvocationRows(invocations []*bazelv1beta.InvocationListEntry) []tui.Row {
+	rows := make([]tui.Row, 0, len(invocations))
+	for _, invocation := range invocations {
+		rows = append(rows, tui.Row{
+			"invocation_id": invocation.GetInvocationId(),
+			"started_at":    humanizeBazelInvocationTime(invocation.GetStartedAt()),
+			"completed_at":  humanizeBazelInvocationTime(invocation.GetCompletedAt()),
+		})
+	}
+	return rows
+}
+
+func formatBazelInvocationTime(value *timestamppb.Timestamp) string {
+	if value == nil {
+		return ""
+	}
+	return value.AsTime().Format(time.RFC3339)
+}
+
+func humanizeBazelInvocationTime(value *timestamppb.Timestamp) string {
+	if value == nil {
+		return "-"
+	}
+	return humanize.Time(value.AsTime().Local())
 }
 
 func newBazelInvocationReportCmd() *cobra.Command {

--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -7,12 +7,14 @@ package cluster
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	iamv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/iam/v1beta"
 	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestNewBazelCreateTokenCmd(t *testing.T) {
@@ -53,6 +55,98 @@ func TestBazelCacheSetupAcceptsToken(t *testing.T) {
 	if setup.Flags().Lookup("token") == nil {
 		t.Fatal("bazel cache setup is missing --token")
 	}
+}
+
+func TestNewBazelInvocationListCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewBazelCmd()
+	list, _, err := cmd.Find([]string{"invocation", "list"})
+	if err != nil {
+		t.Fatalf("Find(invocation list): %v", err)
+	}
+
+	for name, wantDefault := range map[string]string{
+		"max_entries": "50",
+		"output":      "plain",
+		"since":       "0s",
+	} {
+		flag := list.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("bazel invocation list is missing --%s", name)
+		}
+		if flag.DefValue != wantDefault {
+			t.Fatalf("--%s default = %q, want %q", name, flag.DefValue, wantDefault)
+		}
+	}
+}
+
+func TestWriteBazelInvocationList(t *testing.T) {
+	t.Parallel()
+
+	response := &bazelv1beta.ListInvocationsResponse{
+		Invocations: []*bazelv1beta.InvocationListEntry{
+			{
+				InvocationId: "newest",
+				ProjectId:    "project-b",
+				BuildId:      "build-b",
+				StartedAt:    timestamppb.New(time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)),
+			},
+			{
+				InvocationId: "older",
+				ProjectId:    "project-a",
+				BuildId:      "build-a",
+				StartedAt:    timestamppb.New(time.Date(2026, time.July, 17, 11, 0, 0, 0, time.UTC)),
+				CompletedAt:  timestamppb.New(time.Date(2026, time.July, 17, 11, 5, 0, 0, time.UTC)),
+			},
+		},
+	}
+
+	t.Run("plain", func(t *testing.T) {
+		rows := bazelInvocationRows(response.GetInvocations())
+		if len(rows) != 2 {
+			t.Fatalf("rows = %#v, want two entries", rows)
+		}
+		if rows[0]["invocation_id"] != "newest" || rows[1]["invocation_id"] != "older" {
+			t.Fatalf("rows changed invocation order: %#v", rows)
+		}
+		if rows[0]["completed_at"] != "-" || rows[1]["completed_at"] == "-" {
+			t.Fatalf("completed times = %q, %q, want missing then populated", rows[0]["completed_at"], rows[1]["completed_at"])
+		}
+		if _, ok := rows[0]["project_id"]; ok {
+			t.Fatalf("plain output contains project_id: %#v", rows[0])
+		}
+		if _, ok := rows[0]["build_id"]; ok {
+			t.Fatalf("plain output contains build_id: %#v", rows[0])
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		var output bytes.Buffer
+		if err := writeBazelInvocationListJSON(&output, response.GetInvocations()); err != nil {
+			t.Fatalf("writeBazelInvocationListJSON: %v", err)
+		}
+
+		var got []map[string]any
+		if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal JSON output: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("JSON output = %#v, want two entries", got)
+		}
+		if got[0]["invocation_id"] != "newest" || got[0]["started_at"] != "2026-07-17T12:00:00Z" {
+			t.Fatalf("first invocation = %#v, want newest invocation", got[0])
+		}
+		if _, ok := got[0]["completed_at"]; ok {
+			t.Fatalf("running invocation contains completed_at: %#v", got[0])
+		}
+		if _, ok := got[0]["project_id"]; ok {
+			t.Fatalf("JSON output contains project_id: %#v", got[0])
+		}
+		if _, ok := got[0]["build_id"]; ok {
+			t.Fatalf("JSON output contains build_id: %#v", got[0])
+		}
+	})
 }
 
 func TestNewBazelTokenRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `nsc bazel invocation list` with plain and JSON output.
- Matches `nsc list` conventions with the shared table renderer, humanized timestamps, and stable JSON array output.
- Supports maximum-entry and age filters while preserving newest-first server ordering.
- Updates the public Namespace API dependencies for `ListInvocations`.

## Validation

- `go test ./internal/cli/cmd/cluster`
- `go test ./cmd/nsc/...`
- `go build ./cmd/nsc`
- `go run ./cmd/nsc bazel invocation list --max_entries 5`
- `go run ./cmd/nsc bazel invocation list --max_entries 5 --output json`