### PR TITLE
Skip empty keep-alive responses in bazel invocation report

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"namespacelabs.dev/foundation/internal/cli/fncobra"
 	"namespacelabs.dev/foundation/internal/console"
@@ -252,6 +253,13 @@ func newBazelInvocationReportCmd() *cobra.Command {
 			}
 			if err != nil {
 				return fnerrors.Newf("failed to receive Bazel invocation report: %w", err)
+			}
+
+			// Skip the initial keep-alive response (all fields zero) that the
+			// server sends to flush headers before long-running report
+			// generation.
+			if proto.Equal(record, &bazelv1beta.StreamInvocationReportResponse{}) {
+				continue
 			}
 
 			if err := writeBazelInvocationReportRecord(console.Stdout(ctx), record); err != nil {


### PR DESCRIPTION
## Summary

- The server now sends an initial empty `StreamInvocationReportResponse` to flush response headers before long-running report generation (namespacelabs/internal#19094).
- Skip these zero-value responses in the CLI receive loop with `proto.Equal` so they do not produce spurious `{}` output.

## Validation

- `go build ./internal/cli/cmd/cluster/...`
- `go test ./internal/cli/cmd/cluster/...`