### PR TITLE
Roll back secured gRPC listener changes

### DIFF
--- a/internal/integrations/golang/golang.go
+++ b/internal/integrations/golang/golang.go
@@ -276,15 +276,13 @@ func (impl) InternalEndpoints(_ *schema.Environment, srv *schema.Server, ports [
 		{"/livez", runtime.FnServiceLivez},
 		{"/readyz", runtime.FnServiceReadyz},
 	}
+	var serverPortName = "server-port"
 
 	var serverPort *schema.Endpoint_Port
 	for _, port := range ports {
-		if port.Name == "http-port" {
+		if port.Name == serverPortName {
 			serverPort = port
 			break
-		}
-		if port.Name == "server-port" {
-			serverPort = port
 		}
 	}
 

--- a/std/go/core/endpoints.go
+++ b/std/go/core/endpoints.go
@@ -12,6 +12,9 @@ import (
 func RegisterDebugEndpoints(mux *mux.Router) {
 	var endpoints []string
 
+	pprofEndpoint := registerPprofEndpoints(mux)
+	endpoints = append(endpoints, pprofEndpoint)
+
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/livez", livezEndpoint())
 	mux.Handle("/readyz", readyzEndpoint())

--- a/std/go/core/init_test.go
+++ b/std/go/core/init_test.go
@@ -4,13 +4,7 @@
 
 package core
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-
-	"github.com/gorilla/mux"
-)
+import "testing"
 
 func TestEnforceBefore(t *testing.T) {
 	initializers := []*Initializer{
@@ -23,17 +17,6 @@ func TestEnforceBefore(t *testing.T) {
 
 	if _, err := enforceOrder(initializers); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestRegisterDebugEndpointsDoesNotExposePprof(t *testing.T) {
-	router := mux.NewRouter()
-	RegisterDebugEndpoints(router)
-
-	response := httptest.NewRecorder()
-	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
-	if response.Code != http.StatusNotFound {
-		t.Fatalf("got status %d, want %d", response.Code, http.StatusNotFound)
 	}
 }
 

--- a/std/go/core/pprof.go
+++ b/std/go/core/pprof.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package core
+
+import (
+	"net/http/pprof"
+
+	"github.com/gorilla/mux"
+)
+
+func registerPprofEndpoints(mux *mux.Router) string {
+	mux.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return "/debug/pprof/"
+}

--- a/std/go/grpc/extension.cue
+++ b/std/go/grpc/extension.cue
@@ -14,17 +14,13 @@ $inputs: {
 	serverPort: inputs.#Port & {
 		name: "server-port"
 	}
-	httpPort: inputs.#Port & {
-		name: "http-port"
-	}
 }
 
 configure: fn.#Configure & {
 	startup: {
 		args: {
-			listen_hostname:      "0.0.0.0"
-			grpcserver_port:      "\($inputs.serverPort.port)"
-			grpcserver_http_port: "\($inputs.httpPort.port)"
+			listen_hostname: "0.0.0.0"
+			grpcserver_port: "\($inputs.serverPort.port)"
 		}
 
 		env: {

--- a/std/go/grpc/extension.cue
+++ b/std/go/grpc/extension.cue
@@ -7,7 +7,6 @@ extension: fn.#Extension & {
 	import: [
 		"namespacelabs.dev/foundation/std/core",
 		"namespacelabs.dev/foundation/std/go/grpc/metrics",
-		"namespacelabs.dev/foundation/std/go/http",
 	]
 }
 
@@ -15,13 +14,17 @@ $inputs: {
 	serverPort: inputs.#Port & {
 		name: "server-port"
 	}
+	httpPort: inputs.#Port & {
+		name: "http-port"
+	}
 }
 
 configure: fn.#Configure & {
 	startup: {
 		args: {
-			listen_hostname: "0.0.0.0"
-			grpcserver_port: "\($inputs.serverPort.port)"
+			listen_hostname:      "0.0.0.0"
+			grpcserver_port:      "\($inputs.serverPort.port)"
+			grpcserver_http_port: "\($inputs.httpPort.port)"
 		}
 
 		env: {

--- a/std/go/grpc/servercore/listener.go
+++ b/std/go/grpc/servercore/listener.go
@@ -116,7 +116,14 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 		return err
 	}
 
-	tlsL, httpL, anyL := matchDefaultListeners(m, tlsConfig != nil || gogrpc.ServerCreds != nil)
+	var tlsL net.Listener = nil
+	if tlsConfig != nil {
+		tlsL = m.Match(cmux.TLS())
+	}
+
+	httpL := m.Match(cmux.HTTP1())
+	anyL := m.Match(cmux.Any())
+
 	grpcopts := OrderedServerInterceptors()
 
 	if gogrpc.ServerCreds != nil {
@@ -132,14 +139,16 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 		PermitWithoutStream: true,
 	}))
 
-	defaultServerOpts := slices.Clone(grpcopts)
-	if tlsConfig != nil {
-		defaultServerOpts = append(defaultServerOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
-	}
-
-	defaultServer := grpc.NewServer(defaultServerOpts...)
+	defaultServer := grpc.NewServer(grpcopts...)
 	serversByConfiguration := map[string][]*grpc.Server{
 		"": {defaultServer},
+	}
+
+	var mtlsServer *grpc.Server
+	if tlsConfig != nil {
+		mtlsServer = grpc.NewServer(append(grpcopts, grpc.Creds(credentials.NewTLS(tlsConfig)))...)
+
+		serversByConfiguration[""] = append(serversByConfiguration[""], mtlsServer)
 	}
 
 	rt, err := runtime.LoadRuntimeConfig()
@@ -184,7 +193,7 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 	httpMux := NewHTTPMux(middleware.Registered()...)
 
 	s := &ServerImpl{srv: serversByConfiguration, httpMux: httpMux}
-	registerHTTPServices(s, registerServices)
+	registerServices(s)
 
 	grpc_prometheus.EnableHandlingTimeHistogram()
 
@@ -243,16 +252,13 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 		eg.Go(func() error { return ListenAndGracefullyShutdownHTTP(egCtx, "http", httpServer, gwLis) })
 	}
 
-	if httpL != nil {
-		debugHTTP := &http.Server{Handler: debugMux}
-		eg.Go(func() error { return ListenAndGracefullyShutdownHTTP(egCtx, "http/debug", debugHTTP, httpL) })
-	}
+	debugHTTP := &http.Server{Handler: debugMux}
+	eg.Go(func() error { return ListenAndGracefullyShutdownHTTP(egCtx, "http/debug", debugHTTP, httpL) })
 
-	if anyL != nil {
-		eg.Go(func() error { return ListenAndGracefullyShutdownGRPC(egCtx, "grpc", defaultServer, anyL) })
-	}
-	if tlsL != nil {
-		eg.Go(func() error { return ListenAndGracefullyShutdownGRPC(egCtx, "grpc/tls", defaultServer, tlsL) })
+	eg.Go(func() error { return ListenAndGracefullyShutdownGRPC(egCtx, "grpc", defaultServer, anyL) })
+
+	if mtlsServer != nil {
+		eg.Go(func() error { return ListenAndGracefullyShutdownGRPC(egCtx, "grpc/tls", mtlsServer, tlsL) })
 	}
 
 	for k, srvs := range serversByConfiguration {
@@ -314,21 +320,6 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 	err = eg.Wait()
 	core.ZLog.Info().Err(err).Msg("stopped listening")
 	return err
-}
-
-func registerHTTPServices(s *ServerImpl, registerServices func(Server)) {
-	// Gorilla mux resolves routes in registration order. Keep administrative
-	// endpoints ahead of application catch-all routes.
-	core.RegisterDebugEndpoints(s.httpMux)
-	registerServices(s)
-}
-
-func matchDefaultListeners(m cmux.CMux, transportSecurity bool) (net.Listener, net.Listener, net.Listener) {
-	if transportSecurity {
-		return m.Match(cmux.TLS()), nil, nil
-	}
-
-	return nil, m.Match(cmux.HTTP1()), m.Match(cmux.Any())
 }
 
 func NewHttp2CapableServer(mux http.Handler, opts HTTPOptions) *http.Server {

--- a/std/go/grpc/servercore/listener_test.go
+++ b/std/go/grpc/servercore/listener_test.go
@@ -11,112 +11,18 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/soheilhy/cmux"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"namespacelabs.dev/foundation/std/go/core"
 	nsgrpc "namespacelabs.dev/foundation/std/go/grpc"
 )
-
-func TestMatchDefaultListeners(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		mtls     bool
-		wantTLS  bool
-		wantHTTP bool
-		wantGRPC bool
-	}{
-		{name: "plaintext", wantHTTP: true, wantGRPC: true},
-		{name: "mTLS", mtls: true, wantTLS: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
-			if err != nil {
-				t.Fatalf("listen: %v", err)
-			}
-			defer listener.Close()
-
-			tlsListener, httpListener, grpcListener := matchDefaultListeners(cmux.New(listener), tc.mtls)
-			if (tlsListener != nil) != tc.wantTLS || (httpListener != nil) != tc.wantHTTP || (grpcListener != nil) != tc.wantGRPC {
-				t.Fatalf("unexpected listeners: tls=%t http=%t grpc=%t", tlsListener != nil, httpListener != nil, grpcListener != nil)
-			}
-		})
-	}
-}
-
-func TestSecureDefaultListenerRejectsPlaintextHTTP(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer listener.Close()
-
-	m := cmux.New(listener)
-	matchDefaultListeners(m, true)
-	serveDone := make(chan error, 1)
-	go func() {
-		serveDone <- m.Serve()
-	}()
-
-	conn, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	defer conn.Close()
-
-	if _, err := io.WriteString(conn, "GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n"); err != nil {
-		t.Fatalf("write request: %v", err)
-	}
-	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-		t.Fatalf("set deadline: %v", err)
-	}
-
-	buffer := make([]byte, 1)
-	if _, err := conn.Read(buffer); err == nil {
-		t.Fatal("plaintext connection was not closed")
-	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		t.Fatal("plaintext connection remained open")
-	}
-
-	if err := listener.Close(); err != nil {
-		t.Fatalf("close listener: %v", err)
-	}
-	select {
-	case <-serveDone:
-	case <-time.After(time.Second):
-		t.Fatal("cmux did not stop")
-	}
-}
-
-func TestRegisterHTTPServicesKeepsAdministrativeRoutesAheadOfCatchAll(t *testing.T) {
-	httpMux := NewHTTPMux()
-	s := &ServerImpl{httpMux: httpMux}
-
-	registerHTTPServices(s, func(server Server) {
-		server.Scope(&core.Package{}).PathPrefix("/").Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("X-Application-Catch-All", "true")
-			w.WriteHeader(http.StatusTeapot)
-		}))
-	})
-
-	for _, path := range []string{"/metrics", "/livez", "/readyz"} {
-		req := httptest.NewRequest(http.MethodGet, path, nil)
-		response := httptest.NewRecorder()
-		httpMux.ServeHTTP(response, req)
-		if response.Header().Get("X-Application-Catch-All") != "" {
-			t.Errorf("%s was handled by the application catch-all", path)
-		}
-	}
-}
 
 // TestNewHttp2CapableServer_GoawayOnShutdown verifies that
 // NewHttp2CapableServer wires up HTTP/2 graceful shutdown for h2c


### PR DESCRIPTION
## Summary

- Reverts #1905 and #1895.
- Restores the repository tree to its state before `f11e7419213aa9a96364a1b1545d408f7513f4f6`.

## Validation

- `go test -count=1 ./std/go/grpc/servercore ./std/go/core ./internal/integrations/golang`
- Verified the resulting tree matches `da630dcd8`.