### PR TITLE
nsc: bound Bazel provisioning retries

### DIFF
--- a/internal/cli/cmd/cluster/bazel.go
+++ b/internal/cli/cmd/cluster/bazel.go
@@ -347,7 +347,7 @@ func newSetupCacheCmd() *cobra.Command {
 
 		msg := makeEnsureBazelCacheRequest(version, experimentalDirect, enableRemoteAssetAPI, experimentalCacheName)
 
-		resp, err := retryBazelProvisioning(ctx, func() (*connect.Response[bazelv1beta.EnsureBazelCacheResponse], error) {
+		resp, err := retryBazelProvisioning(ctx, func(ctx context.Context) (*connect.Response[bazelv1beta.EnsureBazelCacheResponse], error) {
 			return client.EnsureBazelCache(ctx, connect.NewRequest(msg))
 		})
 		if err != nil {

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -36,6 +36,7 @@ const (
 	defaultBazelRbeCommand      = "build"
 	bazelProvisioningMaxRetries = 3
 	bazelProvisioningRetryWait  = 200 * time.Millisecond
+	bazelProvisioningTimeout    = time.Minute
 	bazelStorageReadOnly        = "read-only"
 	bazelStorageReadWrite       = "read-write"
 )
@@ -397,7 +398,7 @@ func ensureBazelExecutionCluster(ctx context.Context, tok api.TokenSource, key s
 	req.SetAuthMode(authMode)
 	req.SetEnableRemoteAssetApi(enableRemoteAssetAPI)
 
-	return retryBazelProvisioning(ctx, func() (*bazelv1beta.EnsureClusterResponse, error) {
+	return retryBazelProvisioning(ctx, func(ctx context.Context) (*bazelv1beta.EnsureClusterResponse, error) {
 		return client.EnsureCluster(ctx, req)
 	})
 }
@@ -411,7 +412,7 @@ func ensureBazelStorageCluster(ctx context.Context, tok api.TokenSource, key str
 
 	req := makeEnsureBazelStorageClusterRequest(key, authMode, enableRemoteAssetAPI, accessMode)
 
-	return retryBazelProvisioning(ctx, func() (*bazelv1beta.EnsureStorageClusterResponse, error) {
+	return retryBazelProvisioning(ctx, func(ctx context.Context) (*bazelv1beta.EnsureStorageClusterResponse, error) {
 		return client.EnsureStorageCluster(ctx, req)
 	})
 }
@@ -432,14 +433,17 @@ func bazelStorageAccessMode(storageMode string) bazelv1beta.BazelStorageAccessMo
 	return bazelv1beta.BazelStorageAccessMode_BAZEL_STORAGE_ACCESS_MODE_READ_WRITE
 }
 
-func retryBazelProvisioning[T any](ctx context.Context, call func() (T, error)) (T, error) {
+func retryBazelProvisioning[T any](ctx context.Context, call func(context.Context) (T, error)) (T, error) {
+	ctx, cancel := context.WithTimeout(ctx, bazelProvisioningTimeout)
+	defer cancel()
+
 	return retryBazelProvisioningWithBackoff(ctx, backoff.NewConstantBackOff(bazelProvisioningRetryWait), call)
 }
 
-func retryBazelProvisioningWithBackoff[T any](ctx context.Context, b backoff.BackOff, call func() (T, error)) (T, error) {
+func retryBazelProvisioningWithBackoff[T any](ctx context.Context, b backoff.BackOff, call func(context.Context) (T, error)) (T, error) {
 	var result T
 	err := backoff.Retry(func() error {
-		value, err := call()
+		value, err := call(ctx)
 		if err == nil {
 			result = value
 			return nil

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -309,7 +309,7 @@ func TestRetryBazelProvisioning(t *testing.T) {
 
 	t.Run("retries transient failures", func(t *testing.T) {
 		attempts := 0
-		result, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (string, error) {
+		result, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func(context.Context) (string, error) {
 			attempts++
 			if attempts <= bazelProvisioningMaxRetries {
 				return "", status.Error(codes.Unavailable, "rolling out")
@@ -329,7 +329,7 @@ func TestRetryBazelProvisioning(t *testing.T) {
 
 	t.Run("stops after maximum retries", func(t *testing.T) {
 		attempts := 0
-		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (struct{}, error) {
+		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func(context.Context) (struct{}, error) {
 			attempts++
 			return struct{}{}, connect.NewError(connect.CodeUnavailable, errors.New("rolling out"))
 		})
@@ -350,7 +350,7 @@ func TestRetryBazelProvisioning(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			attempts := 0
-			result, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (string, error) {
+			result, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func(context.Context) (string, error) {
 				attempts++
 				if attempts == 1 {
 					return "", tc.err
@@ -371,12 +371,46 @@ func TestRetryBazelProvisioning(t *testing.T) {
 
 	t.Run("does not retry permanent failures", func(t *testing.T) {
 		attempts := 0
-		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func() (struct{}, error) {
+		_, err := retryBazelProvisioningWithBackoff(context.Background(), &backoff.ZeroBackOff{}, func(context.Context) (struct{}, error) {
 			attempts++
 			return struct{}{}, status.Error(codes.InvalidArgument, "invalid")
 		})
 		if status.Code(err) != codes.InvalidArgument {
 			t.Fatalf("error code = %v, want invalid argument", status.Code(err))
+		}
+		if attempts != 1 {
+			t.Fatalf("attempts = %d, want 1", attempts)
+		}
+	})
+
+	t.Run("sets an overall provisioning deadline", func(t *testing.T) {
+		_, err := retryBazelProvisioning(context.Background(), func(ctx context.Context) (struct{}, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("provisioning context has no deadline")
+			}
+			remaining := time.Until(deadline)
+			if remaining < 59*time.Second || remaining > bazelProvisioningTimeout {
+				t.Fatalf("provisioning deadline remaining = %v, want approximately %v", remaining, bazelProvisioningTimeout)
+			}
+			return struct{}{}, nil
+		})
+		if err != nil {
+			t.Fatalf("retryBazelProvisioning: %v", err)
+		}
+	})
+
+	t.Run("passes cancellation to an in-flight attempt", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		attempts := 0
+		_, err := retryBazelProvisioningWithBackoff(ctx, &backoff.ZeroBackOff{}, func(callCtx context.Context) (struct{}, error) {
+			attempts++
+			cancel()
+			<-callCtx.Done()
+			return struct{}{}, callCtx.Err()
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context canceled", err)
 		}
 		if attempts != 1 {
 			t.Fatalf("attempts = %d, want 1", attempts)

--- a/internal/cli/cmd/cluster/pants.go
+++ b/internal/cli/cmd/cluster/pants.go
@@ -64,11 +64,13 @@ func newSetupPantsCacheCmd() *cobra.Command {
 			return err
 		}
 
-		req := connect.NewRequest(&bazelv1beta.EnsureBazelCacheRequest{
+		msg := &bazelv1beta.EnsureBazelCacheRequest{
 			Version: 1,
-		})
+		}
 
-		resp, err := client.EnsureBazelCache(ctx, req)
+		resp, err := retryBazelProvisioning(ctx, func(ctx context.Context) (*connect.Response[bazelv1beta.EnsureBazelCacheResponse], error) {
+			return client.EnsureBazelCache(ctx, connect.NewRequest(msg))
+		})
 		if err != nil {
 			return fnerrors.Newf("failed to provision bazel cache: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Bound Bazel cache, storage, and execution provisioning to an overall 60-second timeout.
- Pass the bounded context to every retry attempt so in-flight RPCs are canceled when the timeout expires.
- Retain the existing limit of 3 retries with fixed 200ms delays.
- Apply the same provisioning retry behavior to Pants cache setup.

## Validation

- `go test ./internal/cli/cmd/cluster`
- `git diff --check`

Follow-up to [foundation#1945](https://github.com/namespacelabs/foundation/pull/1945) and related to [SUP-1031](https://linear.app/namespacelabs/issue/SUP-1031/bazel-cache-provisioning-out-of-capacity-error).
