### PR TITLE
docs: fix verb form (want to used -> want to use) in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Install it with `go install ./cmd/nsdev` to unlock all debug workflows below.
 
 ### Debugging via VS Code
 
-The debugging configuration is not in the repository because different people may want to used
+The debugging configuration is not in the repository because different people may want to use
 different arguments. To bootstrap, create `.vscode/launch.json` and add the following content:
 
 ```bash


### PR DESCRIPTION
## Description
This PR fixes a verb tense/form typo in `CONTRIBUTING.md`.

## Details
Updated `want to used` -> `want to use` under the Debugging via VS Code section.