### PR TITLE
Use HTTP port for service health checks

### DIFF
--- a/internal/integrations/golang/golang.go
+++ b/internal/integrations/golang/golang.go
@@ -277,18 +277,13 @@ func (impl) InternalEndpoints(env *schema.Environment, srv *schema.Server, ports
 		{"/readyz", runtime.FnServiceReadyz},
 	}
 
-	preferredPortName := "http-port"
-	if env.Purpose == schema.Environment_TESTING {
-		preferredPortName = "server-port"
-	}
-
 	var serverPort *schema.Endpoint_Port
 	for _, port := range ports {
-		if port.Name == preferredPortName {
+		if port.Name == "http-port" {
 			serverPort = port
 			break
 		}
-		if port.Name == "server-port" || port.Name == "http-port" {
+		if port.Name == "server-port" {
 			serverPort = port
 		}
 	}

--- a/internal/integrations/golang/golang_test.go
+++ b/internal/integrations/golang/golang_test.go
@@ -21,7 +21,7 @@ func TestInternalEndpointsSelectsHealthPort(t *testing.T) {
 		purpose  schema.Environment_Purpose
 		wantPort string
 	}{
-		{name: "testing", purpose: schema.Environment_TESTING, wantPort: "server-port"},
+		{name: "testing", purpose: schema.Environment_TESTING, wantPort: "http-port"},
 		{name: "production", purpose: schema.Environment_PRODUCTION, wantPort: "http-port"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Use the plaintext HTTP listener for generated readiness, liveness, and metrics endpoints in all environments.

## Motivation

Secured gRPC listeners reject plaintext health probes. Testing environments do not provision the mTLS credentials those listeners require, so selecting the gRPC server port leaves workloads unable to become healthy.

## Validation

- `go test ./internal/integrations/golang`
- `ns test namespacelabs.dev/internal/devbox/testing/management:e2e`