### PR TITLE
nsc bazel: support read-only storage setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.0
 
 require (
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1
-	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260807183118-54ecdac1cb7f.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260807183118-54ecdac1cb7f.1
+	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d
 buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1/go.mod h1:h9DLLqhUERXx+6lPKgrJxRAG03mCRRAv6VEJnmUnQGk=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1 h1:Nu+h9ryPRPUvcJcEl9C8g4ryyGPYFbujbEIIbDVUDxA=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1/go.mod h1:xO9KI77e5zYyYFSpddrTqcwrL8a0z+xys5/CMeKOto4=
-buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260807183118-54ecdac1cb7f.1 h1:uxx7Vq6N+9ON5HNC5yJGH5Y2jLx8K+A4AA7uuw4xIWM=
-buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260807183118-54ecdac1cb7f.1/go.mod h1:DZXt8iyIX/DKXfcPFoaqPoWYKeJ18ZA+swgQ9wn0dR0=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260807183118-54ecdac1cb7f.1 h1:SIWw1Ek76Vh0ztJxrj4XU94edLFBozQrp5bf2kv/UNU=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260807183118-54ecdac1cb7f.1/go.mod h1:Sq0KOCy7xpul1cCYq/55WryE9Nke8fQsext30EBZp7o=
+buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1 h1:z+Fe4SOP1T1BWkdq6WA0VvNdStRYCpAJsPVuKZyM+PU=
+buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1/go.mod h1:kNp5GpQ3qod6DJaIJHXTJOPoORGIGXx/vSTVWAZ3OAM=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1 h1:kv5P02k0h+RfyXDqFydfwEBYP5LwJfKGgk6saY7jO60=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1/go.mod h1:Sq0KOCy7xpul1cCYq/55WryE9Nke8fQsext30EBZp7o=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -36,6 +36,8 @@ const (
 	defaultBazelRbeCommand      = "build"
 	bazelProvisioningMaxRetries = 3
 	bazelProvisioningRetryWait  = 200 * time.Millisecond
+	bazelStorageReadOnly        = "read-only"
+	bazelStorageReadWrite       = "read-write"
 )
 
 func newSetupExecutionCmd() *cobra.Command {
@@ -47,7 +49,7 @@ func newSetupBazelCmd() *cobra.Command {
 }
 
 func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
-	var bazelRcPath, output, bazelCommand, key, tokenFile string
+	var bazelRcPath, output, bazelCommand, key, tokenFile, storageMode string
 	var staticDur time.Duration
 	var static, enableRemoteAssetAPI, disableBuildEvents bool
 	remote := true
@@ -67,9 +69,20 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 		flags.BoolVar(&disableBuildEvents, "disable_build_events", false, "If specified, do not configure Bazel to send build events.")
 		fncobra.DurationVar(flags, &staticDur, "static_token_duration", 4*time.Hour, "The minimum duration of the static token configured (requires --static).")
 		if includeRemoteFlag {
-			flags.BoolVar(&remote, "remote", true, "If false, configure remote caching and build events without remote execution.")
+			flags.BoolVar(&remote, "remote", true, "If false, configure remote caching without remote execution.")
+			flags.StringVar(&storageMode, "storage", bazelStorageReadWrite, "Storage access mode. Valid options: read-only, read-write.")
 		}
 	}).Do(func(ctx context.Context) error {
+		if storageMode != "" && storageMode != bazelStorageReadOnly && storageMode != bazelStorageReadWrite {
+			return fnerrors.BadInputError("invalid storage mode %q (valid values: read-only, read-write)", storageMode)
+		}
+		if remote && storageMode == bazelStorageReadOnly {
+			return fnerrors.BadInputError("--storage=read-only requires --remote=false")
+		}
+		if enableRemoteAssetAPI && storageMode == bazelStorageReadOnly {
+			return fnerrors.BadInputError("--enable_remote_asset_api may not be used with --storage=read-only")
+		}
+
 		var tok api.TokenSource
 		if tokenFile != "" {
 			loaded, err := loadTokenFromFile(tokenFile)
@@ -91,23 +104,44 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			authMode = bazelv1beta.BazelExecutionAuthMode_BAZEL_EXECUTION_AUTH_MODE_STATIC
 		}
 
-		res, err := ensureBazelExecutionCluster(ctx, tok, key, authMode, enableRemoteAssetAPI)
-		if err != nil {
-			return fnerrors.Newf("failed to provision bazel execution cluster: %w", err)
-		}
+		var out bazelRbeSetup
+		if remote {
+			res, err := ensureBazelExecutionCluster(ctx, tok, key, authMode, enableRemoteAssetAPI)
+			if err != nil {
+				return fnerrors.Newf("failed to provision bazel execution cluster: %w", err)
+			}
 
-		if res.GetSchedulerEndpoint() == "" || res.GetStorageEndpoint() == "" {
-			return fnerrors.Newf("received incomplete response (scheduler=%q storage=%q)", res.GetSchedulerEndpoint(), res.GetStorageEndpoint())
-		}
+			if res.GetSchedulerEndpoint() == "" || res.GetStorageEndpoint() == "" {
+				return fnerrors.Newf("received incomplete response (scheduler=%q storage=%q)", res.GetSchedulerEndpoint(), res.GetStorageEndpoint())
+			}
 
-		out := bazelRbeSetup{
-			SchedulerEndpoint:     res.GetSchedulerEndpoint(),
-			StorageEndpoint:       res.GetStorageEndpoint(),
-			RemoteAssetEndpoint:   res.GetRemoteAssetEndpoint(),
-			Jobs:                  int32(res.GetRecommendedBazelJobs()),
-			RemoteTimeout:         time.Duration(res.GetRecommendedBazelRemoteTimeoutSeconds()) * time.Second,
-			RemoteLocalFallback:   res.GetRecommendedBazelRemoteLocalFallback(),
-			RemoteDownloadOutputs: res.GetRecommendedBazelRemoteDownloadOutputs(),
+			out = bazelRbeSetup{
+				SchedulerEndpoint:     res.GetSchedulerEndpoint(),
+				StorageEndpoint:       res.GetStorageEndpoint(),
+				RemoteAssetEndpoint:   res.GetRemoteAssetEndpoint(),
+				Jobs:                  int32(res.GetRecommendedBazelJobs()),
+				RemoteTimeout:         time.Duration(res.GetRecommendedBazelRemoteTimeoutSeconds()) * time.Second,
+				RemoteLocalFallback:   res.GetRecommendedBazelRemoteLocalFallback(),
+				RemoteDownloadOutputs: res.GetRecommendedBazelRemoteDownloadOutputs(),
+			}
+
+			// The build event endpoint is a separate, bearer-authenticated host
+			// (the regional API gateway), independent of the scheduler/storage auth
+			// mode. The server only returns it (and the credential helper domains
+			// used to authenticate it in the default mTLS mode) when build event
+			// ingestion is enabled for the workspace.
+			out.BuildEventEndpoint = res.GetBuildEventEndpoint()
+			out.CredentialHelperDomains = res.GetCredentialHelperDomains()
+		} else {
+			res, err := ensureBazelStorageCluster(ctx, tok, key, authMode, enableRemoteAssetAPI, bazelStorageAccessMode(storageMode))
+			if err != nil {
+				return fnerrors.Newf("failed to provision bazel storage cluster: %w", err)
+			}
+			if res.GetStorageEndpoint() == "" {
+				return fnerrors.Newf("received incomplete response (storage=%q)", res.GetStorageEndpoint())
+			}
+
+			out = bazelStorageSetup(res)
 		}
 
 		if static {
@@ -152,14 +186,6 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			out.ClientCert = clientCertPath
 			out.ClientKey = clientKeyPath
 		}
-
-		// The build event endpoint is a separate, bearer-authenticated host
-		// (the regional API gateway), independent of the scheduler/storage auth
-		// mode. The server only returns it (and the credential helper domains
-		// used to authenticate it in the default mTLS mode) when build event
-		// ingestion is enabled for the workspace.
-		out.BuildEventEndpoint = res.GetBuildEventEndpoint()
-		out.CredentialHelperDomains = res.GetCredentialHelperDomains()
 
 		if bazelRcPath != "" {
 			data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote, disableBuildEvents)
@@ -215,18 +241,28 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 }
 
 type bazelRbeSetup struct {
-	SchedulerEndpoint       string        `json:"scheduler_endpoint,omitempty"`
-	StorageEndpoint         string        `json:"storage_endpoint,omitempty"`
-	RemoteAssetEndpoint     string        `json:"remote_asset_endpoint,omitempty"`
-	ClientCert              string        `json:"client_cert,omitempty"`
-	ClientKey               string        `json:"client_key,omitempty"`
-	IngressAuthToken        string        `json:"ingress_auth_token,omitempty"`
-	Jobs                    int32         `json:"jobs,omitempty"`
-	RemoteTimeout           time.Duration `json:"remote_timeout,omitempty"`
-	RemoteLocalFallback     bool          `json:"remote_local_fallback,omitempty"`
-	RemoteDownloadOutputs   string        `json:"remote_download_outputs,omitempty"`
-	BuildEventEndpoint      string        `json:"build_event_endpoint,omitempty"`
-	CredentialHelperDomains []string      `json:"credential_helper_domains,omitempty"`
+	SchedulerEndpoint        string        `json:"scheduler_endpoint,omitempty"`
+	StorageEndpoint          string        `json:"storage_endpoint,omitempty"`
+	RemoteAssetEndpoint      string        `json:"remote_asset_endpoint,omitempty"`
+	RemoteUploadLocalResults *bool         `json:"remote_upload_local_results,omitempty"`
+	ClientCert               string        `json:"client_cert,omitempty"`
+	ClientKey                string        `json:"client_key,omitempty"`
+	IngressAuthToken         string        `json:"ingress_auth_token,omitempty"`
+	Jobs                     int32         `json:"jobs,omitempty"`
+	RemoteTimeout            time.Duration `json:"remote_timeout,omitempty"`
+	RemoteLocalFallback      bool          `json:"remote_local_fallback,omitempty"`
+	RemoteDownloadOutputs    string        `json:"remote_download_outputs,omitempty"`
+	BuildEventEndpoint       string        `json:"build_event_endpoint,omitempty"`
+	CredentialHelperDomains  []string      `json:"credential_helper_domains,omitempty"`
+}
+
+func bazelStorageSetup(response *bazelv1beta.EnsureStorageClusterResponse) bazelRbeSetup {
+	remoteUploadLocalResults := response.GetRecommendedBazelRemoteUploadLocalResults()
+	return bazelRbeSetup{
+		StorageEndpoint:          response.GetStorageEndpoint(),
+		RemoteAssetEndpoint:      response.GetRemoteAssetEndpoint(),
+		RemoteUploadLocalResults: &remoteUploadLocalResults,
+	}
 }
 
 func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command string, remote, disableBuildEvents bool) ([]byte, error) {
@@ -260,6 +296,9 @@ func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command stri
 	}
 	if out.RemoteDownloadOutputs != "" {
 		lines = append(lines, fmt.Sprintf("--remote_download_outputs=%s", out.RemoteDownloadOutputs))
+	}
+	if out.RemoteUploadLocalResults != nil {
+		lines = append(lines, fmt.Sprintf("--remote_upload_local_results=%t", *out.RemoteUploadLocalResults))
 	}
 	if out.Jobs > 0 {
 		lines = append(lines, fmt.Sprintf("--jobs=%d", out.Jobs))
@@ -335,6 +374,36 @@ func ensureBazelExecutionCluster(ctx context.Context, tok api.TokenSource, key s
 	return retryBazelProvisioning(ctx, func() (*bazelv1beta.EnsureClusterResponse, error) {
 		return client.EnsureCluster(ctx, req)
 	})
+}
+
+func ensureBazelStorageCluster(ctx context.Context, tok api.TokenSource, key string, authMode bazelv1beta.BazelExecutionAuthMode, enableRemoteAssetAPI bool, accessMode bazelv1beta.BazelStorageAccessMode) (*bazelv1beta.EnsureStorageClusterResponse, error) {
+	client, conn, err := newBazelServiceClient(ctx, tok)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	req := makeEnsureBazelStorageClusterRequest(key, authMode, enableRemoteAssetAPI, accessMode)
+
+	return retryBazelProvisioning(ctx, func() (*bazelv1beta.EnsureStorageClusterResponse, error) {
+		return client.EnsureStorageCluster(ctx, req)
+	})
+}
+
+func makeEnsureBazelStorageClusterRequest(key string, authMode bazelv1beta.BazelExecutionAuthMode, enableRemoteAssetAPI bool, accessMode bazelv1beta.BazelStorageAccessMode) *bazelv1beta.EnsureStorageClusterRequest {
+	req := &bazelv1beta.EnsureStorageClusterRequest{}
+	req.SetKey(key)
+	req.SetAuthMode(authMode)
+	req.SetEnableRemoteAssetApi(enableRemoteAssetAPI)
+	req.SetAccessMode(accessMode)
+	return req
+}
+
+func bazelStorageAccessMode(storageMode string) bazelv1beta.BazelStorageAccessMode {
+	if storageMode == bazelStorageReadOnly {
+		return bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_ONLY
+	}
+	return bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_WRITE
 }
 
 func retryBazelProvisioning[T any](ctx context.Context, call func() (T, error)) (T, error) {

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	bazelv1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/integrations/bazel/v1beta"
 	"connectrpc.com/connect"
 	"github.com/cenkalti/backoff/v4"
 	"google.golang.org/grpc/codes"
@@ -122,15 +123,17 @@ func TestToBazelExecutionConfigBuildEventsDisabled(t *testing.T) {
 func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 	t.Parallel()
 
+	remoteUploadLocalResults := false
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
-		SchedulerEndpoint:     "grpcs://scheduler.example:443",
-		StorageEndpoint:       "grpcs://storage.example:443",
-		IngressAuthToken:      "tok123",
-		RemoteLocalFallback:   true,
-		RemoteDownloadOutputs: "minimal",
-		RemoteTimeout:         5 * time.Minute,
-		Jobs:                  32,
-		BuildEventEndpoint:    "grpcs://api.us-east1.namespaceapis.com",
+		SchedulerEndpoint:        "grpcs://scheduler.example:443",
+		StorageEndpoint:          "grpcs://storage.example:443",
+		RemoteUploadLocalResults: &remoteUploadLocalResults,
+		IngressAuthToken:         "tok123",
+		RemoteLocalFallback:      true,
+		RemoteDownloadOutputs:    "minimal",
+		RemoteTimeout:            5 * time.Minute,
+		Jobs:                     32,
+		BuildEventEndpoint:       "grpcs://api.us-east1.namespaceapis.com",
 	}, "build", false, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
@@ -141,6 +144,7 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 		"build --remote_cache=grpcs://storage.example:443\n",
 		"build --remote_header=x-nsc-ingress-auth=Bearer\\ tok123\n",
 		"build --remote_download_outputs=minimal\n",
+		"build --remote_upload_local_results=false\n",
 		"build --jobs=32\n",
 		"build --remote_timeout=300\n",
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
@@ -181,6 +185,13 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	if remote.DefValue != "true" {
 		t.Fatalf("--remote default = %q, want true", remote.DefValue)
 	}
+	storage := setup.Flags().Lookup("storage")
+	if storage == nil {
+		t.Fatal("bazel setup is missing --storage")
+	}
+	if storage.DefValue != bazelStorageReadWrite {
+		t.Fatalf("--storage default = %q, want %q", storage.DefValue, bazelStorageReadWrite)
+	}
 	if setup.Flags().Lookup("token") == nil {
 		t.Fatal("bazel setup is missing --token")
 	}
@@ -195,11 +206,93 @@ func TestNewBazelCmdSetupAlias(t *testing.T) {
 	if executionSetup.Flags().Lookup("remote") != nil {
 		t.Fatal("bazel execution setup must not expose --remote")
 	}
+	if executionSetup.Flags().Lookup("storage") != nil {
+		t.Fatal("bazel execution setup must not expose --storage")
+	}
 	if executionSetup.Flags().Lookup("token") == nil {
 		t.Fatal("bazel execution setup is missing --token")
 	}
 	if executionSetup.Flags().Lookup("disable_build_events") == nil {
 		t.Fatal("bazel execution setup is missing --disable_build_events")
+	}
+}
+
+func TestBazelSetupStorageModeValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "invalid mode", args: []string{"--storage=invalid"}, want: "invalid storage mode"},
+		{name: "read only with remote execution", args: []string{"--storage=read-only"}, want: "requires --remote=false"},
+		{name: "read only with remote asset API", args: []string{"--remote=false", "--storage=read-only", "--enable_remote_asset_api"}, want: "may not be used with --storage=read-only"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newSetupBazelCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.ExecuteContext(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ExecuteContext() error = %v, want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBazelStorageSetup(t *testing.T) {
+	t.Parallel()
+
+	response := &bazelv1beta.EnsureStorageClusterResponse{
+		StorageEndpoint:                          "grpcs://storage.example:444",
+		RemoteAssetEndpoint:                      "grpcs://asset.example:444",
+		RecommendedBazelRemoteUploadLocalResults: true,
+	}
+
+	readWrite := bazelStorageSetup(response)
+	if readWrite.RemoteUploadLocalResults == nil || !*readWrite.RemoteUploadLocalResults {
+		t.Fatalf("read-write setup upload recommendation = %v, want true", readWrite.RemoteUploadLocalResults)
+	}
+	if readWrite.StorageEndpoint != response.GetStorageEndpoint() || readWrite.RemoteAssetEndpoint != response.GetRemoteAssetEndpoint() {
+		t.Fatalf("read-write setup = %#v, want response endpoints", readWrite)
+	}
+
+	response.SetRecommendedBazelRemoteUploadLocalResults(false)
+	readOnly := bazelStorageSetup(response)
+	if readOnly.RemoteUploadLocalResults == nil || *readOnly.RemoteUploadLocalResults {
+		t.Fatalf("read-only setup upload recommendation = %v, want false", readOnly.RemoteUploadLocalResults)
+	}
+}
+
+func TestMakeEnsureBazelStorageClusterRequest(t *testing.T) {
+	t.Parallel()
+
+	req := makeEnsureBazelStorageClusterRequest(
+		"ci",
+		bazelv1beta.BazelExecutionAuthMode_BAZEL_EXECUTION_AUTH_MODE_STATIC,
+		true,
+		bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_ONLY,
+	)
+	if req.GetKey() != "ci" {
+		t.Fatalf("key = %q, want ci", req.GetKey())
+	}
+	if req.GetAuthMode() != bazelv1beta.BazelExecutionAuthMode_BAZEL_EXECUTION_AUTH_MODE_STATIC {
+		t.Fatalf("auth mode = %v, want static", req.GetAuthMode())
+	}
+	if !req.GetEnableRemoteAssetApi() {
+		t.Fatal("remote asset API is disabled, want enabled")
+	}
+	if req.GetAccessMode() != bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_ONLY {
+		t.Fatalf("access mode = %v, want read-only", req.GetAccessMode())
+	}
+}
+
+func TestBazelStorageAccessMode(t *testing.T) {
+	t.Parallel()
+
+	if got := bazelStorageAccessMode(bazelStorageReadOnly); got != bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_ONLY {
+		t.Fatalf("read-only access mode = %v, want read-only", got)
+	}
+	if got := bazelStorageAccessMode(bazelStorageReadWrite); got != bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_WRITE {
+		t.Fatalf("read-write access mode = %v, want read-write", got)
 	}
 }
 

--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -278,8 +278,8 @@ func TestNewBazelTokenRequest(t *testing.T) {
 	}
 
 	grants := req.GetAccess().GetGrants()
-	if len(grants) != 2 {
-		t.Fatalf("grant count = %d, want 2", len(grants))
+	if len(grants) != 3 {
+		t.Fatalf("grant count = %d, want 3", len(grants))
 	}
 	assertGrant := func(got *iamv1beta.Permission, resourceType, action string) {
 		t.Helper()
@@ -288,7 +288,8 @@ func TestNewBazelTokenRequest(t *testing.T) {
 		}
 	}
 	assertGrant(grants[0], "bazel/execution", "ensure")
-	assertGrant(grants[1], "ingress", "access")
+	assertGrant(grants[1], "bazel/storage", "write")
+	assertGrant(grants[2], "ingress", "access")
 
 	tenantReq, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "tenant")
 	if err != nil {

--- a/internal/cli/cmd/cluster/createtoken.go
+++ b/internal/cli/cmd/cluster/createtoken.go
@@ -176,6 +176,7 @@ func newBazelTokenRequest(name string, expiresAt time.Time, scope string) (*iamv
 		Access: &iamv1beta.AccessPolicy{
 			Grants: []*iamv1beta.Permission{
 				{ResourceType: "bazel/execution", ResourceId: "*", Actions: []string{"ensure"}},
+				{ResourceType: "bazel/storage", ResourceId: "*", Actions: []string{"write"}},
 				{ResourceType: "ingress", ResourceId: "*", Actions: []string{"access"}},
 			},
 		},


### PR DESCRIPTION
## Summary

- Use the storage-only Bazel RPC for `nsc bazel setup --remote=false`.
- Add `--storage=read-only|read-write`, defaulting to read-write, and send the requested access mode to the server.
- Configure local-result uploads from the server's resolved access mode.
- Grant storage write access to newly created Bazel execution tokens.

## Validation

- `go test ./internal/cli/cmd/cluster -run Bazel`