### PR TITLE
nsc bazel: wait for cache readiness during setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module namespacelabs.dev/foundation
 go 1.26.0
 
 require (
+	buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1
 	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1
 	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1
@@ -157,7 +158,6 @@ require (
 )
 
 require (
-	buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1 // indirect
 	cloud.google.com/go v0.121.6 // indirect
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect

--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -523,6 +523,24 @@ func newSetupCacheCmd() *cobra.Command {
 			out.RemoteAssetEndpoint = response.GetRemoteAssetEndpoint()
 		}
 
+		readinessToken := out.StaticToken
+		if readinessToken == "" && len(out.CredentialHelperDomains) > 0 {
+			readinessToken, err = tokenSource.IssueToken(ctx, bazelCacheReadinessTimeout, false)
+			if err != nil {
+				return fnerrors.Newf("failed to issue token for bazel cache readiness check: %w", err)
+			}
+		}
+		if err := waitForBazelCacheReady(ctx, bazelCacheReadinessConfig{
+			endpoint:    out.Endpoint,
+			serverCA:    out.ServerCaCert,
+			clientCert:  out.ClientCert,
+			clientKey:   out.ClientKey,
+			bearerToken: readinessToken,
+			waitTimeout: bazelCacheReadinessTimeout,
+		}); err != nil {
+			return fnerrors.Newf("failed waiting for bazel cache readiness: %w", err)
+		}
+
 		// If set, we always generate a bazelrc file.
 		if bazelRcPath != "" {
 			data, err := toBazelConfig(ctx, out, useAbsoluteCredHelperPath, bazelCommand, disableBuildEvents)

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -187,6 +187,16 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			out.ClientKey = clientKeyPath
 		}
 
+		if err := waitForBazelCacheReady(ctx, bazelCacheReadinessConfig{
+			endpoint:    out.StorageEndpoint,
+			clientCert:  out.ClientCert,
+			clientKey:   out.ClientKey,
+			bearerToken: out.IngressAuthToken,
+			waitTimeout: bazelCacheReadinessTimeout,
+		}); err != nil {
+			return fnerrors.Newf("failed waiting for bazel storage readiness: %w", err)
+		}
+
 		if bazelRcPath != "" {
 			data, err := toBazelExecutionConfig(ctx, out, bazelCommand, remote, disableBuildEvents)
 			if err != nil {

--- a/internal/cli/cmd/cluster/bazel_readiness.go
+++ b/internal/cli/cmd/cluster/bazel_readiness.go
@@ -1,0 +1,215 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	executionv2 "buf.build/gen/go/namespace/bazel/protocolbuffers/go/build/bazel/remote/execution/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	bazelCacheReadinessTimeout        = time.Minute
+	bazelCacheReadinessAttemptTimeout = 2 * time.Second
+	bazelCacheReadinessRetryWait      = 200 * time.Millisecond
+	bazelGetCapabilitiesMethod        = "/build.bazel.remote.execution.v2.Capabilities/GetCapabilities"
+)
+
+type bazelCacheReadinessConfig struct {
+	endpoint    string
+	serverCA    string
+	clientCert  string
+	clientKey   string
+	bearerToken string
+	waitTimeout time.Duration
+}
+
+type parsedBazelCacheEndpoint struct {
+	target     string
+	serverName string
+	statusURL  string
+	secure     bool
+}
+
+func waitForBazelCacheReady(ctx context.Context, cfg bazelCacheReadinessConfig) error {
+	waitCtx, cancel := context.WithTimeout(ctx, cfg.waitTimeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		attemptCtx, cancel := context.WithTimeout(waitCtx, bazelCacheReadinessAttemptTimeout)
+		lastErr = checkBazelCacheReady(attemptCtx, cfg)
+		cancel()
+		if lastErr == nil {
+			return nil
+		}
+
+		timer := time.NewTimer(bazelCacheReadinessRetryWait)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return fmt.Errorf("cache endpoint %q did not become ready within %s: %w", cfg.endpoint, cfg.waitTimeout, lastErr)
+		case <-timer.C:
+		}
+	}
+}
+
+func checkBazelCacheReady(ctx context.Context, cfg bazelCacheReadinessConfig) error {
+	endpoint, err := parseBazelCacheEndpoint(cfg.endpoint)
+	if err != nil {
+		return err
+	}
+
+	var tlsConfig *tls.Config
+	if endpoint.secure {
+		tlsConfig = &tls.Config{ServerName: endpoint.serverName}
+		if cfg.serverCA != "" {
+			rootCAs := x509.NewCertPool()
+			serverCA, err := os.ReadFile(cfg.serverCA)
+			if err != nil {
+				return fmt.Errorf("read Bazel cache server CA: %w", err)
+			}
+			if !rootCAs.AppendCertsFromPEM(serverCA) {
+				return fmt.Errorf("parse Bazel cache server CA")
+			}
+			tlsConfig.RootCAs = rootCAs
+		}
+		if cfg.clientCert != "" || cfg.clientKey != "" {
+			if cfg.clientCert == "" || cfg.clientKey == "" {
+				return fmt.Errorf("both Bazel cache client certificate and key are required")
+			}
+			clientCertificate, err := tls.LoadX509KeyPair(cfg.clientCert, cfg.clientKey)
+			if err != nil {
+				return fmt.Errorf("load Bazel cache client certificate: %w", err)
+			}
+			tlsConfig.Certificates = []tls.Certificate{clientCertificate}
+		}
+	}
+
+	if endpoint.statusURL != "" {
+		return checkBazelHTTPCacheReady(ctx, endpoint.statusURL, tlsConfig, cfg.bearerToken)
+	}
+
+	var transportCredentials credentials.TransportCredentials
+	if endpoint.secure {
+		transportCredentials = credentials.NewTLS(tlsConfig)
+	} else {
+		transportCredentials = insecure.NewCredentials()
+	}
+
+	conn, err := grpc.NewClient(endpoint.target, grpc.WithTransportCredentials(transportCredentials))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if cfg.bearerToken != "" {
+		bearer := "Bearer " + cfg.bearerToken
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", bearer, "x-nsc-ingress-auth", bearer)
+	}
+
+	return conn.Invoke(
+		ctx,
+		bazelGetCapabilitiesMethod,
+		&executionv2.GetCapabilitiesRequest{},
+		&executionv2.ServerCapabilities{},
+		grpc.WaitForReady(true),
+	)
+}
+
+func checkBazelHTTPCacheReady(ctx context.Context, statusURL string, tlsConfig *tls.Config, bearerToken string) error {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	defer transport.CloseIdleConnections()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+	if err != nil {
+		return err
+	}
+	if bearerToken != "" {
+		bearer := "Bearer " + bearerToken
+		request.Header.Set("Authorization", bearer)
+		request.Header.Set("x-nsc-ingress-auth", bearer)
+	}
+
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("cache status endpoint returned %s", response.Status)
+	}
+	return nil
+}
+
+func parseBazelCacheEndpoint(endpoint string) (parsedBazelCacheEndpoint, error) {
+	value := endpoint
+	if !strings.Contains(value, "://") {
+		value = "grpcs://" + value
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return parsedBazelCacheEndpoint{}, fmt.Errorf("parse Bazel cache endpoint: %w", err)
+	}
+
+	var secure, useHTTP bool
+	switch parsed.Scheme {
+	case "grpc", "http":
+		secure = false
+		useHTTP = parsed.Scheme == "http"
+	case "grpcs", "https":
+		secure = true
+		useHTTP = parsed.Scheme == "https"
+	default:
+		return parsedBazelCacheEndpoint{}, fmt.Errorf("unsupported Bazel cache endpoint scheme %q", parsed.Scheme)
+	}
+	if parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return parsedBazelCacheEndpoint{}, fmt.Errorf("Bazel cache endpoint must not contain credentials, a path, query parameters, or a fragment")
+	}
+
+	serverName := parsed.Hostname()
+	if serverName == "" {
+		return parsedBazelCacheEndpoint{}, fmt.Errorf("Bazel cache endpoint is missing a host")
+	}
+	port := parsed.Port()
+	if port == "" {
+		if secure {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	result := parsedBazelCacheEndpoint{
+		target:     net.JoinHostPort(serverName, port),
+		secure:     secure,
+		serverName: serverName,
+	}
+	if useHTTP {
+		parsed.Path = "/status"
+		result.statusURL = parsed.String()
+	}
+	return result, nil
+}

--- a/internal/cli/cmd/cluster/bazel_readiness_test.go
+++ b/internal/cli/cmd/cluster/bazel_readiness_test.go
@@ -1,0 +1,164 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cluster
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	executionv2 "buf.build/gen/go/namespace/bazel/protocolbuffers/go/build/bazel/remote/execution/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestWaitForBazelCacheReady(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	endpoint := startBazelCapabilitiesServer(t, func(ctx context.Context) error {
+		if attempts.Add(1) < 3 {
+			return status.Error(codes.Unavailable, "starting")
+		}
+		incoming, _ := metadata.FromIncomingContext(ctx)
+		for _, key := range []string{"authorization", "x-nsc-ingress-auth"} {
+			values := incoming.Get(key)
+			if len(values) != 1 || values[0] != "Bearer readiness-token" {
+				return status.Errorf(codes.PermissionDenied, "unexpected %s metadata: %v", key, values)
+			}
+		}
+		return nil
+	})
+
+	err := waitForBazelCacheReady(context.Background(), bazelCacheReadinessConfig{
+		endpoint:    endpoint,
+		bearerToken: "readiness-token",
+		waitTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("waitForBazelCacheReady: %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts.Load())
+	}
+}
+
+func TestWaitForBazelHTTPCacheReady(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/status" {
+			t.Errorf("path = %q, want /status", request.URL.Path)
+		}
+		if attempts.Add(1) < 3 {
+			response.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		for _, key := range []string{"Authorization", "x-nsc-ingress-auth"} {
+			if value := request.Header.Get(key); value != "Bearer readiness-token" {
+				t.Errorf("%s = %q, want bearer token", key, value)
+			}
+		}
+		response.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	err := waitForBazelCacheReady(context.Background(), bazelCacheReadinessConfig{
+		endpoint:    server.URL,
+		bearerToken: "readiness-token",
+		waitTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("waitForBazelCacheReady: %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts.Load())
+	}
+}
+
+func TestWaitForBazelCacheReadyTimesOut(t *testing.T) {
+	t.Parallel()
+
+	endpoint := startBazelCapabilitiesServer(t, func(context.Context) error {
+		return status.Error(codes.Unavailable, "starting")
+	})
+
+	err := waitForBazelCacheReady(context.Background(), bazelCacheReadinessConfig{
+		endpoint:    endpoint,
+		waitTimeout: 300 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not become ready within 300ms") {
+		t.Fatalf("waitForBazelCacheReady error = %v, want readiness timeout", err)
+	}
+}
+
+func TestParseBazelCacheEndpoint(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		endpoint       string
+		wantTarget     string
+		wantSecure     bool
+		wantServerName string
+		wantStatusURL  string
+	}{
+		{endpoint: "grpcs://cache.example.com:444", wantTarget: "cache.example.com:444", wantSecure: true, wantServerName: "cache.example.com"},
+		{endpoint: "https://cache.example.com", wantTarget: "cache.example.com:443", wantSecure: true, wantServerName: "cache.example.com", wantStatusURL: "https://cache.example.com/status"},
+		{endpoint: "grpc://127.0.0.1:9092", wantTarget: "127.0.0.1:9092", wantSecure: false, wantServerName: "127.0.0.1"},
+		{endpoint: "cache.example.com:444", wantTarget: "cache.example.com:444", wantSecure: true, wantServerName: "cache.example.com"},
+	} {
+		t.Run(test.endpoint, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseBazelCacheEndpoint(test.endpoint)
+			if err != nil {
+				t.Fatalf("parseBazelCacheEndpoint: %v", err)
+			}
+			if got.target != test.wantTarget || got.secure != test.wantSecure || got.serverName != test.wantServerName || got.statusURL != test.wantStatusURL {
+				t.Fatalf("parseBazelCacheEndpoint(%q) = %#v, want target=%q secure=%t serverName=%q statusURL=%q", test.endpoint, got, test.wantTarget, test.wantSecure, test.wantServerName, test.wantStatusURL)
+			}
+		})
+	}
+}
+
+func startBazelCapabilitiesServer(t *testing.T, check func(context.Context) error) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := grpc.NewServer(grpc.UnknownServiceHandler(func(_ any, stream grpc.ServerStream) error {
+		method, _ := grpc.Method(stream.Context())
+		if method != bazelGetCapabilitiesMethod {
+			return status.Errorf(codes.Unimplemented, "unexpected method %q", method)
+		}
+		request := &executionv2.GetCapabilitiesRequest{}
+		if err := stream.RecvMsg(request); err != nil {
+			return err
+		}
+		if err := check(stream.Context()); err != nil {
+			return err
+		}
+		return stream.SendMsg(&executionv2.ServerCapabilities{})
+	}))
+	t.Cleanup(func() {
+		server.Stop()
+		listener.Close()
+	})
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	return "grpc://" + listener.Addr().String()
+}


### PR DESCRIPTION
## Summary

- Wait up to one minute for Bazel storage readiness in `nsc bazel cache setup` and `nsc bazel setup`.
- Probe authenticated gRPC endpoints with `GetCapabilities` and legacy HTTP cache endpoints through `/status`.

## Validation

- `go test ./internal/cli/cmd/cluster`
- `go test -race ./internal/cli/cmd/cluster -run 'TestWaitForBazel|TestParseBazel'`
- `go build -o /tmp/nsc-bazel-readiness ./cmd/nsc`
- `git diff --check`
