### PR TITLE
auth: make token persistence atomic

### DIFF
--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/sys/atomicwriter"
 	"github.com/spf13/pflag"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
@@ -158,10 +159,8 @@ func (t *Token) IssueToken(ctx context.Context, minDur time.Duration, skipCache 
 		} else {
 			claims, err := extractClaims(string(cacheContents))
 			if err != nil {
-				return "", err
-			}
-
-			if claims != nil {
+				fmt.Fprintf(console.Debug(ctx), "Ignoring invalid cached tenant token: %v\n", err)
+			} else if claims != nil {
 				sessionClaims, err := t.Claims(ctx)
 				if err != nil {
 					return "", err
@@ -183,7 +182,7 @@ func (t *Token) IssueToken(ctx context.Context, minDur time.Duration, skipCache 
 	newToken, err := t.ReIssue(ctx, t, dur)
 	if err == nil && t.path != "" {
 		cachePath := tokenCachePath(t.path)
-		if err := os.WriteFile(cachePath, []byte(newToken), 0600); err != nil {
+		if err := atomicwriter.WriteFile(cachePath, []byte(newToken), 0600); err != nil {
 			fmt.Fprintf(console.Warnings(ctx), "Failed to write token cache: %v\n", err)
 		}
 	}
@@ -270,7 +269,7 @@ func StoreToken(token StoredToken) error {
 		}
 	}
 
-	if err := os.WriteFile(p, data, 0600); err != nil {
+	if err := atomicwriter.WriteFile(p, data, 0600); err != nil {
 		return fnerrors.Newf("failed to write token data: %w", err)
 	}
 

--- a/internal/auth/tokens_test.go
+++ b/internal/auth/tokens_test.go
@@ -5,9 +5,11 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"namespacelabs.dev/foundation/internal/workspace/dirs"
 )
@@ -109,5 +111,37 @@ func TestDeleteStoredTokenInvalidatesCacheWithoutTokenFile(t *testing.T) {
 
 	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
 		t.Fatalf("expected token.cache to be removed, stat err = %v", err)
+	}
+}
+
+func TestIssueTokenReplacesInvalidCache(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, defaultTokenLoc)
+	cachePath := filepath.Join(dir, tokenCacheLoc)
+	if err := os.WriteFile(cachePath, []byte("invalid"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	token := &Token{
+		path: tokenPath,
+		ReIssue: func(context.Context, *Token, time.Duration) (string, error) {
+			return "fresh-token", nil
+		},
+	}
+
+	got, err := token.IssueToken(context.Background(), time.Minute, false)
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	if got != "fresh-token" {
+		t.Fatalf("IssueToken returned %q, want fresh-token", got)
+	}
+
+	contents, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	if string(contents) != "fresh-token" {
+		t.Fatalf("cache contains %q, want fresh-token", contents)
 	}
 }


### PR DESCRIPTION
## Summary

- Write stored and cached tokens atomically.
- Recover from invalid cached tokens by issuing and caching a replacement.

## Validation

- `go test ./internal/auth ./internal/fnapi`
- `git diff --check`