### PR TITLE
nsc bazel: allow disabling build events

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -263,7 +263,7 @@ const defaultBazelCommand = "build"
 func newSetupCacheCmd() *cobra.Command {
 	var bazelRcPath, output, certPath, bazelCommand, tokenFile string
 	var experimentalCacheName string
-	var sendBuildEvents, useAbsoluteCredHelperPath, static, experimentalDirect, enableRemoteAssetAPI bool
+	var sendBuildEvents, disableBuildEvents, useAbsoluteCredHelperPath, static, experimentalDirect, enableRemoteAssetAPI bool
 	var version int64
 	var staticDur time.Duration
 
@@ -275,6 +275,7 @@ func newSetupCacheCmd() *cobra.Command {
 		flags.StringVarP(&output, "output", "o", "plain", "One of plain or json.")
 		flags.StringVar(&certPath, "cred_path", "", "If specified, write credentials to this directory. Using this flag also ensures stable file names for all emitted credentials.")
 		flags.BoolVar(&sendBuildEvents, "send_build_events", false, "If specified, send build events to the build event service.")
+		flags.BoolVar(&disableBuildEvents, "disable_build_events", false, "If specified, do not configure Bazel to send build events.")
 		flags.BoolVar(&useAbsoluteCredHelperPath, "use_absolute_credentialhelper_path", false, "If specified, use an absolute path to the credential helper binary.")
 		flags.StringVar(&tokenFile, "token", "", "Use the bearer token stored at this location for authentication instead of the default. Implies --static.")
 		flags.BoolVar(&static, "static", false, "If specified, use a static bearer token in --remote_header instead of a credential helper.")
@@ -495,7 +496,7 @@ func newSetupCacheCmd() *cobra.Command {
 
 		// If set, we always generate a bazelrc file.
 		if bazelRcPath != "" {
-			data, err := toBazelConfig(ctx, out, useAbsoluteCredHelperPath, bazelCommand)
+			data, err := toBazelConfig(ctx, out, useAbsoluteCredHelperPath, bazelCommand, disableBuildEvents)
 			if err != nil {
 				return err
 			}
@@ -520,7 +521,7 @@ func newSetupCacheCmd() *cobra.Command {
 
 			// For plain output, flush the state to a temp bazelrc if none is written yet.
 			if bazelRcPath == "" {
-				data, err := toBazelConfig(ctx, out, useAbsoluteCredHelperPath, bazelCommand)
+				data, err := toBazelConfig(ctx, out, useAbsoluteCredHelperPath, bazelCommand, disableBuildEvents)
 				if err != nil {
 					return err
 				}
@@ -615,7 +616,7 @@ func writeFile(path string, content []byte) error {
 	return nil
 }
 
-func toBazelConfig(ctx context.Context, out bazelSetup, useAbsoluteCredHelperPath bool, command string) ([]byte, error) {
+func toBazelConfig(ctx context.Context, out bazelSetup, useAbsoluteCredHelperPath bool, command string, disableBuildEvents bool) ([]byte, error) {
 	var buffer bytes.Buffer
 	if _, err := buffer.WriteString(fmt.Sprintf("%s --remote_cache=%s\n", command, out.Endpoint)); err != nil {
 		return nil, fnerrors.Newf("failed to append cache endpoint: %w", err)
@@ -639,7 +640,7 @@ func toBazelConfig(ctx context.Context, out bazelSetup, useAbsoluteCredHelperPat
 		}
 	}
 
-	if out.BuildEventEndpoint != "" {
+	if out.BuildEventEndpoint != "" && !disableBuildEvents {
 		if _, err := buffer.WriteString(fmt.Sprintf("%s --bes_backend=%s\n", command, out.BuildEventEndpoint)); err != nil {
 			return nil, fnerrors.Newf("failed to append bes_backend: %w", err)
 		}

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -43,7 +43,7 @@ func newSetupBazelCmd() *cobra.Command {
 func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 	var bazelRcPath, output, bazelCommand, key, tokenFile string
 	var staticDur time.Duration
-	var static, enableRemoteAssetAPI bool
+	var static, enableRemoteAssetAPI, disableBuildEvents bool
 	remote := true
 
 	return fncobra.Cmd(&cobra.Command{
@@ -58,6 +58,7 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 		flags.StringVar(&tokenFile, "token", "", "Use the bearer token stored at this location for authentication instead of the default. Implies --static.")
 		flags.BoolVar(&static, "static", false, "If specified, authenticate using a static bearer token in --remote_header against the public endpoints instead of issuing an mTLS client certificate.")
 		flags.BoolVar(&enableRemoteAssetAPI, "enable_remote_asset_api", false, "If specified, opt-in to the remote asset API and configure bazel's --experimental_remote_downloader.")
+		flags.BoolVar(&disableBuildEvents, "disable_build_events", false, "If specified, do not configure Bazel to send build events.")
 		fncobra.DurationVar(flags, &staticDur, "static_token_duration", 4*time.Hour, "The minimum duration of the static token configured (requires --static).")
 		if includeRemoteFlag {
 			flags.BoolVar(&remote, "remote", true, "If false, configure remote caching and build events without remote execution.")
@@ -155,7 +156,7 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 		out.CredentialHelperDomains = res.GetCredentialHelperDomains()
 
 		if bazelRcPath != "" {
-			data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote)
+			data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote, disableBuildEvents)
 			if err != nil {
 				return err
 			}
@@ -179,7 +180,7 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			}
 
 			if bazelRcPath == "" {
-				data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote)
+				data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote, disableBuildEvents)
 				if err != nil {
 					return err
 				}
@@ -222,7 +223,7 @@ type bazelRbeSetup struct {
 	CredentialHelperDomains []string      `json:"credential_helper_domains,omitempty"`
 }
 
-func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command string, remote bool) ([]byte, error) {
+func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command string, remote, disableBuildEvents bool) ([]byte, error) {
 	var buf bytes.Buffer
 
 	var lines []string
@@ -262,7 +263,7 @@ func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command stri
 		lines = append(lines, fmt.Sprintf("--remote_timeout=%d", int(out.RemoteTimeout.Seconds())))
 	}
 
-	if out.BuildEventEndpoint != "" {
+	if out.BuildEventEndpoint != "" && !disableBuildEvents {
 		lines = append(lines, fmt.Sprintf("--bes_backend=%s", out.BuildEventEndpoint))
 
 		if out.IngressAuthToken != "" {
@@ -279,7 +280,7 @@ func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command stri
 		}
 	}
 
-	if out.BuildEventEndpoint != "" && out.IngressAuthToken == "" && len(out.CredentialHelperDomains) > 0 {
+	if out.BuildEventEndpoint != "" && !disableBuildEvents && out.IngressAuthToken == "" && len(out.CredentialHelperDomains) > 0 {
 		if err := appendExecutionBuildEventCredentialHelper(ctx, &buf, command, out.CredentialHelperDomains); err != nil {
 			return nil, err
 		}

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -19,7 +19,7 @@ func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
 		StorageEndpoint:    "grpcs://storage.example:443",
 		IngressAuthToken:   "tok123",
 		BuildEventEndpoint: "grpcs://api.us-east1.namespaceapis.com",
-	}, "build", true)
+	}, "build", true, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 		ClientKey:               "/tmp/client.key",
 		BuildEventEndpoint:      "grpcs://api.us-east1.namespaceapis.com",
 		CredentialHelperDomains: []string{"api.us-east1.namespaceapis.com"},
-	}, "build", true)
+	}, "build", true, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 		StorageEndpoint:   "grpcs://storage.example:444",
 		ClientCert:        "/tmp/client.cert",
 		ClientKey:         "/tmp/client.key",
-	}, "build", true)
+	}, "build", true, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -86,6 +86,30 @@ func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 	got := string(config)
 	if strings.Contains(got, "--bes_backend") || strings.Contains(got, "credential_helper") {
 		t.Fatalf("must not configure build events when no endpoint is returned: %q", got)
+	}
+}
+
+func TestToBazelExecutionConfigBuildEventsDisabled(t *testing.T) {
+	t.Parallel()
+
+	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		SchedulerEndpoint:       "grpcs://scheduler.example:444",
+		StorageEndpoint:         "grpcs://storage.example:444",
+		BuildEventEndpoint:      "grpcs://api.us-east1.namespaceapis.com",
+		CredentialHelperDomains: []string{"api.us-east1.namespaceapis.com"},
+	}, "build", true, true)
+	if err != nil {
+		t.Fatalf("toBazelExecutionConfig: %v", err)
+	}
+
+	got := string(config)
+	for _, unwanted := range []string{"--bes_backend", "--bes_header", "credential_helper"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("disabled build event config contains %q: %q", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "build --remote_cache=grpcs://storage.example:444\n") {
+		t.Fatalf("disabled build events removed remote cache config: %q", got)
 	}
 }
 
@@ -101,7 +125,7 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 		RemoteTimeout:         5 * time.Minute,
 		Jobs:                  32,
 		BuildEventEndpoint:    "grpcs://api.us-east1.namespaceapis.com",
-	}, "build", false)
+	}, "build", false, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
 	}
