### PR TITLE
orchestration: use public prebuilt by default

### DIFF
--- a/internal/cli/cmd/buildbinary.go
+++ b/internal/cli/cmd/buildbinary.go
@@ -64,12 +64,18 @@ func NewBuildBinaryCmd() *cobra.Command {
 			fncobra.ParseEnv(&env),
 			fncobra.ParseLocations(&cmdLocs, &env, fncobra.ParseLocationsOpts{ReturnAllIfNoneSpecified: true, SupportPackageRef: true})).
 		Do(func(ctx context.Context) error {
-			registry, err := registry.GetRegistry(ctx, env)
-			if err != nil {
-				return err
+			var reg registry.Manager
+			if len(baseRepository) == 0 {
+				// An explicit repository is self-contained; requiring the environment's
+				// registry would prevent remote builds from publishing directly to it.
+				var err error
+				reg, err = registry.GetRegistry(ctx, env)
+				if err != nil {
+					return err
+				}
 			}
 
-			return buildLocations(ctx, env, registry, userTag, cmdLocs, baseRepository, buildOpts)
+			return buildLocations(ctx, env, reg, userTag, cmdLocs, baseRepository, buildOpts)
 		})
 }
 

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -113,10 +113,13 @@ func NewDeployCmd() *cobra.Command {
 				if uploadToRegistry {
 					target = p.Registry.AllocateName(uploadTo, "")
 				} else {
+					// An explicit external registry may require credentials. Use the
+					// standard Docker keychain just as build-binary does when publishing.
 					p.Registry = registry.MakeStaticRegistry(&buildr.Registry{
-						Url: uploadTo,
+						Url:           uploadTo,
+						UseDockerAuth: true,
 					})
-					target = registry.Precomputed(registry.AttachStaticKeychain(nil, filepath.Join(uploadTo, "plan"), oci.RegistryAccess{}))
+					target = registry.Precomputed(registry.AttachStaticKeychain(nil, filepath.Join(uploadTo, "plan"), p.Registry.Access()))
 					uploadToRegistry = true
 				}
 			}

