### PR TITLE
Keep administrative HTTP endpoints internal

### DIFF
--- a/internal/integrations/golang/golang.go
+++ b/internal/integrations/golang/golang.go
@@ -277,15 +277,12 @@ func (impl) InternalEndpoints(_ *schema.Environment, srv *schema.Server, ports [
 		{"/readyz", runtime.FnServiceReadyz},
 	}
 
-	var serverPort *schema.Endpoint_Port
-	for _, port := range ports {
-		if port.Name == "http-port" {
-			serverPort = port
-			break
-		}
-		if port.Name == "server-port" {
-			serverPort = port
-		}
+	serverPort := findPort(ports, "int-http-port")
+	if serverPort == nil {
+		serverPort = findPort(ports, "http-port")
+	}
+	if serverPort == nil {
+		serverPort = findPort(ports, "server-port")
 	}
 
 	if serverPort == nil {
@@ -303,6 +300,15 @@ func (impl) InternalEndpoints(_ *schema.Environment, srv *schema.Server, ports [
 		Port:            serverPort,
 		ServiceMetadata: metadata,
 	}}, nil
+}
+
+func findPort(ports []*schema.Endpoint_Port, name string) *schema.Endpoint_Port {
+	for _, port := range ports {
+		if port.Name == name {
+			return port
+		}
+	}
+	return nil
 }
 
 func toServiceMetadata(internals [][2]string, protocol string) ([]*schema.ServiceMetadata, error) {

--- a/internal/integrations/golang/golang_test.go
+++ b/internal/integrations/golang/golang_test.go
@@ -14,6 +14,7 @@ func TestInternalEndpointsSelectsHealthPort(t *testing.T) {
 	ports := []*schema.Endpoint_Port{
 		{Name: "server-port", ContainerPort: 4000},
 		{Name: "http-port", ContainerPort: 4001},
+		{Name: "int-http-port", ContainerPort: 4002},
 	}
 
 	endpoints, err := (impl{}).InternalEndpoints(
@@ -26,6 +27,23 @@ func TestInternalEndpointsSelectsHealthPort(t *testing.T) {
 	}
 	if len(endpoints) != 1 {
 		t.Fatalf("got %d endpoints, want 1", len(endpoints))
+	}
+	if got := endpoints[0].Port.GetName(); got != "int-http-port" {
+		t.Errorf("got port %q, want %q", got, "int-http-port")
+	}
+}
+
+func TestInternalEndpointsSupportsLegacyHealthPort(t *testing.T) {
+	endpoints, err := (impl{}).InternalEndpoints(
+		&schema.Environment{Purpose: schema.Environment_TESTING},
+		&schema.Server{PackageName: "example.com/server"},
+		[]*schema.Endpoint_Port{
+			{Name: "server-port", ContainerPort: 4000},
+			{Name: "http-port", ContainerPort: 4001},
+		},
+	)
+	if err != nil {
+		t.Fatalf("InternalEndpoints: %v", err)
 	}
 	if got := endpoints[0].Port.GetName(); got != "http-port" {
 		t.Errorf("got port %q, want %q", got, "http-port")

--- a/internal/planning/endpoints.go
+++ b/internal/planning/endpoints.go
@@ -45,7 +45,7 @@ func ComputeEndpoints(planner runtime.Planner, srv Server, merged *schema.Server
 		}
 
 		var lst *schema.Listener
-		var additionalPort *schema.Endpoint_Port
+		var additionalPorts []*schema.Endpoint_Port
 		if service.ListenerName != "" {
 			for _, l := range merged.Listener {
 				if l.Name == service.ListenerName {
@@ -65,10 +65,20 @@ func ComputeEndpoints(planner runtime.Planner, srv Server, merged *schema.Server
 			lst = &schema.Listener{
 				Port: serverPort,
 			}
-			additionalPort = findPort(serverPorts, "grpc-port")
+			internalGrpcPort := findPort(serverPorts, "int-grpc-port")
+			if internalGrpcPort == nil {
+				// Support workspaces generated before int-grpc-port was introduced.
+				internalGrpcPort = findPort(serverPorts, "grpc-port")
+			}
+			if internalGrpcPort != nil {
+				additionalPorts = append(additionalPorts, internalGrpcPort)
+			}
+			if internalHTTPPort := findPort(serverPorts, "int-http-port"); internalHTTPPort != nil {
+				additionalPorts = append(additionalPorts, internalHTTPPort)
+			}
 		}
 
-		nd, err := computeServiceEndpoint(planner, sch.Server, lst, additionalPort, service)
+		nd, err := computeServiceEndpoint(planner, sch.Server, lst, additionalPorts, service)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -150,7 +160,7 @@ func findPort(serverPorts []*schema.Endpoint_Port, name string) *schema.Endpoint
 }
 
 // XXX this should be somewhere else.
-func computeServiceEndpoint(planner runtime.Planner, server *schema.Server, listener *schema.Listener, additionalPort *schema.Endpoint_Port, n *schema.Node) ([]*schema.Endpoint, error) {
+func computeServiceEndpoint(planner runtime.Planner, server *schema.Server, listener *schema.Listener, additionalPorts []*schema.Endpoint_Port, n *schema.Node) ([]*schema.Endpoint, error) {
 	var endpoints []*schema.Endpoint
 
 	exportedPort := n.ExportedPort
@@ -199,7 +209,7 @@ func computeServiceEndpoint(planner runtime.Planner, server *schema.Server, list
 				LoadBalancerClass:  n.GetLoadBalancerClass(),
 				Ports:              []*schema.Endpoint_PortMap{{ExportedPort: exportedPort, Port: listener.Port}},
 			}
-			if additionalPort != nil {
+			for _, additionalPort := range additionalPorts {
 				additionalExportedPort := additionalPort.ContainerPort
 				if additionalExportedPort == exportedPort {
 					additionalExportedPort = listener.Port.ContainerPort

--- a/internal/planning/endpoints_test.go
+++ b/internal/planning/endpoints_test.go
@@ -20,19 +20,22 @@ func (endpointTestPlanner) MakeServiceName(name string) (string, string) {
 	return name, name + ".example.com"
 }
 
-func TestComputeEndpointsUsesPlaintextGrpcPortForDefaultGrpcListener(t *testing.T) {
+func TestComputeEndpointsUsesInternalGrpcPortForDefaultGrpcListener(t *testing.T) {
 	srv := endpointTestServer()
 	ports := []*schema.Endpoint_Port{
 		{Name: "server-port", ContainerPort: 4000},
 		{Name: "grpc-port", ContainerPort: 4001},
+		{Name: "int-grpc-port", ContainerPort: 4002},
+		{Name: "int-http-port", ContainerPort: 4003},
 	}
 
 	endpoints, _, err := ComputeEndpoints(endpointTestPlanner{}, srv, &schema.ServerFragment{}, ports)
 	assert.NilError(t, err)
 	assert.Equal(t, len(endpoints), 1)
-	assert.Equal(t, len(endpoints[0].Ports), 2)
+	assert.Equal(t, len(endpoints[0].Ports), 3)
 	assert.Equal(t, endpoints[0].Ports[0].Port.Name, "server-port")
-	assert.Equal(t, endpoints[0].Ports[1].Port.Name, "grpc-port")
+	assert.Equal(t, endpoints[0].Ports[1].Port.Name, "int-grpc-port")
+	assert.Equal(t, endpoints[0].Ports[2].Port.Name, "int-http-port")
 	assert.Equal(t, endpoints[0].ServiceMetadata[0].Protocol, schema.ClearTextGrpcProtocol)
 }
 

--- a/internal/runtime/ingress.go
+++ b/internal/runtime/ingress.go
@@ -274,6 +274,10 @@ func PortForProtocol(endpoint *schema.Endpoint, protocol string) *schema.Endpoin
 			return port
 		}
 	case schema.ClearTextGrpcProtocol:
+		if port := findEndpointPort(endpoint, "int-grpc-port"); port != nil {
+			return port
+		}
+		// Support endpoints generated before int-grpc-port was introduced.
 		if port := findEndpointPort(endpoint, "grpc-port"); port != nil {
 			return port
 		}

--- a/internal/runtime/ingress_test.go
+++ b/internal/runtime/ingress_test.go
@@ -14,7 +14,7 @@ import (
 func TestIngressPort(t *testing.T) {
 	serverPort := &schema.Endpoint_PortMap{ExportedPort: 4000, Port: &schema.Endpoint_Port{Name: "server-port", ContainerPort: 4000}}
 	httpPort := &schema.Endpoint_PortMap{ExportedPort: 4001, Port: &schema.Endpoint_Port{Name: "http-port", ContainerPort: 4001}}
-	grpcPort := &schema.Endpoint_PortMap{ExportedPort: 4002, Port: &schema.Endpoint_Port{Name: "grpc-port", ContainerPort: 4002}}
+	grpcPort := &schema.Endpoint_PortMap{ExportedPort: 4002, Port: &schema.Endpoint_Port{Name: "int-grpc-port", ContainerPort: 4002}}
 	endpoint := &schema.Endpoint{Ports: []*schema.Endpoint_PortMap{serverPort, httpPort, grpcPort}}
 
 	assert.Equal(t, PortForProtocol(endpoint, schema.ClearTextGrpcProtocol), grpcPort)
@@ -24,4 +24,10 @@ func TestIngressPort(t *testing.T) {
 	assert.Equal(t, PortForProtocol(&schema.Endpoint{Ports: []*schema.Endpoint_PortMap{httpPort, serverPort}}, schema.GrpcProtocol), serverPort)
 	assert.Equal(t, PortForProtocol(&schema.Endpoint{Ports: []*schema.Endpoint_PortMap{serverPort}}, schema.ClearTextGrpcProtocol), serverPort)
 	assert.Equal(t, PortForProtocol(endpoint, "custom"), serverPort)
+
+	legacyHTTPPort := &schema.Endpoint_PortMap{ExportedPort: 4003, Port: &schema.Endpoint_Port{Name: "http-port", ContainerPort: 4003}}
+	legacyGRPCPort := &schema.Endpoint_PortMap{ExportedPort: 4004, Port: &schema.Endpoint_Port{Name: "grpc-port", ContainerPort: 4004}}
+	legacyEndpoint := &schema.Endpoint{Ports: []*schema.Endpoint_PortMap{serverPort, legacyHTTPPort, legacyGRPCPort}}
+	assert.Equal(t, PortForProtocol(legacyEndpoint, schema.HttpProtocol), legacyHTTPPort)
+	assert.Equal(t, PortForProtocol(legacyEndpoint, schema.ClearTextGrpcProtocol), legacyGRPCPort)
 }

--- a/internal/testdata/tests/prometheus/canscrape/testscrape.go
+++ b/internal/testdata/tests/prometheus/canscrape/testscrape.go
@@ -25,14 +25,23 @@ func main() {
 	testing.Do(func(ctx context.Context, t testing.Test) error {
 		endpoint := t.MustEndpoint("namespacelabs.dev/foundation/internal/testdata/service/post", "post")
 
-		metrics, err := schemahelper.UnmarshalServiceMetadata[*schema.HttpExportedService](
-			schemahelper.CombineServiceMetadata(t.InternalOf(endpoint.ServerOwner)),
-			"prometheus.io/metrics")
-		if err != nil {
-			return err
+		var metricsEndpoint *schema.InternalEndpoint
+		var metrics *schema.HttpExportedService
+		for _, internal := range t.InternalOf(endpoint.ServerOwner) {
+			var err error
+			metrics, err = schemahelper.UnmarshalServiceMetadata[*schema.HttpExportedService](
+				internal.ServiceMetadata,
+				"prometheus.io/metrics")
+			if err != nil {
+				return err
+			}
+			if metrics != nil {
+				metricsEndpoint = internal
+				break
+			}
 		}
 
-		if metrics == nil {
+		if metricsEndpoint == nil {
 			return errors.New("prometheus metrics endpoint missing")
 		}
 
@@ -48,7 +57,7 @@ func main() {
 
 		log.Println(response)
 
-		scrapeUrl := testing.MakeHttpUrl(endpoint, metrics.Path)
+		scrapeUrl := fmt.Sprintf("http://%s:%d/%s", endpoint.AllocatedName, metricsEndpoint.Port.ContainerPort, strings.TrimPrefix(metrics.Path, "/"))
 		log.Printf("Scraping responses at: %s", scrapeUrl)
 
 		resp, err := http.Get(scrapeUrl)

--- a/internal/versions/versions.json
+++ b/internal/versions/versions.json
@@ -1,5 +1,5 @@
 {
-	"api_version": 161,
+	"api_version": 162,
 	"minimum_api_version": 40,
 	"cache_version": 1
 }

--- a/std/go/grpc/extension.cue
+++ b/std/go/grpc/extension.cue
@@ -7,7 +7,6 @@ extension: fn.#Extension & {
 	import: [
 		"namespacelabs.dev/foundation/std/core",
 		"namespacelabs.dev/foundation/std/go/grpc/metrics",
-		"namespacelabs.dev/foundation/std/go/http",
 	]
 }
 
@@ -15,17 +14,21 @@ $inputs: {
 	serverPort: inputs.#Port & {
 		name: "server-port"
 	}
-	grpcPort: inputs.#Port & {
-		name: "grpc-port"
+	internalGrpcPort: inputs.#Port & {
+		name: "int-grpc-port"
+	}
+	internalHttpPort: inputs.#Port & {
+		name: "int-http-port"
 	}
 }
 
 configure: fn.#Configure & {
 	startup: {
 		args: {
-			listen_hostname:           "0.0.0.0"
-			grpcserver_port:           "\($inputs.serverPort.port)"
-			grpcserver_plaintext_port: "\($inputs.grpcPort.port)"
+			listen_hostname:               "0.0.0.0"
+			grpcserver_port:               "\($inputs.serverPort.port)"
+			grpcserver_plaintext_port:     "\($inputs.internalGrpcPort.port)"
+			grpcserver_internal_http_port: "\($inputs.internalHttpPort.port)"
 		}
 
 		env: {

--- a/std/go/grpc/servercore/listener.go
+++ b/std/go/grpc/servercore/listener.go
@@ -53,10 +53,11 @@ type HTTPOptions struct {
 }
 
 type ListenOpts struct {
-	CreateListener          func(context.Context) (net.Listener, error)
-	CreateNamedListener     func(context.Context, string) (net.Listener, error)
-	CreatePlaintextListener func(context.Context) (net.Listener, error)
-	CreateHttpListener      func(context.Context) (net.Listener, HTTPOptions, error)
+	CreateListener             func(context.Context) (net.Listener, error)
+	CreateNamedListener        func(context.Context, string) (net.Listener, error)
+	CreatePlaintextListener    func(context.Context) (net.Listener, error)
+	CreateHttpListener         func(context.Context) (net.Listener, HTTPOptions, error)
+	CreateInternalHTTPListener func(context.Context) (net.Listener, error)
 
 	DontHandleSigTerm bool
 }
@@ -118,7 +119,7 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 	}
 
 	tlsOnly := gogrpc.ServerCreds != nil || grpcServerTLSOnly() && tlsConfig != nil
-	tlsL, httpL, anyL := matchDefaultListeners(m, tlsConfig != nil || gogrpc.ServerCreds != nil, tlsOnly)
+	tlsL, httpL, anyL := matchDefaultListeners(m, tlsConfig != nil || gogrpc.ServerCreds != nil, tlsOnly, opts.CreateInternalHTTPListener == nil)
 	keepaliveOpts := []grpc.ServerOption{grpc.KeepaliveParams(keepalive.ServerParameters{
 		Time:              5 * time.Second,
 		Timeout:           20 * time.Second,
@@ -231,6 +232,17 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 	eg, egCtx := errgroup.WithContext(cancelCtx)
 
 	var httpServer *http.Server
+	if opts.CreateInternalHTTPListener != nil {
+		adminLis, err := opts.CreateInternalHTTPListener(ctx)
+		if err != nil {
+			return err
+		}
+
+		adminServer := &http.Server{Handler: debugMux}
+		core.ZLog.Info().Msgf("Starting internal admin HTTP listen on %v", adminLis.Addr())
+		eg.Go(func() error { return ListenAndGracefullyShutdownHTTP(egCtx, "http/admin", adminServer, adminLis) })
+	}
+
 	if opts.CreateHttpListener != nil {
 		gwLis, opts, err := opts.CreateHttpListener(ctx)
 		if err != nil {
@@ -348,13 +360,12 @@ func Listen(ctx context.Context, opts ListenOpts, registerServices func(Server))
 }
 
 func registerHTTPServices(s *ServerImpl, registerServices func(Server)) {
-	// Gorilla mux resolves routes in registration order. Keep administrative
-	// endpoints ahead of application catch-all routes.
-	core.RegisterDebugEndpoints(s.httpMux)
+	// Administrative endpoints are served by the internal admin listener.
+	// Keep the application listener safe to expose through path-based ingress.
 	registerServices(s)
 }
 
-func matchDefaultListeners(m cmux.CMux, hasTLS, tlsOnly bool) (net.Listener, net.Listener, net.Listener) {
+func matchDefaultListeners(m cmux.CMux, hasTLS, tlsOnly, serveAdminHTTP bool) (net.Listener, net.Listener, net.Listener) {
 	if tlsOnly {
 		return m.Match(cmux.TLS()), nil, nil
 	}
@@ -364,7 +375,11 @@ func matchDefaultListeners(m cmux.CMux, hasTLS, tlsOnly bool) (net.Listener, net
 		tlsListener = m.Match(cmux.TLS())
 	}
 
-	return tlsListener, m.Match(cmux.HTTP1()), m.Match(cmux.Any())
+	if serveAdminHTTP {
+		return tlsListener, m.Match(cmux.HTTP1()), m.Match(cmux.Any())
+	}
+
+	return tlsListener, nil, m.Match(cmux.Any())
 }
 
 func NewHttp2CapableServer(mux http.Handler, opts HTTPOptions) *http.Server {

--- a/std/go/grpc/servercore/listener_test.go
+++ b/std/go/grpc/servercore/listener_test.go
@@ -29,16 +29,18 @@ import (
 
 func TestMatchDefaultListeners(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		hasTLS   bool
-		tlsOnly  bool
-		wantTLS  bool
-		wantHTTP bool
-		wantGRPC bool
+		name          string
+		hasTLS        bool
+		tlsOnly       bool
+		separateAdmin bool
+		wantTLS       bool
+		wantHTTP      bool
+		wantGRPC      bool
 	}{
 		{name: "plaintext", wantHTTP: true, wantGRPC: true},
 		{name: "mTLS compatibility", hasTLS: true, wantTLS: true, wantHTTP: true, wantGRPC: true},
 		{name: "mTLS only", hasTLS: true, tlsOnly: true, wantTLS: true},
+		{name: "separate admin listener", hasTLS: true, separateAdmin: true, wantTLS: true, wantGRPC: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -47,7 +49,7 @@ func TestMatchDefaultListeners(t *testing.T) {
 			}
 			defer listener.Close()
 
-			tlsListener, httpListener, grpcListener := matchDefaultListeners(cmux.New(listener), tc.hasTLS, tc.tlsOnly)
+			tlsListener, httpListener, grpcListener := matchDefaultListeners(cmux.New(listener), tc.hasTLS, tc.tlsOnly, !tc.separateAdmin)
 			if (tlsListener != nil) != tc.wantTLS || (httpListener != nil) != tc.wantHTTP || (grpcListener != nil) != tc.wantGRPC {
 				t.Fatalf("unexpected listeners: tls=%t http=%t grpc=%t", tlsListener != nil, httpListener != nil, grpcListener != nil)
 			}
@@ -63,7 +65,7 @@ func TestSecureDefaultListenerRejectsPlaintextHTTP(t *testing.T) {
 	defer listener.Close()
 
 	m := cmux.New(listener)
-	matchDefaultListeners(m, true, true)
+	matchDefaultListeners(m, true, true, false)
 	serveDone := make(chan error, 1)
 	go func() {
 		serveDone <- m.Serve()
@@ -111,7 +113,7 @@ func TestGrpcServerTLSOnly(t *testing.T) {
 	}
 }
 
-func TestRegisterHTTPServicesKeepsAdministrativeRoutesAheadOfCatchAll(t *testing.T) {
+func TestRegisterHTTPServicesDoesNotExposeAdministrativeRoutes(t *testing.T) {
 	httpMux := NewHTTPMux()
 	s := &ServerImpl{httpMux: httpMux}
 
@@ -126,8 +128,8 @@ func TestRegisterHTTPServicesKeepsAdministrativeRoutesAheadOfCatchAll(t *testing
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		response := httptest.NewRecorder()
 		httpMux.ServeHTTP(response, req)
-		if response.Header().Get("X-Application-Catch-All") != "" {
-			t.Errorf("%s was handled by the application catch-all", path)
+		if response.Header().Get("X-Application-Catch-All") != "true" {
+			t.Errorf("%s was not handled by the application catch-all", path)
 		}
 	}
 }

--- a/std/go/server/grpcserver.go
+++ b/std/go/server/grpcserver.go
@@ -19,11 +19,12 @@ import (
 )
 
 var (
-	listenHostname = flag.String("listen_hostname", "localhost", "Hostname to listen on.")
-	port           = flag.Int("grpcserver_port", 0, "Port to listen on.")
-	plaintextPort  = flag.Int("grpcserver_plaintext_port", 0, "Port to listen for plaintext gRPC on.")
-	httpPort       = flag.Int("grpcserver_http_port", 0, "Port to listen HTTP on.")
-	httpOptions    = flag.String("grpc_http_options", "{}", "Options to pass to the HTTP server.")
+	listenHostname   = flag.String("listen_hostname", "localhost", "Hostname to listen on.")
+	port             = flag.Int("grpcserver_port", 0, "Port to listen on.")
+	plaintextPort    = flag.Int("grpcserver_plaintext_port", 0, "Port to listen for plaintext gRPC on.")
+	httpPort         = flag.Int("grpcserver_http_port", 0, "Port to listen HTTP on.")
+	internalHTTPPort = flag.Int("grpcserver_internal_http_port", 0, "Port to listen for internal HTTP health and metrics on.")
+	httpOptions      = flag.String("grpc_http_options", "{}", "Options to pass to the HTTP server.")
 )
 
 const drainTimeout = 30 * time.Second
@@ -80,6 +81,10 @@ func makeListenerOpts() servercore.ListenOpts {
 			lst, err := servercore.MakeTCPListener(*listenHostname, *httpPort)(ctx)
 			return lst, parsed, err
 		}
+	}
+
+	if *internalHTTPPort != 0 {
+		opts.CreateInternalHTTPListener = servercore.MakeTCPListener(*listenHostname, *internalHTTPPort)
 	}
 
 	return opts


### PR DESCRIPTION
## Summary

- Serves health and metrics on a dedicated internal HTTP port.
- Keeps application HTTP routes separate.
- Renames the plaintext gRPC port for clarity.

## Validation

- `go test ./std/go/grpc/servercore ./std/go/server ./internal/integrations/golang ./internal/planning ./internal/runtime`