### PR TITLE
servercore: wait for readiness propagation before lameduck

### DIFF
--- a/std/go/grpc/servercore/listener.go
+++ b/std/go/grpc/servercore/listener.go
@@ -236,11 +236,9 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 		// Register a lameduck hook so SIGTERM triggers HTTP/2 GOAWAY on
 		// open h2c connections (wired up via http2.ConfigureServer in
 		// NewHttp2CapableServer). Calling Shutdown here also closes the
-		// listener; that's intentional: by the time SIGTERM is delivered
-		// the pod is being rolled and Kubernetes is removing us from the
-		// service endpoints, so refusing new TCP connections is fine and
-		// the OnShutdown hooks (which fan out the GOAWAY frames in
-		// goroutines) are what matters for in-flight pooled clients.
+		// listener. The lameduck phase begins only after the readiness
+		// propagation delay, so proxies have time to remove this backend before
+		// it starts refusing new TCP connections.
 		gogrpc.SetNamedLameduckFunc("servercore.http", func() {
 			// Shutdown blocks until tracked HTTP/1 connections idle out,
 			// so run it asynchronously to keep the lameduck phase short.

--- a/std/go/grpc/servercore/listener_test.go
+++ b/std/go/grpc/servercore/listener_test.go
@@ -237,7 +237,9 @@ func TestListenAndGracefullyShutdownGRPC_LameduckThenShutdown(t *testing.T) {
 
 	lameduckReturned := make(chan struct{})
 	go func() {
-		runShutdownPhases(map[string]func(){lameduckName: lameduck}, nil, nil)
+		runShutdownPhases(func() {}, func() map[string]func() {
+			return map[string]func(){lameduckName: lameduck}
+		}, nil, nil)
 		close(lameduckReturned)
 	}()
 	select {

--- a/std/go/grpc/servercore/sigterm.go
+++ b/std/go/grpc/servercore/sigterm.go
@@ -18,16 +18,17 @@ import (
 // How long do we expect it would take Kubernetes to notice that we're no longer ready.
 const readinessPropagationDelay = 15 * time.Second
 
-// runShutdownPhases runs the lameduck phase and then the drain phase. It is
-// extracted from handleGracefulShutdown so it can be unit-tested without
-// having to send a real signal to the process.
-func runShutdownPhases(lameducks map[string]func(), drainFunc func(), drainFuncs map[string]func()) {
+// runShutdownPhases waits for readiness propagation, then runs the lameduck
+// phase followed by the drain phase.
+func runShutdownPhases(waitForReadinessPropagation func(), beginLameduck func() map[string]func(), drainFunc func(), drainFuncs map[string]func()) {
+	waitForReadinessPropagation()
+
 	// Lameduck phase: signal clients that we're going away (e.g. send
 	// HTTP/2 GOAWAY) before we start blocking on in-flight work. This
 	// gives clients a head start to migrate to other backends while the
 	// drain phase below waits for the requests we already have to
 	// complete.
-	for name, f := range lameducks {
+	for name, f := range beginLameduck() {
 		core.ZLog.Info().Str("name", name).Msg("running lameduck func")
 		f()
 	}
@@ -64,14 +65,14 @@ func handleGracefulShutdown(ctx context.Context, finishShutdown func()) {
 		t := time.Now()
 		core.MarkShutdownStarted()
 
-		runShutdownPhases(nsgrpc.BeginLameduck(), nsgrpc.DrainFunc, nsgrpc.DrainFuncsByName)
-
-		delta := time.Since(t)
-		if delta < readinessPropagationDelay {
-			dur := readinessPropagationDelay - delta
-			core.ZLog.Info().Dur("duration", dur).Msg("sleeping before final shutdown")
-			time.Sleep(dur)
-		}
+		runShutdownPhases(func() {
+			delta := time.Since(t)
+			if delta < readinessPropagationDelay {
+				dur := readinessPropagationDelay - delta
+				core.ZLog.Info().Dur("duration", dur).Msg("waiting for readiness propagation")
+				time.Sleep(dur)
+			}
+		}, nsgrpc.BeginLameduck, nsgrpc.DrainFunc, nsgrpc.DrainFuncsByName)
 
 		finishShutdown()
 	case <-ctx.Done():

--- a/std/go/grpc/servercore/sigterm_test.go
+++ b/std/go/grpc/servercore/sigterm_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 )
 
-// TestRunShutdownPhases verifies that all lameduck functions run before any
-// drain function (so clients get the GOAWAY signal before drain phase blocks
-// on in-flight work) and that DrainFunc runs before DrainFuncsByName.
+// TestRunShutdownPhases verifies that readiness propagation completes before
+// lameduck closes listeners, all lameduck functions run before any drain
+// function, and DrainFunc runs before DrainFuncsByName.
 func TestRunShutdownPhases(t *testing.T) {
 	var (
 		mu     sync.Mutex
@@ -36,7 +36,19 @@ func TestRunShutdownPhases(t *testing.T) {
 	}
 	drainFunc := record("drain-singleton")
 
-	runShutdownPhases(lameducks, drainFunc, drainFuncs)
+	runShutdownPhases(
+		record("readiness-propagated"),
+		func() map[string]func() {
+			record("begin-lameduck")()
+			return lameducks
+		},
+		drainFunc,
+		drainFuncs,
+	)
+
+	if len(events) < 2 || events[0] != "readiness-propagated" || events[1] != "begin-lameduck" {
+		t.Fatalf("expected readiness propagation before lameduck, got %v", events)
+	}
 
 	// Map iteration order is non-deterministic, so we only assert the
 	// phase boundaries: every "lame.*" event must come before every
@@ -89,7 +101,10 @@ func TestRunShutdownPhases(t *testing.T) {
 func TestRunShutdownPhases_NilDrainFunc(t *testing.T) {
 	called := []string{}
 	runShutdownPhases(
-		map[string]func(){"l": func() { called = append(called, "l") }},
+		func() {},
+		func() map[string]func() {
+			return map[string]func(){"l": func() { called = append(called, "l") }}
+		},
 		nil,
 		map[string]func(){"d": func() { called = append(called, "d") }},
 	)


### PR DESCRIPTION
## Summary

- Waits for readiness propagation before HTTP and gRPC lameduck hooks close their listeners.
- Preserves lameduck-before-drain ordering and adds regression coverage for all shutdown phase boundaries.

## Validation

- `go test ./std/go/grpc/servercore ./std/go/grpc`