--- a/ns-workspace.cue
+++ b/ns-workspace.cue
@@ -7,7 +7,9 @@ prebuilts: {
 	digest: {
 		"namespacelabs.dev/foundation/std/development/filesync/controller": "sha256:41ffa681aec6a70dcd5a7ebeccd94814688389a45f39810138a4d3f1ef8278da"
 	}
-	baseRepository: "us-docker.pkg.dev/foundation-344819/prebuilts/"
+	// Keep all Foundation prebuilts in the public registry so consumers don't
+	// need credentials to prepare a local environment.
+	baseRepository: "public.registry.namespace.systems/"
 }
 internalAliases: [{
 	module_name: "library.namespace.so"

--- a/orchestration/env.go
+++ b/orchestration/env.go
@@ -10,8 +10,10 @@ import (
 	"google.golang.org/protobuf/proto"
 	"namespacelabs.dev/foundation/framework/kubernetes/kubedef"
 	"namespacelabs.dev/foundation/framework/kubernetes/kubetool"
+	"namespacelabs.dev/foundation/internal/build/binary"
 	"namespacelabs.dev/foundation/internal/protos"
 	"namespacelabs.dev/foundation/internal/runtime/kubernetes/client"
+	"namespacelabs.dev/foundation/orchestration/server/constants"
 	"namespacelabs.dev/foundation/schema"
 	"namespacelabs.dev/foundation/std/cfg"
 )
@@ -30,7 +32,7 @@ func MakeSyntheticContext(wsproto *schema.Workspace, env *schema.Environment, ho
 	return cfg.MakeUnverifiedContext(newCfg, env)
 }
 
-func MakeOrchestratorContext(ctx context.Context, conf cfg.Configuration) (cfg.Context, error) {
+func MakeOrchestratorContext(ctx context.Context, conf cfg.Configuration, mode string) (cfg.Context, error) {
 	// We use a static environment here, since the orchestrator has global scope.
 	envProto := &schema.Environment{
 		Name:      kubedef.AdminNamespace,
@@ -50,6 +52,17 @@ func MakeOrchestratorContext(ctx context.Context, conf cfg.Configuration) (cfg.C
 		previous.Configuration = append(previous.Configuration, protos.WrapAnyOrDie(
 			&kubetool.KubernetesEnv{Namespace: kubedef.AdminNamespace}, // pin deployments to admin namespace
 		))
+		if mode == OrchestratorModePrebuilt {
+			// Keep the tool prebuilt scoped to this mode so --orchestrator=head
+			// rebuilds both the server and its provisioning logic from source.
+			previous.Configuration = append(previous.Configuration, protos.WrapAnyOrDie(&binary.Prebuilts{
+				PrebuiltBinary: []*schema.Workspace_BinaryDigest{{
+					PackageName: constants.ToolPkg.String(),
+					Repository:  PrebuiltOrchestratorToolRepository,
+					Digest:      PrebuiltOrchestratorToolDigest,
+				}},
+			}))
+		}
 		return previous
 	})
 

--- a/orchestration/env_test.go
+++ b/orchestration/env_test.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package orchestration
+
+import (
+	"context"
+	"testing"
+
+	"namespacelabs.dev/foundation/internal/build/binary"
+	"namespacelabs.dev/foundation/orchestration/server/constants"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/cfg"
+	"namespacelabs.dev/foundation/std/pkggraph"
+)
+
+func TestOrchestratorToolPrebuiltFollowsMode(t *testing.T) {
+	base := cfg.MakeConfigurationWith("test", cfg.MakeSyntheticWorkspace(&schema.Workspace{}, nil), cfg.ConfigurationSlice{})
+	module := pkggraph.NewModule(&schema.Workspace{}, &schema.Workspace_LoadedFrom{}, "")
+	tool := pkggraph.NewLocationForTesting(module, constants.ToolPkg.String(), "orchestration/server/tool")
+
+	t.Run("prebuilt", func(t *testing.T) {
+		env, err := MakeOrchestratorContext(context.Background(), base, OrchestratorModePrebuilt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := binary.PrebuiltImageID(context.Background(), tool, env.Configuration())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == nil {
+			t.Fatal("expected the orchestrator tool to resolve to a prebuilt image")
+		}
+		want := PrebuiltOrchestratorToolRepository + "@" + PrebuiltOrchestratorToolDigest
+		if got.RepoAndDigest() != want {
+			t.Fatalf("unexpected orchestrator tool image: got %q, want %q", got.RepoAndDigest(), want)
+		}
+	})
+
+	t.Run("head", func(t *testing.T) {
+		env, err := MakeOrchestratorContext(context.Background(), base, OrchestratorModeHead)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := binary.PrebuiltImageID(context.Background(), tool, env.Configuration())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Fatalf("head mode unexpectedly resolved a prebuilt: %s", got.RepoAndDigest())
+		}
+	})
+}

--- a/orchestration/prepare.go
+++ b/orchestration/prepare.go
@@ -22,12 +22,16 @@ import (
 )
 
 const (
-	OrchestratorModeHead      = "head"
-	OrchestratorModePrebuilt  = "prebuilt"
-	PrebuiltOrchestratorImage = "registry.zrh-services.namespace.systems/namespacelabs.dev/foundation/orchestration/server@sha256:c9fb3e8e70e06d47168879a998049f96bf3e1693e0e3b65f581b5d93ea80b5c8"
+	OrchestratorModeHead               = "head"
+	OrchestratorModePrebuilt           = "prebuilt"
+	PrebuiltOrchestratorImage          = "public.registry.namespace.systems/namespacelabs.dev/foundation/orchestration/server@sha256:9dfde24a3a7a5570ac4fd4f3447da7ebbce3f4a1c98f809c1a86ca70502dda24"
+	PrebuiltOrchestratorToolRepository = "public.registry.namespace.systems/namespacelabs.dev/foundation/orchestration/server/tool"
+	PrebuiltOrchestratorToolDigest     = "sha256:bcc828b2ef2f48efdbbec7e6896fc05d30caf511a5d3a12ebd3f27c70bbab45a"
 )
 
-var OrchestratorMode = OrchestratorModeHead
+// The orchestrator rarely changes, so avoid rebuilding it during every local
+// prepare. Use --orchestrator=head when explicitly testing orchestrator changes.
+var OrchestratorMode = OrchestratorModePrebuilt
 
 var stateless = &runtimepb.Deployable{
 	PackageRef:      schema.MakePackageSingleRef(constants.ServerPkg),
@@ -45,7 +49,7 @@ func RegisterPrepare() {
 }
 
 func PrepareOrchestrator(ctx context.Context, targetEnv cfg.Configuration, cluster runtime.Cluster, wait bool) (any, error) {
-	env, err := MakeOrchestratorContext(ctx, targetEnv)
+	env, err := MakeOrchestratorContext(ctx, targetEnv, OrchestratorMode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Use an immutable public multi-platform orchestrator image by default while retaining `--orchestrator=head` for source testing.
- Scope the prebuilt provisioning tool to prebuilt mode so head mode rebuilds both the server and tool.
- Use Docker credentials when publishing deploy plans and avoid requiring an unused environment registry for explicit binary repositories.

## Validation

- `go test ./internal/cli/cmd ./internal/build/binary ./internal/planning/deploy ./orchestration/...`
- `nsdev fmt`
- Ran uncached `nsdev prepare local --env=dev --log_actions` and verified both public prebuilt references were used with no orchestrator source builds.
- Ran uncached `nsdev prepare local --env=dev --orchestrator=head --log_actions` and verified both the server and provisioning tool were built from source.
- Verified anonymous pulls of the pinned amd64/arm64 server, provisioning tool, and migrated filesync prebuilt from `public.registry.namespace.systems`.