@@ -154,6 +178,9 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	if setup.Flags().Lookup("token") == nil {
 		t.Fatal("bazel setup is missing --token")
 	}
+	if setup.Flags().Lookup("disable_build_events") == nil {
+		t.Fatal("bazel setup is missing --disable_build_events")
+	}
 
 	executionSetup, _, err := cmd.Find([]string{"execution", "setup"})
 	if err != nil {
@@ -164,5 +191,8 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	}
 	if executionSetup.Flags().Lookup("token") == nil {
 		t.Fatal("bazel execution setup is missing --token")
+	}
+	if executionSetup.Flags().Lookup("disable_build_events") == nil {
+		t.Fatal("bazel execution setup is missing --disable_build_events")
 	}
 }

--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -55,6 +55,9 @@ func TestBazelCacheSetupAcceptsToken(t *testing.T) {
 	if setup.Flags().Lookup("token") == nil {
 		t.Fatal("bazel cache setup is missing --token")
 	}
+	if setup.Flags().Lookup("disable_build_events") == nil {
+		t.Fatal("bazel cache setup is missing --disable_build_events")
+	}
 }
 
 func TestNewBazelInvocationListCmd(t *testing.T) {
@@ -304,7 +307,7 @@ func TestToBazelConfigExperimentalDirect(t *testing.T) {
 		ServerCaCert: "/tmp/server_ca.cert",
 		ClientCert:   "/tmp/client.cert",
 		ClientKey:    "/tmp/client.key",
-	}, false, "build")
+	}, false, "build", false)
 	if err != nil {
 		t.Fatalf("toBazelConfig: %v", err)
 	}
