### PR TITLE
kubernetes: wait for ingress admission endpoints

### DIFF
--- a/framework/kubernetes/kubedef/kubecluster.go
+++ b/framework/kubernetes/kubedef/kubecluster.go
@@ -67,6 +67,7 @@ type IngressAnnotations struct {
 type IngressSelector struct {
 	InClusterController     kubeobj.Object // May be nil.
 	LoadBalancerServiceName string         // In the same namespace.
+	ReadinessServiceName    string         // If set, readiness also requires at least one service endpoint.
 
 	ContainerPort int
 	PodSelector   map[string]string

--- a/internal/networking/ingress/nginx/nginx_ingress.go
+++ b/internal/networking/ingress/nginx/nginx_ingress.go
@@ -271,6 +271,7 @@ func (Ingress) Service() *kubedef.IngressSelector {
 			},
 		},
 		LoadBalancerServiceName: "ingress-nginx-controller",
+		ReadinessServiceName:    "ingress-nginx-controller-admission",
 	}
 }
 

--- a/internal/networking/ingress/state.go
+++ b/internal/networking/ingress/state.go
@@ -7,10 +7,16 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"namespacelabs.dev/foundation/framework/kubernetes/kubedef"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/runtime"
+	"namespacelabs.dev/foundation/internal/runtime/kubernetes/client"
 	"namespacelabs.dev/foundation/internal/runtime/kubernetes/kubeobserver"
 	"namespacelabs.dev/foundation/std/cfg"
 	"namespacelabs.dev/foundation/std/tasks"
@@ -50,8 +56,46 @@ func RegisterRuntimeState() {
 			return nil, err
 		}
 
+		if z.ReadinessServiceName != "" {
+			if err := tasks.Action("ingress.wait-service").HumanReadable("Waiting until Ingress controller service is ready").Run(ctx, func(ctx context.Context) error {
+				return waitForServiceEndpoints(ctx, kube.PreparedClient().Clientset, z.InClusterController.GetNamespace(), z.ReadinessServiceName)
+			}); err != nil {
+				return nil, err
+			}
+		}
+
 		return ingress, nil
 	})
