### PR TITLE
ns: release Go source snapshots after hashing

### DIFF
--- a/internal/integrations/golang/localbuild.go
+++ b/internal/integrations/golang/localbuild.go
@@ -50,7 +50,7 @@ func buildLocalImage(ctx context.Context, env pkggraph.SealedContext, workspace 
 	}
 
 	if bin.UnsafeCacheable || workspace.IsExternal() {
-		comp.localfs = memfs.DeferSnapshot(workspace.ReadOnlyFS(bin.GoWorkspacePath), memfs.SnapshotOpts{})
+		comp.sourceDigest = deferSourceDigest(workspace.ReadOnlyFS(bin.GoWorkspacePath))
 	}
 
 	layers := []oci.NamedLayer{
@@ -68,6 +68,18 @@ func buildLocalImage(ctx context.Context, env pkggraph.SealedContext, workspace 
 
 	return compute.Named(tasks.Action("go.make-binary-image").Arg("binary", bin),
 		oci.MakeImage(fmt.Sprintf("Go binary %s", bin.PackageName), base, layers...).Image()), nil
+}
+
+func deferSourceDigest(fsys fs.FS) compute.Computable[schema.Digest] {
+	return compute.Inline(tasks.Action("go.source-digest"), func(ctx context.Context) (schema.Digest, error) {
+		snapshot, err := memfs.Snapshot(fsys, memfs.SnapshotOpts{})
+		if err != nil {
+			return schema.Digest{}, err
+		}
+		// Compilation reads from disk, so retain only the digest, not a full source
+		// snapshot for every binary in the build graph.
+		return snapshot.ComputeDigest(ctx)
+	})
 }
 
 func baseImage(ctx context.Context, env pkggraph.SealedContext, target build.BuildTarget) (oci.NamedImage, error) {
@@ -159,8 +171,8 @@ func goarm(platform specs.Platform) (string, error) {
 type compilation struct {
 	workspaceAbs string // Does not by itself affect the output.
 	sdk          compute.Computable[golang.LocalSDK]
-	trigger      compute.Computable[any]   // We depend on `trigger` so we trigger a re-build on workspace changes.
-	localfs      compute.Computable[fs.FS] // If specified, this becomes a stable build.
+	trigger      compute.Computable[any] // We depend on `trigger` so we trigger a re-build on workspace changes.
+	sourceDigest compute.Computable[schema.Digest]
 	binary       GoBinary
 	platform     specs.Platform
 
@@ -185,8 +197,8 @@ func (c *compilation) Inputs() *compute.In {
 		in = in.Computable("trigger", c.trigger)
 	}
 
-	if c.localfs != nil {
-		in = in.Computable("localfs", c.localfs)
+	if c.sourceDigest != nil {
+		in = in.Computable("localfs", c.sourceDigest)
 	} else {
 		in = in.Indigestible("localfs", "not available")
 	}

--- a/internal/integrations/golang/localbuild_test.go
+++ b/internal/integrations/golang/localbuild_test.go
@@ -1,0 +1,149 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package golang
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/internal/compute/cache"
+	"namespacelabs.dev/foundation/internal/fnfs/memfs"
+	"namespacelabs.dev/foundation/schema"
+	"namespacelabs.dev/foundation/std/tasks"
+	"namespacelabs.dev/foundation/std/tasks/simplelog"
+)
+
+func TestSourceDigest(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(filename, []byte("package main\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Snapshots ignore symlinks, including dangling ones.
+	if err := os.Symlink("missing", filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := tasks.WithSink(context.Background(), simplelog.NewSink(io.Discard, 0))
+	readDigest := func() schema.Digest {
+		t.Helper()
+		var digest schema.Digest
+		err := compute.DoWithCache(ctx, cache.NoCache, func(ctx context.Context) error {
+			result, err := compute.Get(ctx, deferSourceDigest(os.DirFS(dir)))
+			if err != nil {
+				return err
+			}
+			digest = result.Value
+			if !digest.IsSet() || digest != result.Digest {
+				t.Errorf("invalid result: value %v, digest %v", digest, result.Digest)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return digest
+	}
+
+	before := readDigest()
+	snapshot, err := memfs.Snapshot(os.DirFS(dir), memfs.SnapshotOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := snapshot.ComputeDigest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != want || readDigest() != before {
+		t.Error("source digest must match the snapshot and be stable across invocations")
+	}
+
+	if err := os.WriteFile(filename, []byte("package main\nfunc main() {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	after := readDigest()
+	if before == after {
+		t.Error("a later invocation must see edited sources")
+	}
+	if err := os.Rename(filename, filepath.Join(dir, "renamed.go")); err != nil {
+		t.Fatal(err)
+	}
+	renamed := readDigest()
+	if after == renamed {
+		t.Error("file names are part of the source digest")
+	}
+	if err := os.Remove(filepath.Join(dir, "renamed.go")); err != nil {
+		t.Fatal(err)
+	}
+	if renamed == readDigest() {
+		t.Error("a later invocation must see deleted sources")
+	}
+}
+
+func TestSourceDigestReadError(t *testing.T) {
+	ctx := tasks.WithSink(context.Background(), simplelog.NewSink(io.Discard, 0))
+	err := compute.DoWithCache(ctx, cache.NoCache, func(ctx context.Context) error {
+		_, err := compute.GetValue(ctx, deferSourceDigest(os.DirFS(filepath.Join(t.TempDir(), "missing"))))
+		return err
+	})
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("got %v, want a missing-source error", err)
+	}
+}
+
+func BenchmarkSourceDigestRetention(b *testing.B) {
+	dir := b.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "source"), make([]byte, 1<<20), 0600); err != nil {
+		b.Fatal(err)
+	}
+	ctx := tasks.WithSink(context.Background(), simplelog.NewSink(io.Discard, 0))
+	for _, keepSnapshot := range []bool{true, false} {
+		name := "digest"
+		if keepSnapshot {
+			name = "snapshot"
+		}
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				err := compute.DoWithCache(ctx, cache.NoCache, func(ctx context.Context) error {
+					const builds = 64
+					nodes := make([]compute.UntypedComputable, 0, builds)
+					runtime.GC()
+					var before, after runtime.MemStats
+					runtime.ReadMemStats(&before)
+					for j := 0; j < builds; j++ {
+						if keepSnapshot {
+							node := memfs.DeferSnapshot(os.DirFS(dir), memfs.SnapshotOpts{})
+							if _, err := compute.GetValue(ctx, node); err != nil {
+								return err
+							}
+							nodes = append(nodes, node)
+						} else {
+							node := deferSourceDigest(os.DirFS(dir))
+							if _, err := compute.GetValue(ctx, node); err != nil {
+								return err
+							}
+							nodes = append(nodes, node)
+						}
+					}
+					runtime.GC()
+					runtime.ReadMemStats(&after)
+					runtime.KeepAlive(nodes)
+					b.ReportMetric(float64(int64(after.HeapAlloc)-int64(before.HeapAlloc))/builds, "retained-B/build")
+					return nil
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Retain only source digests during local Go build preparation instead of keeping a full source-tree snapshot for every binary.
- Add coverage for source edits, renames, deletions, and read errors, plus a retained-memory benchmark.
- Keep workflow configuration and build concurrency unchanged.

## Validation

- `go test -count=1 ./internal/integrations/golang/... ./internal/compute/... ./internal/fnfs/memfs`
- `go test ./internal/integrations/golang -run '^$' -bench '^BenchmarkSourceDigestRetention$' -benchtime=1x -count=3`
- Benchmark with 64 build nodes and a 1 MiB source tree: retained memory fell from approximately 1,058,000 bytes to 962–973 bytes per build.
- The full e2e workflow has not been rerun with this change.