### PR TITLE
install: retry failed downloads

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -102,7 +102,8 @@ do_install() {
   fi
 
   cd ${TEMP_DIR}
-  $sh_c "curl $ci_header --fail --location --progress-bar --user-agent install.sh \"${download_uri}\" | tar -xz"
+  $sh_c "curl $ci_header --fail --location --retry 3 --retry-all-errors --progress-bar --user-agent install.sh --output ns.tar.gz \"${download_uri}\""
+  $sh_c "tar -xzf ns.tar.gz"
 
   $sh_c "chmod +x ${tool_name}"
 

--- a/install/install_nsc.ps1
+++ b/install/install_nsc.ps1
@@ -46,6 +46,31 @@ $toolName = 'nsc'
 $dockerCredHelperName = 'docker-credential-nsc'
 $bazelCredHelperName = 'bazel-credential-nsc'
 
+function Invoke-WebRequestWithRetry {
+    param(
+        [hashtable]$Parameters,
+        [int]$MaxAttempts = 4
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            if ($Parameters.ContainsKey('OutFile')) {
+                Remove-Item -Path $Parameters['OutFile'] -Force -ErrorAction SilentlyContinue
+            }
+            $response = Invoke-WebRequest @Parameters
+            return $response
+        } catch {
+            if ($attempt -eq $MaxAttempts) {
+                throw
+            }
+
+            $delaySeconds = [Math]::Pow(2, $attempt - 1)
+            Write-Warning "Request failed (attempt $attempt of $MaxAttempts): $($_.Exception.Message). Retrying in $delaySeconds seconds..."
+            Start-Sleep -Seconds $delaySeconds
+        }
+    }
+}
+
 function Get-Architecture {
     $procArch = $env:PROCESSOR_ARCHITECTURE
     # 32-bit process on a 64-bit host reports x86; the real arch is in
@@ -107,9 +132,13 @@ if ($Dir) {
 if (-not $Version) {
     Write-Host "Querying latest version..."
     $body = "{`"$toolName`":{}}"
-    $response = Invoke-WebRequest -Method Post -ContentType 'application/json' `
-        -Body $body -Uri 'https://get.namespace.so/nsl.versions.VersionsService/GetLatest' `
-        -UseBasicParsing
+    $response = Invoke-WebRequestWithRetry -Parameters @{
+        Method = 'Post'
+        ContentType = 'application/json'
+        Body = $body
+        Uri = 'https://get.namespace.so/nsl.versions.VersionsService/GetLatest'
+        UseBasicParsing = $true
+    }
     if ($response.Content -match '"version"\s*:\s*"([^"]+)"') {
         $Version = $Matches[1] -replace '^v', ''
     }
@@ -146,7 +175,13 @@ try {
         $headers['CI'] = $env:CI
     }
 
-    Invoke-WebRequest -Uri $downloadUri -OutFile $zipPath -UserAgent 'install_nsc.ps1' -Headers $headers -UseBasicParsing
+    Invoke-WebRequestWithRetry -Parameters @{
+        Uri = $downloadUri
+        OutFile = $zipPath
+        UserAgent = 'install_nsc.ps1'
+        Headers = $headers
+        UseBasicParsing = $true
+    }
     Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
 
     if (-not (Test-Path $binDir)) {

--- a/install/install_nsc.sh
+++ b/install/install_nsc.sh
@@ -107,7 +107,7 @@ do_install() {
     api_os=$(echo "$os" | tr '[:lower:]' '[:upper:]')
     api_arch=$(echo "$architecture" | tr '[:lower:]' '[:upper:]')
 
-    version_response=$(curl --fail --silent --location \
+    version_response=$(curl --fail --silent --location --retry 3 --retry-all-errors \
       -X POST \
       -H "Content-Type: application/json" \
       -d "{\"${tool_name}\":{}}" \
@@ -138,7 +138,8 @@ do_install() {
   trap "rm -rf $TEMP_DIR" EXIT
 
   cd ${TEMP_DIR}
-  $sh_c "curl $ci_header --fail --location --progress-bar --user-agent install_nsc.sh \"${download_uri}\" | tar -xz"
+  $sh_c "curl $ci_header --fail --location --retry 3 --retry-all-errors --progress-bar --user-agent install_nsc.sh --output nsc.tar.gz \"${download_uri}\""
+  $sh_c "tar -xzf nsc.tar.gz"
 
   $sh_c "chmod +x ${tool_name}"
   $sh_c "chmod +x ${docker_cred_helper_name}"


### PR DESCRIPTION
## Summary

- retry installer HTTP requests up to three times after the initial attempt
- use exponential backoff on both PowerShell and curl-based installers
- download archives fully before extraction so retries discard partial responses
- retry latest-version lookup for nsc as well as package downloads

This applies the same fresh-download behavior used by the internal artifact downloader for mid-response failures such as the HTTP/2 stream errors covered by #1886.

## Testing

- `sh -n install/install.sh`
- `sh -n install/install_nsc.sh`
- `install/install.sh --dry_run --version 0.0.546`
- `install/install_nsc.sh --dry_run --version 0.0.546`
- `git diff --check`

PowerShell is not available in the local validation environment.