+}
+
+func waitForServiceEndpoints(ctx context.Context, cli kubernetes.Interface, namespace, name string) error {
+	// Deployment readiness and endpoint publication are separate controller
+	// updates. Wait for the latter before allowing fail-closed admission webhooks
+	// to receive Ingress resources.
+	err := client.PollImmediateWithContext(ctx, 500*time.Millisecond, 5*time.Minute, func(ctx context.Context) (bool, error) {
+		endpoints, err := cli.CoreV1().Endpoints(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+
+		return hasReadyEndpoint(endpoints), nil
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for service %s/%s to have ready endpoints: %w", namespace, name, err)
+	}
+	return nil
+}
+
+func hasReadyEndpoint(endpoints *corev1.Endpoints) bool {
+	for _, subset := range endpoints.Subsets {
+		if len(subset.Addresses) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func EnsureState(ctx context.Context, cluster kubedef.KubeCluster, ingressClass string) (kubedef.IngressClass, error) {

--- a/internal/networking/ingress/state_test.go
+++ b/internal/networking/ingress/state_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package ingress
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestHasReadyEndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints *corev1.Endpoints
+		want      bool
+	}{
+		{name: "no subsets", endpoints: &corev1.Endpoints{}},
+		{
+			name: "not-ready endpoint",
+			endpoints: &corev1.Endpoints{Subsets: []corev1.EndpointSubset{{
+				NotReadyAddresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+			}}},
+		},
+		{
+			name: "ready endpoint",
+			endpoints: &corev1.Endpoints{Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+			}}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasReadyEndpoint(tt.endpoints); got != tt.want {
+				t.Fatalf("hasReadyEndpoint() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/kubernetes/clusternamespace.go
+++ b/internal/runtime/kubernetes/clusternamespace.go
@@ -44,9 +44,10 @@ type ClusterNamespace struct {
 }
 
 type BoundNamespace struct {
-	env       *schema.Environment
-	namespace string
-	planning  *client.DeploymentPlanning
+	env                       *schema.Environment
+	namespace                 string
+	planning                  *client.DeploymentPlanning
+	skipIngressControllerWait bool
 }
 
 var _ runtime.ClusterNamespace = &ClusterNamespace{}

--- a/internal/runtime/kubernetes/ingress.go
+++ b/internal/runtime/kubernetes/ingress.go
@@ -53,12 +53,11 @@ func planIngress(ctx context.Context, ingressPlanner kubedef.IngressClass, r Bou
 		}
 	}
 
-	// On ephemeral environments, e.g. tests, we don't wait for an
-	// ingress controller to be present, before installing ingress
-	// objects. This is because we sometimes run in environments where
-	// there's no controller installed (e.g. in ephemeral nscloud
-	// clusters). And tests don't (yet) exercise ingress objects.
-	if len(state.Definitions) > 0 && !r.env.Ephemeral {
+	// Local ephemeral environments install nginx and may exercise Ingress
+	// resources, so they need the same readiness ordering as persistent
+	// environments. Ephemeral nscloud clusters use provider-managed ingress and
+	// intentionally have no in-cluster controller to wait for.
+	if len(state.Definitions) > 0 && !r.skipIngressControllerWait {
 		var d defs.DefList
 
 		d.AddExt("Ensure Ingress Controller", &kubedef.OpEnsureIngressController{

--- a/internal/runtime/kubernetes/ingress_test.go
+++ b/internal/runtime/kubernetes/ingress_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"namespacelabs.dev/foundation/framework/kubernetes/kubedef"
+	"namespacelabs.dev/foundation/internal/networking/ingress/nginx"
+	"namespacelabs.dev/foundation/internal/protos"
+	"namespacelabs.dev/foundation/internal/runtime/kubernetes/client"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/cfg"
+)
+
+func TestBindNamespaceSkipsIngressControllerForEphemeralNscloud(t *testing.T) {
+	env := &schema.Environment{Name: "test", Ephemeral: true}
+	workspace := cfg.MakeSyntheticWorkspace(&schema.Workspace{ModuleName: "example.com/test"}, nil)
+	config := cfg.MakeConfigurationWith(env.Name, workspace, cfg.ConfigurationSlice{
+		Configuration: protos.WrapAnysOrDie(&client.HostEnv{Provider: "nscloud"}),
+	})
+
+	bound := bindNamespace(cfg.MakeUnverifiedContext(config, env))
+	if !bound.skipIngressControllerWait {
+		t.Fatal("ephemeral nscloud namespace waits for an in-cluster ingress controller")
+	}
+}
+
+func TestPlanIngressWaitsForControllerInEphemeralEnvironment(t *testing.T) {
+	const packageName = "example.com/test/server"
+
+	for _, tt := range []struct {
+		name                      string
+		skipIngressControllerWait bool
+		wantReadiness             bool
+	}{
+		{name: "local", wantReadiness: true},
+		{name: "nscloud", skipIngressControllerWait: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := planIngress(context.Background(), nginx.IngressClass(), BoundNamespace{
+				env:                       &schema.Environment{Name: "test", Ephemeral: true},
+				namespace:                 "test",
+				skipIngressControllerWait: tt.skipIngressControllerWait,
+			}, &schema.Stack{Entry: []*schema.Stack_Entry{{
+				Server: &schema.Server{PackageName: packageName, Id: "server"},
+			}}}, []*schema.IngressFragment{{
+				Name:   "server",
+				Owner:  packageName,
+				Domain: &schema.Domain{Fqdn: "server.example.com"},
+				HttpPath: []*schema.IngressFragment_IngressHttpPath{{
+					Path: "/", Service: "server", ServicePort: 8080,
+				}},
+			}})
+			if err != nil {
+				t.Fatalf("planIngress: %v", err)
+			}
+
+			var found bool
+			for _, def := range plan.Definitions {
+				if def.GetImpl().MessageIs(&kubedef.OpEnsureIngressController{}) {
+					found = true
+					break
+				}
+			}
+			if found != tt.wantReadiness {
+				t.Fatalf("controller readiness operation = %t, want %t", found, tt.wantReadiness)
+			}
+		})
+	}
+}

--- a/internal/runtime/kubernetes/runtime.go
+++ b/internal/runtime/kubernetes/runtime.go
@@ -135,6 +135,9 @@ func bindNamespace(env cfg.Context) BoundNamespace {
 	}
 
 	b := BoundNamespace{env: env.Environment(), namespace: ns}
+	if hostEnv, err := client.CheckGetHostEnv(env.Configuration()); err == nil {
+		b.skipIngressControllerWait = env.Environment().Ephemeral && hostEnv.GetProvider() == "nscloud"
+	}
 
 	if conf, ok := kubernetesDeploymentPlanning.CheckGet(env.Configuration()); ok {
 		b.planning = conf


### PR DESCRIPTION
## Summary

- Ensure local ephemeral ingress plans wait for the ingress controller before applying Ingress resources while preserving provider-managed nscloud behavior.
- Wait for nginx admission service endpoints after the controller deployment becomes ready.
- Add regression coverage for ephemeral plans and endpoint readiness.

## Validation

- `go test ./internal/networking/ingress ./internal/networking/ingress/nginx ./internal/runtime/kubernetes`
- `nsdev debug update-license --check`
- Deployed `internal/testdata/integrations/golang` to k3d with the controller scaled to zero; deployment waited 26.5s for controller readiness before applying the Ingress.
- Repeated with the controller ready but admission endpoints withheld; deployment waited 7.0s for endpoint publication before applying the Ingress.