### PR TITLE
nsc bazel: configure build results URL

### DIFF
--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -144,6 +144,18 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			out = bazelStorageSetup(res)
 		}
 
+		if out.BuildEventEndpoint != "" && !disableBuildEvents {
+			tenant, err := fnapi.GetTenantWithToken(ctx, tok)
+			if err != nil {
+				return fnerrors.Newf("failed to resolve tenant for build event results: %w", err)
+			}
+			if tenant.Tenant == nil || tenant.Tenant.TenantId == "" {
+				return fnerrors.New("received incomplete tenant response")
+			}
+
+			out.TenantID = tenant.Tenant.TenantId
+		}
+
 		if static {
 			// In static mode the server returns the public, bearer-authenticated
 			// endpoints (and deliberately does not expose the mTLS endpoints). A
@@ -241,6 +253,7 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 }
 
 type bazelRbeSetup struct {
+	TenantID                 string        `json:"-"`
 	SchedulerEndpoint        string        `json:"scheduler_endpoint,omitempty"`
 	StorageEndpoint          string        `json:"storage_endpoint,omitempty"`
 	RemoteAssetEndpoint      string        `json:"remote_asset_endpoint,omitempty"`
@@ -309,7 +322,10 @@ func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command stri
 	}
 
 	if out.BuildEventEndpoint != "" && !disableBuildEvents {
-		lines = append(lines, fmt.Sprintf("--bes_backend=%s", out.BuildEventEndpoint))
+		lines = append(lines,
+			fmt.Sprintf("--bes_backend=%s", out.BuildEventEndpoint),
+			fmt.Sprintf("--bes_results_url=https://cloud.namespace.so/%s/bazel/invocation/", out.TenantID),
+		)
 
 		if out.IngressAuthToken != "" {
 			lines = append(lines,

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -22,6 +22,7 @@ func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		TenantID:           "tenant_test",
 		SchedulerEndpoint:  "grpcs://scheduler.example:443",
 		StorageEndpoint:    "grpcs://storage.example:443",
 		IngressAuthToken:   "tok123",
@@ -34,6 +35,7 @@ func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
 	got := string(config)
 	for _, want := range []string{
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
+		"build --bes_results_url=https://cloud.namespace.so/tenant_test/bazel/invocation/\n",
 		"build --bes_header=Authorization=Bearer\\ tok123\n",
 		"build --bes_header=x-nsc-ingress-auth=Bearer\\ tok123\n",
 	} {
@@ -51,6 +53,7 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		TenantID:                "tenant_test",
 		SchedulerEndpoint:       "grpcs://scheduler.example:444",
 		StorageEndpoint:         "grpcs://storage.example:444",
 		ClientCert:              "/tmp/client.cert",
@@ -65,6 +68,7 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 	got := string(config)
 	for _, want := range []string{
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
+		"build --bes_results_url=https://cloud.namespace.so/tenant_test/bazel/invocation/\n",
 		"build --credential_helper=*.api.us-east1.namespaceapis.com=" + BazelCredHelperBinary + "\n",
 	} {
 		if !strings.Contains(got, want) {
@@ -81,6 +85,7 @@ func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		TenantID:          "tenant_test",
 		SchedulerEndpoint: "grpcs://scheduler.example:444",
 		StorageEndpoint:   "grpcs://storage.example:444",
 		ClientCert:        "/tmp/client.cert",
@@ -91,7 +96,7 @@ func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 	}
 
 	got := string(config)
-	if strings.Contains(got, "--bes_backend") || strings.Contains(got, "credential_helper") {
+	if strings.Contains(got, "--bes_backend") || strings.Contains(got, "--bes_results_url") || strings.Contains(got, "credential_helper") {
 		t.Fatalf("must not configure build events when no endpoint is returned: %q", got)
 	}
 }
@@ -100,6 +105,7 @@ func TestToBazelExecutionConfigBuildEventsDisabled(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		TenantID:                "tenant_test",
 		SchedulerEndpoint:       "grpcs://scheduler.example:444",
 		StorageEndpoint:         "grpcs://storage.example:444",
 		BuildEventEndpoint:      "grpcs://api.us-east1.namespaceapis.com",
@@ -110,7 +116,7 @@ func TestToBazelExecutionConfigBuildEventsDisabled(t *testing.T) {
 	}
 
 	got := string(config)
-	for _, unwanted := range []string{"--bes_backend", "--bes_header", "credential_helper"} {
+	for _, unwanted := range []string{"--bes_backend", "--bes_results_url", "--bes_header", "credential_helper"} {
 		if strings.Contains(got, unwanted) {
 			t.Fatalf("disabled build event config contains %q: %q", unwanted, got)
 		}
@@ -125,6 +131,7 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 
 	remoteUploadLocalResults := false
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		TenantID:                 "tenant_test",
 		SchedulerEndpoint:        "grpcs://scheduler.example:443",
 		StorageEndpoint:          "grpcs://storage.example:443",
 		RemoteUploadLocalResults: &remoteUploadLocalResults,
@@ -148,6 +155,7 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 		"build --jobs=32\n",
 		"build --remote_timeout=300\n",
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
+		"build --bes_results_url=https://cloud.namespace.so/tenant_test/bazel/invocation/\n",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing config line %q in %q", want, got)

--- a/internal/fnapi/tenants.go
+++ b/internal/fnapi/tenants.go
@@ -11,6 +11,7 @@ import (
 
 	v1beta "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/iam/v1beta"
 	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/integrations/api"
 )
 
 const AdminScope = "admin"
@@ -308,12 +309,27 @@ type ListTrustRelationshipsResponse struct {
 }
 
 func GetTenant(ctx context.Context) (GetTenantResponse, error) {
+	return getTenant(ctx, IssueBearerToken)
+}
+
+func GetTenantWithToken(ctx context.Context, token api.TokenSource) (GetTenantResponse, error) {
+	return getTenant(ctx, func(ctx context.Context) (ResolvedToken, error) {
+		bearerToken, err := token.IssueToken(ctx, 15*time.Minute, false)
+		if err != nil {
+			return ResolvedToken{}, err
+		}
+
+		return ResolvedToken{BearerToken: bearerToken}, nil
+	})
+}
+
+func getTenant(ctx context.Context, issueBearerToken func(context.Context) (ResolvedToken, error)) (GetTenantResponse, error) {
 	req := struct{}{}
 
 	var res GetTenantResponse
 	if err := (Call[any]{
 		Method:           "nsl.tenants.TenantsService/GetTenant",
-		IssueBearerToken: IssueBearerToken,
+		IssueBearerToken: issueBearerToken,
 		Retryable:        true,
 	}).Do(ctx, req, ResolveIAMEndpoint, DecodeJSONResponse(&res)); err != nil {
 		return GetTenantResponse{}, err


### PR DESCRIPTION
## Summary

- Adds a tenant-scoped `--bes_results_url` to the bazelrc generated by `nsc bazel setup`.
- Resolves the tenant from the same token used for Bazel setup and omits the URL when build events are disabled.

## Validation

- `GOWORK=off go test ./internal/fnapi ./internal/cli/cmd/cluster`