### PR TITLE
nsc: use build event results URL from EnsureCluster

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -218,6 +218,7 @@ jobs:
           /tmp/ns test \
             --also_report_start_events \
             --debug_to_file=/tmp/debug_log \
+            --log_dir=/tmp/test_logs \
             --use_prebuilts=true \
             --deploy_push_prebuilts_to_registry=false \
             --golang_use_buildkit=true \
@@ -233,6 +234,7 @@ jobs:
           path: |
             /tmp/action_log
             /tmp/debug_log
+            /tmp/test_logs
           retention-days: 3
         if: always()
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module namespacelabs.dev/foundation
 go 1.26.0
 
 require (
-	buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1
+	buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.12-20260717182923-633d56cd145e.1
 	buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1
 	buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1
-	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1
+	buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.12-20260907160645-4561629269c7.1
 	cloud.google.com/go/artifactregistry v1.17.2
 	cloud.google.com/go/container v1.45.0
 	connectrpc.com/connect v1.20.0
@@ -139,7 +139,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/grpc v1.82.1
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.20.2

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1 h1:0dFwGad+AGt34eoyYRYRddrt/sTYHo3YO5TMFKyepmE=
-buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.11-20260717182923-633d56cd145e.1/go.mod h1:h9DLLqhUERXx+6lPKgrJxRAG03mCRRAv6VEJnmUnQGk=
+buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.12-20260717182923-633d56cd145e.1 h1:yeusUVBBPUCU30p3muCO6Fu6h6+ofN/uvhyG2ZQOQKo=
+buf.build/gen/go/namespace/bazel/protocolbuffers/go v1.36.12-20260717182923-633d56cd145e.1/go.mod h1:zxytu9g+lg+R/S7nG/trcmBcrd9KAZeHqQbgtChow7U=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1 h1:Nu+h9ryPRPUvcJcEl9C8g4ryyGPYFbujbEIIbDVUDxA=
 buf.build/gen/go/namespace/cloud/connectrpc/go v1.20.0-20260803095335-52d3e79ff3ca.1/go.mod h1:xO9KI77e5zYyYFSpddrTqcwrL8a0z+xys5/CMeKOto4=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1 h1:z+Fe4SOP1T1BWkdq6WA0VvNdStRYCpAJsPVuKZyM+PU=
 buf.build/gen/go/namespace/cloud/grpc/go v1.6.2-20260814090053-550b37c69cb1.1/go.mod h1:kNp5GpQ3qod6DJaIJHXTJOPoORGIGXx/vSTVWAZ3OAM=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1 h1:kv5P02k0h+RfyXDqFydfwEBYP5LwJfKGgk6saY7jO60=
-buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.11-20260814090053-550b37c69cb1.1/go.mod h1:Sq0KOCy7xpul1cCYq/55WryE9Nke8fQsext30EBZp7o=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.12-20260907160645-4561629269c7.1 h1:COCAucZpe41i4Pl70UtxGDak107DM5Iy3P6BdukCzCg=
+buf.build/gen/go/namespace/cloud/protocolbuffers/go v1.36.12-20260907160645-4561629269c7.1/go.mod h1:qZ8DAMLNpt2zvGyC5UsmblfkkKyUWbVHEkLodBFoMKg=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -1235,8 +1235,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cli/cmd/cluster/bazel_rbe.go
+++ b/internal/cli/cmd/cluster/bazel_rbe.go
@@ -131,6 +131,7 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			// used to authenticate it in the default mTLS mode) when build event
 			// ingestion is enabled for the workspace.
 			out.BuildEventEndpoint = res.GetBuildEventEndpoint()
+			out.BuildEventResultsURL = res.GetBuildEventResultsUrl()
 			out.CredentialHelperDomains = res.GetCredentialHelperDomains()
 		} else {
 			res, err := ensureBazelStorageCluster(ctx, tok, key, authMode, enableRemoteAssetAPI, bazelStorageAccessMode(storageMode))
@@ -142,18 +143,6 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 			}
 
 			out = bazelStorageSetup(res)
