### PR TITLE
artifact/download: retry HTTP/2 stream errors

### DIFF
--- a/internal/artifacts/download/download.go
+++ b/internal/artifacts/download/download.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"golang.org/x/net/http2"
 	"namespacelabs.dev/foundation/internal/artifacts"
 	"namespacelabs.dev/foundation/internal/bytestream"
 	"namespacelabs.dev/foundation/internal/compute"
@@ -226,6 +227,13 @@ func isRetryableDownloadError(err error) bool {
 	// Don't retry on cancellation/deadline of the caller context.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
+	}
+
+	// HTTP/2 stream failures may occur while reading the response body, after
+	// the request itself has succeeded. A fresh GET can use a new stream.
+	var streamErr http2.StreamError
+	if errors.As(err, &streamErr) {
+		return true
 	}
 
 	// Mid-body truncation — the symptom we're trying to fix here.

--- a/internal/artifacts/download/download_test.go
+++ b/internal/artifacts/download/download_test.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/http2"
 	"namespacelabs.dev/foundation/internal/artifacts"
 	"namespacelabs.dev/foundation/internal/bytestream"
 	"namespacelabs.dev/foundation/internal/compute"
@@ -137,6 +138,12 @@ func TestRetries5xx(t *testing.T) {
 }
 
 func TestErrorClassification(t *testing.T) {
+	streamErr := http2.StreamError{
+		StreamID: 1,
+		Code:     http2.ErrCodeInternal,
+		Cause:    errors.New("received from peer"),
+	}
+
 	cases := []struct {
 		name string
 		err  error
@@ -144,6 +151,8 @@ func TestErrorClassification(t *testing.T) {
 	}{
 		{"unexpected EOF", io.ErrUnexpectedEOF, true},
 		{"plain EOF", io.EOF, true},
+		{"HTTP/2 stream error", streamErr, true},
+		{"wrapped HTTP/2 stream error", fmt.Errorf("reading response body: %w", streamErr), true},
 		{"context canceled", context.Canceled, false},
 		{"context deadline", context.DeadlineExceeded, false},
 		{"http 502", newHTTPStatusError("u", http.StatusBadGateway), true},


### PR DESCRIPTION
## Summary

- Classify HTTP/2 stream errors encountered while reading download response bodies as retryable.
- Cover direct and wrapped HTTP/2 stream errors in download error classification tests.

## Validation

- `go test ./internal/artifacts/download`
- `git diff --check`
- Tested in a disposable Linux environment with an uncommitted integration harness that returned a partial response body followed by `stream error: stream ID 1; INTERNAL_ERROR; received from peer` on the first request, then a complete digest-valid body on the second request. The parent commit stopped after the first request and reported a permanent error; this change classified it as transient, issued a second request, and returned only the complete second body.