### PR TITLE
nsc: improve command documentation

### DIFF
--- a/cmd/nsc/cmd/register.go
+++ b/cmd/nsc/cmd/register.go
@@ -65,7 +65,7 @@ func RegisterCommands(root *cobra.Command) {
 	root.AddCommand(cluster.NewBazelCmd())
 	root.AddCommand(cluster.NewGradleCmd())
 	root.AddCommand(cluster.NewPantsCmd())
-	cacheCmd := &cobra.Command{Use: "cache", Short: "Build cache related functionality."}
+	cacheCmd := &cobra.Command{Use: "cache", Short: "Manage remote build caches."}
 	cacheCmd.AddCommand(cluster.NewSccacheCmd())
 	cacheCmd.AddCommand(cluster.NewGradleCacheCmd())
 	cacheCmd.AddCommand(cluster.NewBazelCacheCmd())
@@ -100,6 +100,7 @@ func RegisterCommands(root *cobra.Command) {
 func newGithub() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "github",
+		Short:  "Manage GitHub Actions resources.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/admin/admin.go
+++ b/internal/cli/cmd/admin/admin.go
@@ -11,7 +11,7 @@ import (
 func NewAdminCmd(hidden bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "admin",
-		Short:  "Partner administration commands.",
+		Short:  "Manage partner accounts.",
 		Hidden: hidden,
 	}
 

--- a/internal/cli/cmd/admin/signpartnertoken.go
+++ b/internal/cli/cmd/admin/signpartnertoken.go
@@ -41,7 +41,7 @@ func newSignPartnerTokenCmd() *cobra.Command {
 	return fncobra.Cmd(
 		&cobra.Command{
 			Use:   "sign-partner-token --partner_id=user_... --issuer_url=https://... --key_from_file=...",
-			Short: "Run gcloud.",
+			Short: "Sign a partner token.",
 		}).
 		WithFlags(func(flags *pflag.FlagSet) {
 			flags.StringVar(&partnerID, "partner_id", "", "Partner account ID to assert.")

--- a/internal/cli/cmd/auth/checkauth.go
+++ b/internal/cli/cmd/auth/checkauth.go
@@ -22,7 +22,7 @@ import (
 func NewCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "check",
-		Short:  "Returns information on whether the caller is still authenticated to Namespace.",
+		Short:  "Report whether the caller is authenticated to Namespace.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/auth/cmd.go
+++ b/internal/cli/cmd/auth/cmd.go
@@ -16,7 +16,7 @@ import (
 func NewAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Authentication related operations (e.g. login).",
+		Short: "Manage authentication.",
 	}
 
 	cmd.AddCommand(NewLoginCmd())

--- a/internal/cli/cmd/auth/impersonatetenant.go
+++ b/internal/cli/cmd/auth/impersonatetenant.go
@@ -20,7 +20,7 @@ import (
 func NewImpersonateTenantCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "impersonate-tenant",
-		Short:  "Signs in as a tenant, using a partner account.",
+		Short:  "Sign in as a tenant using a partner account.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/auth/login.go
+++ b/internal/cli/cmd/auth/login.go
@@ -29,7 +29,7 @@ func NewLoginCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Login to Namespace to access Namespace Instances, Remote Builders, etc.",
+		Short: "Log in to Namespace.",
 		Args:  cobra.NoArgs,
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {

--- a/internal/cli/cmd/auth/logout.go
+++ b/internal/cli/cmd/auth/logout.go
@@ -19,7 +19,7 @@ import (
 func NewLogoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Logout from Namespace",
+		Short: "Log out of Namespace.",
 		Args:  cobra.NoArgs,
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {

--- a/internal/cli/cmd/aws/cmd.go
+++ b/internal/cli/cmd/aws/cmd.go
@@ -9,7 +9,7 @@ import "github.com/spf13/cobra"
 func NewAwsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws",
-		Short: "AWS Federation related commands.",
+		Short: "Authenticate to AWS with workload federation.",
 	}
 
 	cmd.AddCommand(newAssumeRoleCmd())

--- a/internal/cli/cmd/aws/ecr.go
+++ b/internal/cli/cmd/aws/ecr.go
@@ -32,7 +32,7 @@ const dockerCfgName = "config.json"
 func newEcrDockerLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ecr-docker-login",
-		Short:  "Uses Workload Federation to log into ECR for use with Docker.",
+		Short:  "Log in to Amazon ECR with workload federation.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/aws/federation.go
+++ b/internal/cli/cmd/aws/federation.go
@@ -27,7 +27,7 @@ const (
 func newAssumeRoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "assume-role",
-		Short: "Uses Workload Federation to assume a particular AWS role.",
+		Short: "Assume an AWS role with workload federation.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/cli/cmd/aws/setupwebidentity.go
+++ b/internal/cli/cmd/aws/setupwebidentity.go
@@ -20,7 +20,7 @@ import (
 func newSetupWebIdentity() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "setup-web-identity",
-		Short:  "Provides configuration to the AWS CLI/SDK to use Workload Federation to access a particular AWS role.",
+		Short:  "Configure AWS tools to assume a role with workload federation.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/cluster/artifact.go
+++ b/internal/cli/cmd/cluster/artifact.go
@@ -44,7 +44,7 @@ const (
 func NewArtifactCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "artifact",
-		Short: "Artifact-related activities.",
+		Short: "Manage artifacts.",
 	}
 
 	cmd.AddCommand(newArtifactUploadCmd())

--- a/internal/cli/cmd/cluster/attachdocker.go
+++ b/internal/cli/cmd/cluster/attachdocker.go
@@ -31,7 +31,7 @@ import (
 func newDockerAttachCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attach-context",
-		Short: "Configures a Docker context that uses an ephemeral environment.",
+		Short: "Configure a Docker context backed by an ephemeral instance.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/cli/cmd/cluster/baseimage/cmd.go
+++ b/internal/cli/cmd/cluster/baseimage/cmd.go
@@ -12,7 +12,7 @@ import (
 func NewBaseImageCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "base-image",
-		Short: "Operations for managing your base images.",
+		Short: "Manage base images.",
 	}
 
 	cmd.AddCommand(newUploadBaseImageCmd())

--- a/internal/cli/cmd/cluster/baseimage/optimize.go
+++ b/internal/cli/cmd/cluster/baseimage/optimize.go
@@ -20,7 +20,7 @@ import (
 func newOptimizeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "optimize",
-		Short: "Triggers the optimization of a base image.",
+		Short: "Optimize a base image.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/cli/cmd/cluster/baseimage/upload_base_image.go
+++ b/internal/cli/cmd/cluster/baseimage/upload_base_image.go
@@ -24,7 +24,7 @@ import (
 func newUploadBaseImageCmd() *cobra.Command {
 	run := &cobra.Command{
 		Use:   "upload [source-image] [target-tag]",
-		Short: "Converts an existing image into a base image and uploads it to nscr.io",
+		Short: "Convert and upload an image as a base image to nscr.io.",
 		Args:  cobra.ExactArgs(2),
 	}
 

--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -40,19 +40,19 @@ const bazelCachePathBase = "bazelcache"
 func NewBazelCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bazel",
-		Short: "Bazel-related activities.",
+		Short: "Manage Bazel integrations.",
 	}
 
-	cache := &cobra.Command{Use: "cache", Short: "Bazel cache related functionality."}
+	cache := &cobra.Command{Use: "cache", Short: "Manage remote Bazel caches."}
 	cache.AddCommand(newSetupCacheCmd())
 
 	execution := &cobra.Command{
 		Use:    "execution",
-		Short:  "Bazel remote execution related functionality.",
+		Short:  "Manage Bazel remote execution.",
 		Hidden: true,
 	}
 	execution.AddCommand(newSetupExecutionCmd())
-	invocation := &cobra.Command{Use: "invocation", Short: "Bazel invocation related functionality."}
+	invocation := &cobra.Command{Use: "invocation", Short: "Inspect Bazel invocations."}
 	invocation.AddCommand(newBazelInvocationListCmd())
 	invocation.AddCommand(newBazelInvocationReportCmd())
 
@@ -250,7 +250,7 @@ func writeBazelInvocationReportRecord(w io.Writer, record *bazelv1beta.StreamInv
 func NewBazelCacheCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bazel",
-		Short: "Bazel cache related functionality.",
+		Short: "Manage remote Bazel caches.",
 	}
 
 	cmd.AddCommand(newSetupCacheCmd())

--- a/internal/cli/cmd/cluster/buildkit.go
+++ b/internal/cli/cmd/cluster/buildkit.go
@@ -37,7 +37,7 @@ import (
 func NewBuildkitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "buildkit",
-		Short:  "Buildkit-related functionality.",
+		Short:  "Run BuildKit tools against build instances.",
 		Hidden: true,
 	}
 	fncobra.MarkAsNotSupportedOnWindows(cmd)

--- a/internal/cli/cmd/cluster/buildx.go
+++ b/internal/cli/cmd/cluster/buildx.go
@@ -463,7 +463,7 @@ func wireBuildx(dockerCli *command.DockerCli, name string, use, defaultLoad bool
 func newCleanupBuildxCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cleanup",
-		Short: "Unregisters Namespace Remote builders from buildx.",
+		Short: "Unregister Namespace remote builders from Buildx.",
 	}
 
 	name := cmd.Flags().String("name", defaultBuilder, "The name of the builder to clean up.")
@@ -721,7 +721,7 @@ func makeUnixHTTPClient(unixSockPath string) *http.Client {
 func newStatusBuildxCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Status information for the local Namespace buildx context.",
+		Short: "Show the local Namespace Buildx context status.",
 	}
 
 	output := cmd.Flags().StringP("output", "o", "plain", "One of plain or json.")
@@ -999,7 +999,7 @@ func newDumpListWorkersBuildxCommand() *cobra.Command {
 func newWaitBuilderCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "wait-for-builder",
-		Short:  "Ensures a remote builder is running and ready to execute builds.",
+		Short:  "Ensure a remote builder is ready.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/cluster/cmd.go
+++ b/internal/cli/cmd/cluster/cmd.go
@@ -27,7 +27,7 @@ var ErrEmptyClusterList = errors.New("no instances")
 func NewBareClusterCmd(use string, hidden bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    use,
-		Short:  "Instance-related activities.",
+		Short:  "Manage instances.",
 		Hidden: hidden,
 	}
 

--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -28,7 +28,7 @@ import (
 func NewCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Creates a new instance.",
+		Short: "Create an instance.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/cli/cmd/cluster/describe.go
+++ b/internal/cli/cmd/cluster/describe.go
@@ -37,7 +37,7 @@ var resources = append(kubernetesResources,
 func NewDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Outputs a description of the specified instance.",
+		Short: "Describe an instance.",
 		Args:  cobra.ExactArgs(1),
 	}
 

--- a/internal/cli/cmd/cluster/destroy.go
+++ b/internal/cli/cmd/cluster/destroy.go
@@ -18,7 +18,7 @@ import (
 func NewDestroyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy [instance-id]",
-		Short: "Destroys an existing instance.",
+		Short: "Destroy an instance.",
 		Args:  cobra.ArbitraryArgs,
 	}
 

--- a/internal/cli/cmd/cluster/docker.go
+++ b/internal/cli/cmd/cluster/docker.go
@@ -38,7 +38,7 @@ const (
 func NewDockerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "docker",
-		Short: "Docker-related functionality.",
+		Short: "Manage Docker integrations.",
 	}
 	fncobra.MarkAsNotSupportedOnWindows(cmd)
 
@@ -46,7 +46,7 @@ func NewDockerCmd() *cobra.Command {
 	cmd.AddCommand(newDockerRemoteCmd())     // nsc docker remote
 	cmd.AddCommand(newDockerLoginCmd(false)) // nsc docker login
 
-	buildx := &cobra.Command{Use: "buildx", Short: "Docker Buildx related functionality."}
+	buildx := &cobra.Command{Use: "buildx", Short: "Manage Docker Buildx integrations."}
 	fncobra.MarkAsNotSupportedOnWindows(buildx)
 	buildx.AddCommand(newSetupBuildxCmd())
 	buildx.AddCommand(newCleanupBuildxCommand())
@@ -146,7 +146,7 @@ func runDocker(ctx context.Context, socketPath string, args ...string) error {
 func newDockerLoginCmd(hidden bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "login",
-		Short:  "Log into the Namespace private registry for use with Docker.",
+		Short:  "Log in to the Namespace private registry with Docker.",
 		Args:   cobra.NoArgs,
 		Hidden: hidden,
 	}

--- a/internal/cli/cmd/cluster/egress.go
+++ b/internal/cli/cmd/cluster/egress.go
@@ -26,7 +26,7 @@ import (
 func NewEgressCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "egress",
-		Short: "Egress-related activities.",
+		Short: "Inspect instance egress.",
 	}
 
 	cmd.AddCommand(newEgressLogsCmd())

--- a/internal/cli/cmd/cluster/execscoped.go
+++ b/internal/cli/cmd/cluster/execscoped.go
@@ -25,7 +25,7 @@ import (
 func NewExecScoped() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exec-scoped --service=docker|kubernetes <clusterid> <cmd...>",
-		Short: "Runs the specified command (e.g. a script) with the corresponding environment variables set, based on the services selected (e.g. DOCKER_HOST, KUBECONFIG).",
+		Short: "Run a command with instance service environment variables.",
 		Args:  cobra.MinimumNArgs(1),
 	}
 	fncobra.MarkAsNotSupportedOnWindows(cmd)

--- a/internal/cli/cmd/cluster/expose.go
+++ b/internal/cli/cmd/cluster/expose.go
@@ -75,7 +75,7 @@ func NewExposeCmd() *cobra.Command {
 func newExposeContainerCmd(use string, hidden bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    use,
-		Short:  "Opens a public ingress to the specified exported port.",
+		Short:  "Expose an instance port publicly.",
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: hidden,
 	}

--- a/internal/cli/cmd/cluster/generatereport.go
+++ b/internal/cli/cmd/cluster/generatereport.go
@@ -28,7 +28,7 @@ import (
 func NewGenerateReportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "report",
-		Short: "Generates a report of compute instances.",
+		Short: "Generate an instance report.",
 		Args:  cobra.NoArgs, // for now
 	}
 

--- a/internal/cli/cmd/cluster/gitcheckout.go
+++ b/internal/cli/cmd/cluster/gitcheckout.go
@@ -26,7 +26,7 @@ import (
 func NewGitCheckoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "git-checkout",
-		Short:  "Actions for git checkouts supporting Namespace Cache Volumes.",
+		Short:  "Manage Git checkouts on cache volumes.",
 		Hidden: true,
 	}
 
@@ -41,7 +41,7 @@ func NewGitCheckoutCmd() *cobra.Command {
 func newUpdateSubmodulesCmd(mirrorBaseDir *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update-submodules",
-		Short: "Updates git submodules using a Namespace git mirror.",
+		Short: "Update Git submodules using a Namespace mirror.",
 	}
 
 	repositoryPath := cmd.Flags().String("repository_path", "", "the path of the repository to work in")

--- a/internal/cli/cmd/cluster/gradle.go
+++ b/internal/cli/cmd/cluster/gradle.go
@@ -33,10 +33,10 @@ const gradleCachePathBase = "gradle"
 func NewGradleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gradle",
-		Short: "Gradle-related activities.",
+		Short: "Manage Gradle integrations.",
 	}
 
-	cache := &cobra.Command{Use: "cache", Short: "Gradle cache related functionality."}
+	cache := &cobra.Command{Use: "cache", Short: "Manage remote Gradle caches."}
 	cache.AddCommand(newSetupGradleCacheCmd())
 	cache.AddCommand(newGradleCreateTokenCmd())
 
@@ -50,7 +50,7 @@ func NewGradleCmd() *cobra.Command {
 func NewGradleCacheCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gradle",
-		Short: "Gradle cache related functionality.",
+		Short: "Manage remote Gradle caches.",
 	}
 
 	cmd.AddCommand(newSetupGradleCacheCmd())

--- a/internal/cli/cmd/cluster/history.go
+++ b/internal/cli/cmd/cluster/history.go
@@ -19,7 +19,7 @@ import (
 func NewListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists all of your instances.",
+		Short: "List your instances.",
 		Args:  cobra.NoArgs,
 	}
 
@@ -96,7 +96,7 @@ func transformForOutput(md api.KubernetesClusterMetadata) map[string]any {
 func newHistoryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "history",
-		Short: "History of your previous running instances.",
+		Short: "List previously running instances.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/cli/cmd/cluster/ingress.go
+++ b/internal/cli/cmd/cluster/ingress.go
@@ -22,7 +22,7 @@ import (
 func NewIngressCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ingress",
-		Short: "Ingress-related activities.",
+		Short: "Manage instance ingress.",
 	}
 
 	cmd.AddCommand(newListIngressesCmd())
@@ -39,7 +39,7 @@ type ingressOut struct {
 func newListIngressesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists the registered ingresses on the specified instance.",
+		Short: "List registered ingress endpoints for an instance.",
 		Args:  cobra.MaximumNArgs(1),
 	}
 

--- a/internal/cli/cmd/cluster/kubectl.go
+++ b/internal/cli/cmd/cluster/kubectl.go
@@ -63,7 +63,7 @@ func NewKubectlCmd() *cobra.Command {
 func NewKubeconfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
-		Short: "Kubeconfig-related activities.",
+		Short: "Manage instance kubeconfigs.",
 	}
 
 	cmd.AddCommand(newWriteKubeconfigCmd("write", false))

--- a/internal/cli/cmd/cluster/macos/cmd.go
+++ b/internal/cli/cmd/cluster/macos/cmd.go
@@ -9,6 +9,7 @@ import "github.com/spf13/cobra"
 func NewMacOSCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "macos",
+		Short:  "Manage macOS packages.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/cluster/macos/package.go
+++ b/internal/cli/cmd/cluster/macos/package.go
@@ -30,7 +30,7 @@ import (
 func newPackageCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "package [path]",
-		Short: "Creates a macOS package from a directory and uploads it to nscr.io",
+		Short: "Create and upload a macOS package to nscr.io.",
 		Args:  cobra.ExactArgs(1),
 	}
 

--- a/internal/cli/cmd/cluster/pants.go
+++ b/internal/cli/cmd/cluster/pants.go
@@ -26,10 +26,10 @@ const pantsCachePathBase = "pantscache"
 func NewPantsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pants",
-		Short: "Pants-related activities.",
+		Short: "Manage Pants integrations.",
 	}
 
-	cache := &cobra.Command{Use: "cache", Short: "Pants cache related functionality."}
+	cache := &cobra.Command{Use: "cache", Short: "Manage remote Pants caches."}
 	cache.AddCommand(newSetupPantsCacheCmd())
 
 	cmd.AddCommand(cache)
@@ -42,7 +42,7 @@ func NewPantsCmd() *cobra.Command {
 func NewPantsCacheCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pants",
-		Short: "Pants cache related functionality.",
+		Short: "Manage remote Pants caches.",
 	}
 
 	cmd.AddCommand(newSetupPantsCacheCmd())

--- a/internal/cli/cmd/cluster/portforward.go
+++ b/internal/cli/cmd/cluster/portforward.go
@@ -23,7 +23,7 @@ import (
 func newPortForwardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "port-forward [instance-id]",
-		Short: "Opens a local port which connects to the instance.",
+		Short: "Forward a local port to an instance.",
 		Args:  cobra.MaximumNArgs(1),
 	}
 

--- a/internal/cli/cmd/cluster/private/root.go
+++ b/internal/cli/cmd/cluster/private/root.go
@@ -9,6 +9,7 @@ import "github.com/spf13/cobra"
 func NewInternalCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "internal",
+		Short:  "Run internal instance commands.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/cluster/proxy.go
+++ b/internal/cli/cmd/cluster/proxy.go
@@ -51,7 +51,7 @@ func (p proxyOutput) MarshalJSON() ([]byte, error) {
 func NewProxyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proxy [instance-id]",
-		Short: "Provides proxy support for instance services.",
+		Short: "Proxy local requests to instance services.",
 		Args:  cobra.ArbitraryArgs,
 	}
 

--- a/internal/cli/cmd/cluster/rdp.go
+++ b/internal/cli/cmd/cluster/rdp.go
@@ -19,7 +19,7 @@ import (
 func NewRdpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "rdp [instance-id]",
-		Short:  "Start a RDP session.",
+		Short:  "Start an RDP session.",
 		Args:   cobra.ArbitraryArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/cluster/registry.go
+++ b/internal/cli/cmd/cluster/registry.go
@@ -301,7 +301,7 @@ func newRegistryListCmd() *cobra.Command {
 func newRegistryDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe [image-reference]",
-		Short: "Get detailed information about a specific image.",
+		Short: "Describe a registry image.",
 		Args:  cobra.MaximumNArgs(1),
 		Long: `Get detailed information about a specific image.
 
@@ -724,7 +724,7 @@ Alternatively, use --repository and --digest flags.`,
 func newRegistryGetDefaultExpirationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "Gets the default expiration setting.",
+		Short: "Get the default expiration setting.",
 		Args:  cobra.NoArgs,
 		Long:  `Gets the default expiration setting that is currently configured.`,
 	}
@@ -742,7 +742,7 @@ func newRegistryGetDefaultExpirationCmd() *cobra.Command {
 func newRegistrySetDefaultExpirationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
-		Short: "Sets the default expiration setting.",
+		Short: "Set the default expiration setting.",
 		Args:  cobra.NoArgs,
 		Long:  `Sets the default expiration setting that is applied to new images.`,
 	}
@@ -945,7 +945,7 @@ func setPolicy(ctx context.Context, repository string, expiration time.Duration,
 func newRegistryPolicyGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "Gets the current policy settings.",
+		Short: "Get the current policy settings.",
 		Args:  cobra.NoArgs,
 		Long:  `Gets the policy settings that are currently configured. If --repository is specified, gets the policy for that repository.`,
 	}
@@ -963,7 +963,7 @@ func newRegistryPolicyGetCmd() *cobra.Command {
 func newRegistryPolicySetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
-		Short: "Sets policy settings.",
+		Short: "Set policy settings.",
 		Args:  cobra.NoArgs,
 		Long:  `Sets the policy settings. If --repository is specified, sets the policy for that repository, otherwise sets the default policy.`,
 	}

--- a/internal/cli/cmd/cluster/release.go
+++ b/internal/cli/cmd/cluster/release.go
@@ -16,7 +16,7 @@ import (
 func newSuspendCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "suspend [instance-id]",
-		Short:  "Suspends an existing instance.",
+		Short:  "Suspend an instance.",
 		Args:   cobra.ExactArgs(1),
 		Hidden: true,
 	}
@@ -33,7 +33,7 @@ func newSuspendCmd() *cobra.Command {
 func newReleaseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "release [instance-id]",
-		Short:  "Releases an existing instance.",
+		Short:  "Release an instance.",
 		Args:   cobra.ExactArgs(1),
 		Hidden: true,
 	}
@@ -50,7 +50,7 @@ func newReleaseCmd() *cobra.Command {
 func newWakeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "wake [instance-id]",
-		Short:  "Wakes up an existing instance.",
+		Short:  "Wake an instance.",
 		Args:   cobra.ExactArgs(1),
 		Hidden: true,
 	}

--- a/internal/cli/cmd/cluster/reservation.go
+++ b/internal/cli/cmd/cluster/reservation.go
@@ -32,7 +32,7 @@ import (
 func NewReservationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reservation",
-		Short: "Reservation-related activities.",
+		Short: "Manage instance reservations.",
 	}
 
 	cmd.AddCommand(NewReservationWaitCmd())
@@ -78,7 +78,7 @@ func callReservation(ctx context.Context, method string, req, resp proto.Message
 func NewReservationListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists your reservations.",
+		Short: "List your reservations.",
 		Args:  cobra.NoArgs,
 	}
 
@@ -140,7 +140,7 @@ func NewReservationListCmd() *cobra.Command {
 func NewReservationDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <reservation_id>",
-		Short: "Describes a reservation.",
+		Short: "Describe a reservation.",
 		Args:  cobra.ExactArgs(1),
 	}
 
@@ -185,7 +185,7 @@ func NewReservationDescribeCmd() *cobra.Command {
 func NewReservationCancelCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cancel <reservation_id>",
-		Short: "Cancels a pending reservation.",
+		Short: "Cancel a pending reservation.",
 		Args:  cobra.ExactArgs(1),
 	}
 
@@ -249,7 +249,7 @@ func orDash(s string) string {
 func NewReservationWaitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wait <reservation_id>",
-		Short: "Waits for a reservation to be fulfilled, returning the instance id.",
+		Short: "Wait for a reservation and print its instance ID.",
 		Args:  cobra.ExactArgs(1),
 	}
 

--- a/internal/cli/cmd/cluster/run.go
+++ b/internal/cli/cmd/cluster/run.go
@@ -28,7 +28,7 @@ import (
 func NewRunCmd() *cobra.Command {
 	run := &cobra.Command{
 		Use:   "run",
-		Short: "Starts a container in an ephemeral environment, optionally exporting ports for public serving.",
+		Short: "Run a container in an ephemeral instance.",
 		Args:  cobra.ArbitraryArgs,
 	}
 

--- a/internal/cli/cmd/cluster/sccache.go
+++ b/internal/cli/cmd/cluster/sccache.go
@@ -27,7 +27,7 @@ import (
 func NewSccacheCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sccache",
-		Short: "sccache cache related functionality.",
+		Short: "Manage the remote sccache cache.",
 	}
 
 	cmd.AddCommand(newSetupSccacheCacheCmd())

--- a/internal/cli/cmd/cluster/volume.go
+++ b/internal/cli/cmd/cluster/volume.go
@@ -24,7 +24,7 @@ import (
 func NewVolumeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "volume",
-		Short: "Volume-related activities.",
+		Short: "Manage workspace volumes.",
 	}
 
 	cmd.AddCommand(newListVolumesCmd())
@@ -42,7 +42,7 @@ const (
 func newListVolumesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists the volumes for this workspace.",
+		Short: "List volumes for the current workspace.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/cli/cmd/devbox/cmd.go
+++ b/internal/cli/cmd/devbox/cmd.go
@@ -25,7 +25,7 @@ const (
 func NewDevboxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "devbox",
-		Short:  "Devboxes are managed by the separate devbox CLI.",
+		Short:  "Install or run the Devbox CLI.",
 		Hidden: true,
 		Args:   cobra.NoArgs,
 	}

--- a/internal/cli/cmd/gcp/cmd.go
+++ b/internal/cli/cmd/gcp/cmd.go
@@ -9,7 +9,7 @@ import "github.com/spf13/cobra"
 func NewGcpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gcp",
-		Short: "Google Cloud Platform Federation related commands.",
+		Short: "Authenticate to Google Cloud with workload federation.",
 	}
 
 	cmd.AddCommand(newImpersonateCmd())

--- a/internal/cli/cmd/gcp/federation.go
+++ b/internal/cli/cmd/gcp/federation.go
@@ -27,7 +27,7 @@ const (
 func newImpersonateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "impersonate",
-		Short:  "To impersonate Namespace workload as a GCP service account.",
+		Short:  "Impersonate a Google Cloud service account.",
 		Args:   cobra.NoArgs,
 		Hidden: true,
 	}

--- a/internal/cli/cmd/sdk/sdk.go
+++ b/internal/cli/cmd/sdk/sdk.go
@@ -40,7 +40,7 @@ func NewSdkCmd(hidden bool) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:    "sdk",
-		Short:  "SDK related operations (e.g. download, shell).",
+		Short:  "Manage development SDKs.",
 		Hidden: hidden,
 	}
 
@@ -118,7 +118,7 @@ func simpleFileSDK[V ~string](name string, makeComputable func(context.Context, 
 func newSdkShellCmd(selectedSdkList func() []sdk) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "shell",
-		Short: "Starts a shell with every SDK in the PATH.",
+		Short: "Start a shell with configured SDKs in PATH.",
 		Args:  cobra.NoArgs,
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
@@ -181,7 +181,7 @@ func newSdkShellCmd(selectedSdkList func() []sdk) *cobra.Command {
 func newSdkDownloadCmd(selectedSdkList func() []sdk) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download",
-		Short: "Downloads a predefined set of SDKs.",
+		Short: "Download the configured SDKs.",
 		Args:  cobra.NoArgs,
 	}
 
@@ -223,7 +223,7 @@ func newSdkDownloadCmd(selectedSdkList func() []sdk) *cobra.Command {
 func newSdkVerifyCmd(selectedSdkList func() []sdk) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "verify-digest",
-		Short:  "Downloads all of the SDKs known URLs to verify their digests (for development).",
+		Short:  "Verify the digests of all known SDK downloads.",
 		Hidden: true,
 		Args:   cobra.NoArgs,
 

--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -32,7 +32,7 @@ func NewVersionCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Outputs the compiled version of Namespace.",
+		Short: "Print the Namespace CLI version.",
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
 			if buildInfo {
@@ -76,7 +76,7 @@ func newEnsureCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "ensure",
-		Short: "Ensures the current binary is at least a given version, updating if needed.",
+		Short: "Ensure the CLI meets a minimum version.",
 		Args:  cobra.NoArgs,
 
 		RunE: fncobra.RunE(func(ctx context.Context, args []string) error {
@@ -124,7 +124,7 @@ func newCheckCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "check",
-		Short: "Checks whether the current binary is up to date.",
+		Short: "Check whether the CLI is up to date.",
 		Long: `Checks whether the current binary is up to date.
 
 By default (--latest), checks if a newer version is available.
@@ -200,7 +200,7 @@ Exits with code 2 if the version is outdated or the constraint is not met.`,
 func newUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update",
-		Short:   "Updates the current binary to the latest version.",
+		Short:   "Update the CLI to the latest version.",
 		Aliases: []string{"update-ns"},
 		Args:    cobra.NoArgs,
 		Annotations: map[string]string{

--- a/internal/cli/cmd/workspace/cmd.go
+++ b/internal/cli/cmd/workspace/cmd.go
@@ -20,7 +20,7 @@ import (
 func NewWorkspaceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workspace",
-		Short: "Interact with Namespace workspace.",
+		Short: "Inspect the current workspace.",
 	}
 
 	cmd.AddCommand(newDescribeCmd())
@@ -31,7 +31,7 @@ func NewWorkspaceCmd() *cobra.Command {
 func newDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Describe current workspace details.",
+		Short: "Describe the current workspace.",
 		Args:  cobra.NoArgs,
 	}
 


### PR DESCRIPTION
## Summary

- make `nsc` command summaries concise and action-oriented
- standardize terminology, capitalization, grammar, and punctuation
- add missing summaries for hidden command groups and correct misleading descriptions

## Testing

- `go test ./cmd/nsc/... ./internal/cli/cmd/admin ./internal/cli/cmd/auth ./internal/cli/cmd/aws ./internal/cli/cmd/gcp ./internal/cli/cmd/cluster/... ./internal/cli/cmd/devbox ./internal/cli/cmd/integrations ./internal/cli/cmd/scratch ./internal/cli/cmd/sdk ./internal/cli/cmd/token ./internal/cli/cmd/vault ./internal/cli/cmd/version ./internal/cli/cmd/workspace`
- `go run ./cmd/nsc/gendoc /tmp/nscdocs`
- `git diff --check`