### PR TITLE
nsc bazel: create parent directory for --bazelrc output

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -638,6 +638,12 @@ func writeTempFile(base, pattern string, content []byte) (string, error) {
 }
 
 func writeFile(path string, content []byte) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fnerrors.Newf("failed to create directory %q: %w", dir, err)
+		}
+	}
+
 	if err := os.WriteFile(path, content, 0644); err != nil {
 		return fnerrors.Newf("failed to write %q: %w", path, err)
 	}


### PR DESCRIPTION
## Summary

When using `nsc bazel cache setup` or `nsc bazel setup` with the `--bazelrc` flag, the command failed if the parent directory of the specified path did not already exist, because `os.WriteFile` does not create parent directories.

## Motivation

Users expect `--bazelrc=some/new/dir/.bazelrc` to just work, similar to how `--cred_path` already creates its target directory with `os.MkdirAll` before writing credential files. Forgetting to pre-create the directory is an easy mistake that results in a confusing error.

## Key changes

`writeFile` now calls `os.MkdirAll` on the parent directory before `os.WriteFile`. This is idempotent (`MkdirAll` is a no-op if the directory exists), so all existing call sites — including credential files written under `--cred_path` — are unaffected.