### PR TITLE
nsc: retry resource-exhausted Bazel provisioning

### DIFF
--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -454,12 +454,12 @@ func retryBazelProvisioningWithBackoff[T any](ctx context.Context, b backoff.Bac
 
 func retryableBazelProvisioningError(err error) bool {
 	switch connect.CodeOf(err) {
-	case connect.CodeUnavailable, connect.CodeAborted, connect.CodeDeadlineExceeded:
+	case connect.CodeUnavailable, connect.CodeAborted, connect.CodeDeadlineExceeded, connect.CodeResourceExhausted:
 		return true
 	}
 
 	switch status.Code(err) {
-	case codes.Unavailable, codes.Aborted, codes.DeadlineExceeded:
+	case codes.Unavailable, codes.Aborted, codes.DeadlineExceeded, codes.ResourceExhausted:
 		return true
 	default:
 		return false

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -341,6 +341,34 @@ func TestRetryBazelProvisioning(t *testing.T) {
 		}
 	})
 
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "gRPC resource exhausted", err: status.Error(codes.ResourceExhausted, "capacity unavailable")},
+		{name: "Connect resource exhausted", err: connect.NewError(connect.CodeResourceExhausted, errors.New("capacity unavailable"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attempts := 0
+			result, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (string, error) {
+				attempts++
+				if attempts == 1 {
+					return "", tc.err
+				}
+				return "ready", nil
+			})
+			if err != nil {
+				t.Fatalf("retryBazelProvisioningWithBackoff: %v", err)
+			}
+			if result != "ready" {
+				t.Fatalf("result = %q, want ready", result)
+			}
+			if attempts != 2 {
+				t.Fatalf("attempts = %d, want 2", attempts)
+			}
+		})
+	}
+
 	t.Run("does not retry permanent failures", func(t *testing.T) {
 		attempts := 0
 		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (struct{}, error) {


### PR DESCRIPTION
## Summary

- Retry `ResourceExhausted` responses when provisioning Bazel cache, storage, and execution clusters.
- Cover both Connect and gRPC error representations.
- Preserve the existing limit of three retries with a fixed 200ms delay.

## Validation

- `go test ./internal/cli/cmd/cluster`
- `git diff --check`

Related to [SUP-1031](https://linear.app/namespacelabs/issue/SUP-1031/bazel-cache-provisioning-out-of-capacity-error).
