### PR TITLE
build: make Bazel a first-class graph pass

### DIFF
--- a/internal/build/bazel/bazel.go
+++ b/internal/build/bazel/bazel.go
@@ -1,0 +1,279 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package bazel
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/bazelbuild/bazelisk/core"
+	"github.com/bazelbuild/bazelisk/repositories"
+	"namespacelabs.dev/foundation/internal/build"
+	"namespacelabs.dev/foundation/internal/compute"
+	"namespacelabs.dev/foundation/internal/console"
+	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/foundation/std/tasks"
+)
+
+type Builder struct {
+	bazelRC string
+}
+
+func NewBuilder(bazelRC string) *Builder {
+	return &Builder{bazelRC: bazelRC}
+}
+
+// Target describes a Bazel target that produces exactly one output file.
+type Target struct {
+	WorkspaceAbs string
+	Label        string
+	BuildArgs    []string
+}
+
+// AddTarget adds a Bazel target to the current build graph. When there is no
+// graph, the target is finalized as a standalone invocation.
+func (b *Builder) AddTarget(ctx context.Context, target Target) (compute.Computable[string], error) {
+	graph, ok := build.GraphFromContext(ctx)
+	if !ok {
+		pass := &bazelGraph{bazelRC: b.bazelRC}
+		node, err := pass.add(target)
+		if err != nil {
+			return nil, err
+		}
+		if err := pass.Finalize(); err != nil {
+			return nil, err
+		}
+		return node, nil
+	}
+	pass, err := graph.Pass("bazel:"+b.bazelRC, func() build.GraphPass {
+		return &bazelGraph{bazelRC: b.bazelRC}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pass.(*bazelGraph).add(target)
+}
+
+type bazelGraph struct {
+	mu sync.Mutex
+
+	bazelRC   string
+	nodes     []*targetNode
+	finalized bool
+}
+
+func (g *bazelGraph) add(target Target) (*targetNode, error) {
+	if target.WorkspaceAbs == "" {
+		return nil, fnerrors.InternalError("bazel: workspace is missing")
+	}
+	if target.Label == "" {
+		return nil, fnerrors.InternalError("bazel: target label is missing")
+	}
+	node := &targetNode{target: Target{
+		WorkspaceAbs: target.WorkspaceAbs,
+		Label:        target.Label,
+		BuildArgs:    append([]string(nil), target.BuildArgs...),
+	}}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.finalized {
+		return nil, fnerrors.InternalError("bazel: build graph has already been finalized")
+	}
+	g.nodes = append(g.nodes, node)
+	return node, nil
+}
+
+type invocationKey struct {
+	workspaceAbs string
+	buildArgs    string
+}
+
+func (g *bazelGraph) Finalize() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.finalized {
+		return fnerrors.InternalError("bazel: build graph has already been finalized")
+	}
+	g.finalized = true
+
+	invocations := map[invocationKey]*invocation{}
+	for _, node := range g.nodes {
+		key := invocationKey{
+			workspaceAbs: node.target.WorkspaceAbs,
+			buildArgs:    strings.Join(node.target.BuildArgs, "\x00"),
+		}
+		inv := invocations[key]
+		if inv == nil {
+			inv = &invocation{
+				workspaceAbs: node.target.WorkspaceAbs,
+				bazelRC:      g.bazelRC,
+				buildArgs:    append([]string(nil), node.target.BuildArgs...),
+				targets:      map[string]struct{}{},
+			}
+			invocations[key] = inv
+		}
+		inv.targets[node.target.Label] = struct{}{}
+		node.invocation = inv
+	}
+	return nil
+}
+
+type targetNode struct {
+	target     Target
+	invocation *invocation
+
+	compute.LocalScoped[string]
+}
+
+func (n *targetNode) Action() *tasks.ActionEvent {
+	return tasks.Action("bazel.collect-output").Arg("target", n.target.Label)
+}
+
+func (n *targetNode) Inputs() *compute.In {
+	if n.invocation == nil {
+		panic("Bazel build graph was not finalized")
+	}
+	return compute.Inputs().Str("target", n.target.Label).Computable("invocation", n.invocation)
+}
+
+func (n *targetNode) Output() compute.Output {
+	return compute.Output{NonDeterministic: true, Unshareable: true}
+}
+
+func (n *targetNode) Compute(_ context.Context, deps compute.Resolved) (string, error) {
+	outputs := compute.MustGetDepValue(deps, n.invocation, "invocation")
+	output := outputs[n.target.Label]
+	if output == "" {
+		return "", fnerrors.InternalError("bazel: output for target %s is missing", n.target.Label)
+	}
+	return output, nil
+}
+
+type outputs map[string]string
+
+type invocation struct {
+	workspaceAbs string
+	bazelRC      string
+	buildArgs    []string
+	targets      map[string]struct{}
+
+	compute.LocalScoped[outputs]
+}
+
+func (inv *invocation) targetList() []string {
+	targets := make([]string, 0, len(inv.targets))
+	for target := range inv.targets {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	return targets
+}
+
+func (inv *invocation) Action() *tasks.ActionEvent {
+	return tasks.Action("bazel.build").Arg("targets", strings.Join(inv.targetList(), " ")).Arg("args", strings.Join(inv.buildArgs, " "))
+}
+
+func (inv *invocation) Inputs() *compute.In {
+	return compute.Inputs().
+		Indigestible("workspace", inv.workspaceAbs).
+		Str("bazelrc", inv.bazelRC).
+		JSON("args", inv.buildArgs).
+		JSON("targets", inv.targetList())
+}
+
+func (inv *invocation) Output() compute.Output {
+	return compute.Output{NonDeterministic: true, Unshareable: true}
+}
+
+func (inv *invocation) Compute(ctx context.Context, _ compute.Resolved) (outputs, error) {
+	installation, err := bazelInstallation()
+	if err != nil {
+		return nil, err
+	}
+	targets := inv.targetList()
+	startup := []string{"--bazelrc=" + inv.bazelRC}
+	buildArgs := append([]string{}, startup...)
+	buildArgs = append(buildArgs, "build", "--remote_download_outputs=all")
+	buildArgs = append(buildArgs, inv.buildArgs...)
+	buildArgs = append(buildArgs, targets...)
+	if err := runBazel(ctx, installation, inv.workspaceAbs, buildArgs...); err != nil {
+		return nil, err
+	}
+
+	result := outputs{}
+	for _, target := range targets {
+		var stdout bytes.Buffer
+		cqueryArgs := append([]string{}, startup...)
+		cqueryArgs = append(cqueryArgs, "cquery", "--output=files")
+		cqueryArgs = append(cqueryArgs, inv.buildArgs...)
+		cqueryArgs = append(cqueryArgs, target)
+		if err := runBazelWithOutput(ctx, installation, inv.workspaceAbs, &stdout, cqueryArgs...); err != nil {
+			return nil, err
+		}
+		output, err := parseOutput(inv.workspaceAbs, target, stdout.String())
+		if err != nil {
+			return nil, err
+		}
+		result[target] = output
+	}
+	return result, nil
+}
+
+func bazelInstallation() (string, error) {
+	config := core.MakeDefaultConfig()
+	gcs := &repositories.GCSRepo{}
+	github := repositories.CreateGitHubRepo(config.Get("BAZELISK_GITHUB_TOKEN"))
+	repos := core.CreateRepositories(gcs, github, gcs, gcs, true)
+	installation, err := core.GetBazelInstallation(repos, config)
+	if err != nil {
+		return "", fnerrors.Newf("bazel: failed to install Bazel: %w", err)
+	}
+	return installation.Path, nil
+}
+
+func parseOutput(workspaceAbs, target, output string) (string, error) {
+	var files []string
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		files = append(files, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fnerrors.Newf("bazel: failed to read cquery output: %w", err)
+	}
+	if len(files) != 1 {
+		return "", fnerrors.Newf("bazel: target %s produced %d files, expected one", target, len(files))
+	}
+	source := files[0]
+	if !filepath.IsAbs(source) {
+		source = filepath.Join(workspaceAbs, source)
+	}
+	return source, nil
+}
+
+func runBazel(ctx context.Context, binary, dir string, args ...string) error {
+	return runBazelWithOutput(ctx, binary, dir, console.Output(ctx, "bazel"), args...)
+}
+
+func runBazelWithOutput(ctx context.Context, binary, dir string, stdout io.Writer, args ...string) error {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = dir
+	cmd.Stdout = stdout
+	cmd.Stderr = console.Output(ctx, "bazel")
+	if err := cmd.Run(); err != nil {
+		return fnerrors.Newf("bazel: command failed: %w", err)
+	}
+	return nil
+}

--- a/internal/build/bazel/bazel_test.go
+++ b/internal/build/bazel/bazel_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package bazel
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"namespacelabs.dev/foundation/internal/build"
+)
+
+func TestGraphCollapsesCompatibleTargets(t *testing.T) {
+	graph := build.NewGraph()
+	ctx := build.WithGraph(context.Background(), graph)
+	builder := NewBuilder("/tmp/namespace.bazelrc")
+
+	first, err := builder.AddTarget(ctx, Target{WorkspaceAbs: "/workspace", Label: "//global/server/iam:iam", BuildArgs: []string{"--platforms=linux_amd64"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := builder.AddTarget(ctx, Target{WorkspaceAbs: "/workspace", Label: "//registry/server:server", BuildArgs: []string{"--platforms=linux_amd64"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentPlatform, err := builder.AddTarget(ctx, Target{WorkspaceAbs: "/workspace", Label: "//global/server/iam:iam", BuildArgs: []string{"--platforms=linux_arm64"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+
+	firstNode := first.(*targetNode)
+	secondNode := second.(*targetNode)
+	differentPlatformNode := differentPlatform.(*targetNode)
+	if firstNode.invocation != secondNode.invocation {
+		t.Fatal("compatible targets were assigned to different Bazel invocations")
+	}
+	if firstNode.invocation == differentPlatformNode.invocation {
+		t.Fatal("targets with different arguments were assigned to the same Bazel invocation")
+	}
+	want := []string{"//global/server/iam:iam", "//registry/server:server"}
+	if got := firstNode.invocation.targetList(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("targets = %q, want %q", got, want)
+	}
+}
+
+func TestTargetWithoutBuildGraphUsesStandaloneInvocation(t *testing.T) {
+	got, err := NewBuilder("/tmp/namespace.bazelrc").AddTarget(context.Background(), Target{WorkspaceAbs: "/workspace", Label: "//target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(*targetNode).invocation == nil {
+		t.Fatal("target was not assigned to a standalone Bazel invocation")
+	}
+}
+
+func TestGraphRejectsTargetAfterFinalize(t *testing.T) {
+	graph := &bazelGraph{}
+	if err := graph.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := graph.add(Target{WorkspaceAbs: "/workspace", Label: "//target"}); err == nil {
+		t.Fatal("expected adding a target after finalization to fail")
+	}
+}
+
+func TestParseOutputPreservesRequestedTargetIdentity(t *testing.T) {
+	got, err := parseOutput("/workspace", "//global/server/iam:alias", "bazel-bin/global/server/iam/iam\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/workspace", "bazel-bin/global/server/iam/iam")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("outputs = %q, want %q", got, want)
+	}
+}
+
+func TestParseOutputRejectsMultipleFiles(t *testing.T) {
+	if _, err := parseOutput("/workspace", "//target", "bazel-bin/first\nbazel-bin/second\n"); err == nil {
+		t.Fatal("expected multiple outputs to fail")
+	}
+}

--- a/internal/build/graph.go
+++ b/internal/build/graph.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// GraphPass collects build nodes during graph generation and rewrites them into
+// executable compute nodes when graph generation is complete.
+type GraphPass interface {
+	Finalize() error
+}
+
+// Graph coordinates build-system-specific graph generation passes.
+type Graph struct {
+	mu        sync.Mutex
+	passes    map[string]GraphPass
+	order     []GraphPass
+	finalized bool
+}
+
+func NewGraph() *Graph {
+	return &Graph{passes: map[string]GraphPass{}}
+}
+
+// Pass returns the pass registered under name, creating it if necessary.
+func (g *Graph) Pass(name string, create func() GraphPass) (GraphPass, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.finalized {
+		return nil, fmt.Errorf("build graph has already been finalized")
+	}
+	if pass := g.passes[name]; pass != nil {
+		return pass, nil
+	}
+	pass := create()
+	g.passes[name] = pass
+	g.order = append(g.order, pass)
+	return pass, nil
+}
+
+// Finalize runs each registered graph pass after graph generation is complete.
+func (g *Graph) Finalize() error {
+	g.mu.Lock()
+	if g.finalized {
+		g.mu.Unlock()
+		return fmt.Errorf("build graph has already been finalized")
+	}
+	g.finalized = true
+	passes := append([]GraphPass(nil), g.order...)
+	g.mu.Unlock()
+
+	for _, pass := range passes {
+		if err := pass.Finalize(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type graphContextKey struct{}
+
+func WithGraph(ctx context.Context, graph *Graph) context.Context {
+	return context.WithValue(ctx, graphContextKey{}, graph)
+}
+
+func GraphFromContext(ctx context.Context) (*Graph, bool) {
+	graph, ok := ctx.Value(graphContextKey{}).(*Graph)
+	return graph, ok
+}

--- a/internal/build/graph_test.go
+++ b/internal/build/graph_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Namespace Labs Inc; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package build
+
+import "testing"
+
+type testGraphPass struct {
+	finalized int
+}
+
+func (p *testGraphPass) Finalize() error {
+	p.finalized++
+	return nil
+}
+
+func TestGraphFinalizesRegisteredPasses(t *testing.T) {
+	graph := NewGraph()
+	want := &testGraphPass{}
+	first, err := graph.Pass("test", func() GraphPass { return want })
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := graph.Pass("test", func() GraphPass { return &testGraphPass{} })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("same pass name produced different graph passes")
+	}
+	if err := graph.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if want.finalized != 1 {
+		t.Fatalf("finalized = %d, want 1", want.finalized)
+	}
+	if _, err := graph.Pass("late", func() GraphPass { return &testGraphPass{} }); err == nil {
+		t.Fatal("expected registering a pass after finalization to fail")
+	}
+}

--- a/internal/integrations/golang/bazel.go
+++ b/internal/integrations/golang/bazel.go
@@ -5,22 +5,19 @@
 package golang
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/bazelbuild/bazelisk/core"
-	"github.com/bazelbuild/bazelisk/repositories"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/build"
+	buildbazel "namespacelabs.dev/foundation/internal/build/bazel"
 	"namespacelabs.dev/foundation/internal/compute"
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/fnerrors"
@@ -31,23 +28,34 @@ import (
 	"namespacelabs.dev/foundation/std/tasks"
 )
 
-func buildBazelImage(ctx context.Context, env pkggraph.SealedContext, workspace build.Workspace, bin GoBinary, target build.BuildTarget, bazelrc string) (compute.Computable[oci.Image], error) {
+func buildBazelImage(ctx context.Context, env pkggraph.SealedContext, workspace build.Workspace, bin GoBinary, target build.BuildTarget, builder *buildbazel.Builder) (compute.Computable[oci.Image], error) {
 	if workspace == nil {
 		return nil, fnerrors.InternalError("bazel: workspace is missing")
 	}
 	if target.TargetPlatform() == nil {
 		return nil, fnerrors.InternalError("bazel: target platform is missing")
 	}
-	if bazelrc == "" {
-		return nil, fnerrors.InternalError("bazel: bazelrc is missing")
+	if builder == nil {
+		return nil, fnerrors.InternalError("bazel: builder is missing")
 	}
 
-	comp := &bazelCompilation{
-		binary:       bin,
-		platform:     *target.TargetPlatform(),
-		workspaceAbs: workspace.Abs(),
-		bazelrc:      bazelrc,
+	label, err := bazelTarget(bin)
+	if err != nil {
+		return nil, err
 	}
+	goPlatform, err := rulesGoPlatform(*target.TargetPlatform())
+	if err != nil {
+		return nil, err
+	}
+	output, err := builder.AddTarget(ctx, buildbazel.Target{
+		WorkspaceAbs: workspace.Abs(),
+		Label:        label,
+		BuildArgs:    []string{"--platforms=" + goPlatform},
+	})
+	if err != nil {
+		return nil, err
+	}
+	comp := &bazelCompilation{binary: bin, target: label, output: output}
 
 	layers := []oci.NamedLayer{oci.MakeLayer(fmt.Sprintf("go binary layer %s", bin.PackageName), comp)}
 	if bin.BinaryOnly {
@@ -84,61 +92,24 @@ func rulesGoPlatform(p specs.Platform) (string, error) {
 }
 
 type bazelCompilation struct {
-	workspaceAbs string
-	bazelrc      string
-	binary       GoBinary
-	platform     specs.Platform
+	binary GoBinary
+	target string
+	output compute.Computable[string]
 
 	compute.LocalScoped[fs.FS]
 }
 
 func (c *bazelCompilation) Action() *tasks.ActionEvent {
-	return tasks.Action("go.build.binary.bazel").Arg("binary", c.binary.BinaryName).Arg("target", c.binary.BazelPackagePath).Arg("platform", platform.FormatPlatform(c.platform))
+	return tasks.Action("go.build.binary.bazel").Arg("binary", c.binary.BinaryName).Arg("target", c.target)
 }
 
 func (c *bazelCompilation) Inputs() *compute.In {
-	return compute.Inputs().JSON("binary", c.binary).JSON("platform", c.platform).Str("bazelrc", c.bazelrc)
+	return compute.Inputs().JSON("binary", c.binary).Computable("bazel", c.output)
 }
 
-func (c *bazelCompilation) Compute(ctx context.Context, _ compute.Resolved) (fs.FS, error) {
-	target, err := bazelTarget(c.binary)
-	if err != nil {
-		return nil, err
-	}
-	goPlatform, err := rulesGoPlatform(c.platform)
-	if err != nil {
-		return nil, err
-	}
+func (c *bazelCompilation) Compute(ctx context.Context, deps compute.Resolved) (fs.FS, error) {
+	source := compute.MustGetDepValue(deps, c.output, "bazel")
 
-	config := core.MakeDefaultConfig()
-	gcs := &repositories.GCSRepo{}
-	github := repositories.CreateGitHubRepo(config.Get("BAZELISK_GITHUB_TOKEN"))
-	repos := core.CreateRepositories(gcs, github, gcs, gcs, true)
-	installation, err := core.GetBazelInstallation(repos, config)
-	if err != nil {
-		return nil, fnerrors.Newf("bazel: failed to install Bazel: %w", err)
-	}
-
-	startup := []string{"--bazelrc=" + c.bazelrc}
-	buildArgs := append(startup, "build", "--platforms="+goPlatform, "--remote_download_outputs=all", target)
-	if err := runBazel(ctx, installation.Path, c.workspaceAbs, buildArgs...); err != nil {
-		return nil, err
-	}
-
-	var stdout bytes.Buffer
-	cqueryArgs := append(startup, "cquery", "--output=files", "--platforms="+goPlatform, target)
-	if err := runBazelWithOutput(ctx, installation.Path, c.workspaceAbs, &stdout, cqueryArgs...); err != nil {
-		return nil, err
-	}
-	outputs := strings.Fields(stdout.String())
-	if len(outputs) != 1 {
-		return nil, fnerrors.Newf("bazel: target %s produced %d files, expected one: %q", target, len(outputs), stdout.String())
-	}
-
-	source := outputs[0]
-	if !filepath.IsAbs(source) {
-		source = filepath.Join(c.workspaceAbs, source)
-	}
 	targetDir, err := dirs.CreateUserTempDir("bazel", "build")
 	if err != nil {
 		return nil, err
@@ -173,19 +144,4 @@ func copyExecutable(source, destination string) error {
 		return err
 	}
 	return dst.Close()
-}
-
-func runBazel(ctx context.Context, binary, dir string, args ...string) error {
-	return runBazelWithOutput(ctx, binary, dir, console.Output(ctx, "bazel"), args...)
-}
-
-func runBazelWithOutput(ctx context.Context, binary, dir string, stdout io.Writer, args ...string) error {
-	cmd := exec.CommandContext(ctx, binary, args...)
-	cmd.Dir = dir
-	cmd.Stdout = stdout
-	cmd.Stderr = console.Output(ctx, "bazel")
-	if err := cmd.Run(); err != nil {
-		return fnerrors.Newf("bazel: command failed: %w", err)
-	}
-	return nil
 }

--- a/internal/integrations/golang/bazel_test.go
+++ b/internal/integrations/golang/bazel_test.go
@@ -41,3 +41,9 @@ func TestRulesGoPlatform(t *testing.T) {
 		t.Fatal("expected variant to be rejected")
 	}
 }
+
+func TestMaybeBazelBuilderWithoutBazelRC(t *testing.T) {
+	if builder := MaybeBazelBuilder(""); builder.bazel != nil {
+		t.Fatal("empty Bazel configuration unexpectedly enabled the Bazel builder")
+	}
+}

--- a/internal/integrations/golang/gobinary.go
+++ b/internal/integrations/golang/gobinary.go
@@ -13,6 +13,7 @@ import (
 	"namespacelabs.dev/foundation/framework/findroot"
 	"namespacelabs.dev/foundation/internal/artifacts/oci"
 	"namespacelabs.dev/foundation/internal/build"
+	buildbazel "namespacelabs.dev/foundation/internal/build/bazel"
 	"namespacelabs.dev/foundation/internal/compute"
 	"namespacelabs.dev/foundation/internal/fnerrors"
 	"namespacelabs.dev/foundation/internal/gosupport"
@@ -49,11 +50,14 @@ var (
 )
 
 type Builder struct {
-	bazelRC string
+	bazel *buildbazel.Builder
 }
 
 func MaybeBazelBuilder(bazelRC string) Builder {
-	return Builder{bazelRC: bazelRC}
+	if bazelRC == "" {
+		return Builder{}
+	}
+	return Builder{bazel: buildbazel.NewBuilder(bazelRC)}
 }
 
 func (gb GoBinary) BuildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration) (compute.Computable[oci.Image], error) {
@@ -61,9 +65,9 @@ func (gb GoBinary) BuildImage(ctx context.Context, env pkggraph.SealedContext, c
 }
 
 func (b Builder) buildImage(ctx context.Context, env pkggraph.SealedContext, conf build.Configuration, gb GoBinary) (compute.Computable[oci.Image], error) {
-	if b.bazelRC != "" {
+	if b.bazel != nil {
 		if bazelBuildAvailable(conf.Workspace(), gb) {
-			return buildBazelImage(ctx, env, conf.Workspace(), gb, conf, b.bazelRC)
+			return buildBazelImage(ctx, env, conf.Workspace(), gb, conf, b.bazel)
 		}
 	}
 

--- a/internal/planning/deploy/deploy.go
+++ b/internal/planning/deploy/deploy.go
@@ -798,6 +798,9 @@ func ComputeStackAndImages(ctx context.Context, planner planning.Planner, server
 }
 
 func computeStackAndImages(ctx context.Context, planner planning.Planner, stack *planning.Stack, opts serverImagesOpts) ([]schema.PackageName, []compute.Computable[ResolvedServerImages], error) {
+	buildGraph := build.NewGraph()
+	ctx = build.WithGraph(ctx, buildGraph)
+
 	imageMap, err := prepareServerImages(ctx, planner, stack, opts)
 	if err != nil {
 		return nil, nil, err
@@ -805,6 +808,9 @@ func computeStackAndImages(ctx context.Context, planner planning.Planner, stack 
 
 	sidecarImages, err := prepareSidecarAndInitImages(ctx, planner.Runtime, planner.Registry, stack, makeBuildAssets(opts.IngressFragments))
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := buildGraph.Finalize(); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
## Summary

- Add an explicit build-graph finalization phase for build-system-specific graph passes.
- Represent Bazel targets as first-class compute nodes and collapse compatible targets into one Bazel build per workspace and argument set.
- Support standalone targets used by prepare hooks and handlers, and preserve requested Bazel labels when collecting alias outputs.
- Keep Foundation from caching Bazel results so Bazel remains the action-cache owner.

## Validation

- `go test ./internal/build ./internal/build/bazel ./internal/integrations/golang ./internal/planning/deploy ./internal/cli/cmd`
- `go test -race ./internal/build ./internal/build/bazel ./internal/integrations/golang`
- `go vet ./internal/build ./internal/build/bazel ./internal/integrations/golang ./internal/planning/deploy ./internal/cli/cmd`
- `go build -o /tmp/ns ./cmd/ns`
- `go build -o /tmp/nsdev ./cmd/nsdev`
- Built IAM, admin, registry, and policy together with `--go_builder=maybe_bazel` and default Namespace remote execution. The graph produced one `bazel.build` action with all four labels and four result nodes.
- Replaced IAM's direct `go_binary` label with a temporary Bazel alias, built successfully, and restored the BUILD file without committing the perturbation.
- Warm rerun still executed Foundation's `bazel.build` node; Bazel completed with zero processes, confirming caching remains inside Bazel.
- Temporarily changed `pkg/prefixed/prefix.go`, rebuilt, and restored it. Bazel reran the leaf's transitive compile/link closure while unaffected actions hit the action cache.