-		}
-
-		if out.BuildEventEndpoint != "" && !disableBuildEvents {
-			tenant, err := fnapi.GetTenantWithToken(ctx, tok)
-			if err != nil {
-				return fnerrors.Newf("failed to resolve tenant for build event results: %w", err)
-			}
-			if tenant.Tenant == nil || tenant.Tenant.TenantId == "" {
-				return fnerrors.New("received incomplete tenant response")
-			}
-
-			out.TenantID = tenant.Tenant.TenantId
 		}
 
 		if static {
@@ -263,7 +252,6 @@ func newSetupExecutionCmdWithRemoteFlag(includeRemoteFlag bool) *cobra.Command {
 }
 
 type bazelRbeSetup struct {
-	TenantID                 string        `json:"-"`
 	SchedulerEndpoint        string        `json:"scheduler_endpoint,omitempty"`
 	StorageEndpoint          string        `json:"storage_endpoint,omitempty"`
 	RemoteAssetEndpoint      string        `json:"remote_asset_endpoint,omitempty"`
@@ -276,6 +264,7 @@ type bazelRbeSetup struct {
 	RemoteLocalFallback      bool          `json:"remote_local_fallback,omitempty"`
 	RemoteDownloadOutputs    string        `json:"remote_download_outputs,omitempty"`
 	BuildEventEndpoint       string        `json:"build_event_endpoint,omitempty"`
+	BuildEventResultsURL     string        `json:"build_event_results_url,omitempty"`
 	CredentialHelperDomains  []string      `json:"credential_helper_domains,omitempty"`
 }
 
@@ -332,10 +321,10 @@ func toBazelExecutionConfig(ctx context.Context, out bazelRbeSetup, command stri
 	}
 
 	if out.BuildEventEndpoint != "" && !disableBuildEvents {
-		lines = append(lines,
-			fmt.Sprintf("--bes_backend=%s", out.BuildEventEndpoint),
-			fmt.Sprintf("--bes_results_url=https://cloud.namespace.so/%s/bazel/invocation/", out.TenantID),
-		)
+		lines = append(lines, fmt.Sprintf("--bes_backend=%s", out.BuildEventEndpoint))
+		if out.BuildEventResultsURL != "" {
+			lines = append(lines, fmt.Sprintf("--bes_results_url=%s", out.BuildEventResultsURL))
+		}
 
 		if out.IngressAuthToken != "" {
 			lines = append(lines,

--- a/internal/cli/cmd/cluster/bazel_rbe_test.go
+++ b/internal/cli/cmd/cluster/bazel_rbe_test.go
@@ -22,11 +22,11 @@ func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
-		TenantID:           "tenant_test",
-		SchedulerEndpoint:  "grpcs://scheduler.example:443",
-		StorageEndpoint:    "grpcs://storage.example:443",
-		IngressAuthToken:   "tok123",
-		BuildEventEndpoint: "grpcs://api.us-east1.namespaceapis.com",
+		SchedulerEndpoint:    "grpcs://scheduler.example:443",
+		StorageEndpoint:      "grpcs://storage.example:443",
+		IngressAuthToken:     "tok123",
+		BuildEventEndpoint:   "grpcs://api.us-east1.namespaceapis.com",
+		BuildEventResultsURL: "https://cloud.namespace.so/test/bazel/invocation/",
 	}, "build", true, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
@@ -35,7 +35,7 @@ func TestToBazelExecutionConfigBuildEventsStatic(t *testing.T) {
 	got := string(config)
 	for _, want := range []string{
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
-		"build --bes_results_url=https://cloud.namespace.so/tenant_test/bazel/invocation/\n",
+		"build --bes_results_url=https://cloud.namespace.so/test/bazel/invocation/\n",
 		"build --bes_header=Authorization=Bearer\\ tok123\n",
 		"build --bes_header=x-nsc-ingress-auth=Bearer\\ tok123\n",
 	} {
@@ -53,12 +53,12 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
-		TenantID:                "tenant_test",
 		SchedulerEndpoint:       "grpcs://scheduler.example:444",
 		StorageEndpoint:         "grpcs://storage.example:444",
 		ClientCert:              "/tmp/client.cert",
 		ClientKey:               "/tmp/client.key",
 		BuildEventEndpoint:      "grpcs://api.us-east1.namespaceapis.com",
+		BuildEventResultsURL:    "https://cloud.namespace.so/test/bazel/invocation/",
 		CredentialHelperDomains: []string{"api.us-east1.namespaceapis.com"},
 	}, "build", true, false)
 	if err != nil {
@@ -68,7 +68,7 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 	got := string(config)
 	for _, want := range []string{
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
-		"build --bes_results_url=https://cloud.namespace.so/tenant_test/bazel/invocation/\n",
+		"build --bes_results_url=https://cloud.namespace.so/test/bazel/invocation/\n",
 		"build --credential_helper=*.api.us-east1.namespaceapis.com=" + BazelCredHelperBinary + "\n",
 	} {
 		if !strings.Contains(got, want) {
@@ -81,11 +81,31 @@ func TestToBazelExecutionConfigBuildEventsMTLS(t *testing.T) {
 	}
 }
 
+func TestToBazelExecutionConfigBuildEventsWithoutResultsURL(t *testing.T) {
+	t.Parallel()
+
+	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
+		SchedulerEndpoint:  "grpcs://scheduler.example:443",
+		StorageEndpoint:    "grpcs://storage.example:443",
+		BuildEventEndpoint: "grpcs://api.us-east1.namespaceapis.com",
+	}, "build", true, false)
+	if err != nil {
+		t.Fatalf("toBazelExecutionConfig: %v", err)
+	}
+
+	got := string(config)
+	if !strings.Contains(got, "build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n") {
+		t.Fatalf("missing build event backend in %q", got)
+	}
+	if strings.Contains(got, "--bes_results_url=") {
+		t.Fatalf("configured empty build event results URL in %q", got)
+	}
+}
+
 func TestToBazelExecutionConfigNoBuildEvents(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
-		TenantID:          "tenant_test",
 		SchedulerEndpoint: "grpcs://scheduler.example:444",
 		StorageEndpoint:   "grpcs://storage.example:444",
 		ClientCert:        "/tmp/client.cert",
@@ -105,7 +125,6 @@ func TestToBazelExecutionConfigBuildEventsDisabled(t *testing.T) {
 	t.Parallel()
 
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
-		TenantID:                "tenant_test",
 		SchedulerEndpoint:       "grpcs://scheduler.example:444",
 		StorageEndpoint:         "grpcs://storage.example:444",
 		BuildEventEndpoint:      "grpcs://api.us-east1.namespaceapis.com",
@@ -131,7 +150,6 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 
 	remoteUploadLocalResults := false
 	config, err := toBazelExecutionConfig(context.Background(), bazelRbeSetup{
-		TenantID:                 "tenant_test",
 		SchedulerEndpoint:        "grpcs://scheduler.example:443",
 		StorageEndpoint:          "grpcs://storage.example:443",
 		RemoteUploadLocalResults: &remoteUploadLocalResults,
@@ -141,6 +159,7 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 		RemoteTimeout:            5 * time.Minute,
 		Jobs:                     32,
 		BuildEventEndpoint:       "grpcs://api.us-east1.namespaceapis.com",
+		BuildEventResultsURL:     "https://cloud.namespace.so/test/bazel/invocation/",
 	}, "build", false, false)
 	if err != nil {
 		t.Fatalf("toBazelExecutionConfig: %v", err)
@@ -155,7 +174,7 @@ func TestToBazelExecutionConfigWithoutRemoteExecution(t *testing.T) {
 		"build --jobs=32\n",
 		"build --remote_timeout=300\n",
 		"build --bes_backend=grpcs://api.us-east1.namespaceapis.com\n",
-		"build --bes_results_url=https://cloud.namespace.so/tenant_test/bazel/invocation/\n",
+		"build --bes_results_url=https://cloud.namespace.so/test/bazel/invocation/\n",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing config line %q in %q", want, got)


### PR DESCRIPTION
## Summary

- Uses the build event results URL returned by `EnsureCluster` when generating Bazel configuration.
- Removes the extra tenant lookup, allowing revocable Bazel tokens to configure BES without `tenant/get` permission.
- Omits `--bes_results_url` when an older backend does not return the field while retaining the BES backend configuration.

## API design

- Consumes `build_event_results_url` added by namespacelabs/internal#20255.
- Updates the generated Namespace Cloud protobuf dependency containing the new response field.

## Validation

- `go test ./internal/cli/cmd/cluster`
- `git diff --check`