@@ -323,6 +326,32 @@ func TestToBazelConfigExperimentalDirect(t *testing.T) {
 
 	if strings.Contains(got, "credential_helper") {
 		t.Fatalf("unexpected credential helper config: %q", got)
+	}
+}
+
+func TestToBazelConfigBuildEventsDisabled(t *testing.T) {
+	t.Parallel()
+
+	config, err := toBazelConfig(context.Background(), bazelSetup{
+		Endpoint:           "grpcs://cache.example:444",
+		BuildEventEndpoint: "grpcs://api.us-east1.namespaceapis.com",
+		StaticToken:        "tok123",
+	}, false, "build", true)
+	if err != nil {
+		t.Fatalf("toBazelConfig: %v", err)
+	}
+
+	got := string(config)
+	if strings.Contains(got, "--bes_") {
+		t.Fatalf("disabled build event config contains BES fields: %q", got)
+	}
+	for _, want := range []string{
+		"build --remote_cache=grpcs://cache.example:444\n",
+		"build --remote_header=x-nsc-ingress-auth=Bearer\\ tok123\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing config line %q in %q", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Add `--disable_build_events` to:

- `nsc bazel cache setup`
- `nsc bazel setup`
- `nsc bazel execution setup`

When set, generated bazelrc files omit BES backend and header fields, along with BES-only credential-helper configuration. Remote cache and execution authentication remain unchanged.

Tests: `go test ./internal/cli/cmd/cluster`