### PR TITLE
nsc: keep Buck2 identity out of config scan

### DIFF
--- a/internal/cli/cmd/cluster/buck2_config.go
+++ b/internal/cli/cmd/cluster/buck2_config.go
@@ -18,6 +18,7 @@ import (
 	"namespacelabs.dev/foundation/internal/console"
 	"namespacelabs.dev/foundation/internal/console/colors"
 	"namespacelabs.dev/foundation/internal/fnerrors"
+	"namespacelabs.dev/foundation/internal/workspace/dirs"
 )
 
 const (
@@ -202,7 +203,15 @@ func emitBuck2Config(ctx context.Context, out buck2Setup, configPath, output, co
 		return err
 	}
 	if len(out.clientIdentity) > 0 {
-		out.TLSClientCert, err = filepath.Abs(path + ".tls.pem")
+		identityPath := path + ".tls.pem"
+		switch filepath.Base(filepath.Dir(path)) {
+		case buck2ConfigDirName, "buckconfig.d":
+			identityPath, err = dirs.ConfigSubdir(filepath.Join("buck2", "client.pem"))
+			if err != nil {
+				return fnerrors.Newf("failed to resolve the Namespace configuration directory: %w", err)
+			}
+		}
+		out.TLSClientCert, err = filepath.Abs(identityPath)
 		if err != nil {
 			return fnerrors.Newf("failed to resolve the client identity path: %w", err)
 		}

--- a/internal/cli/cmd/cluster/reapi_test.go
+++ b/internal/cli/cmd/cluster/reapi_test.go
@@ -217,6 +217,43 @@ func TestEmitReapiBuck2Config(t *testing.T) {
 	}
 }
 
+func TestEmitReapiBuck2ConfigDefaultPathKeepsIdentityOutsideConfigDirectory(t *testing.T) {
+	home := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	configPath := filepath.Join(home, ".buckconfig.d", "50-namespace")
+
+	result := reapiSetupResult{
+		bazelRbeSetup: bazelRbeSetup{
+			SchedulerEndpoint: "grpcs://scheduler.example:443",
+			StorageEndpoint:   "grpcs://storage.example:443",
+		},
+		clientCertPEM: []byte("certificate"),
+		clientKeyPEM:  []byte("private-key"),
+	}
+	if err := emitReapiBuck2Config(context.Background(), result, "", "json", true, time.Hour); err != nil {
+		t.Fatalf("emitReapiBuck2Config: %v", err)
+	}
+
+	identityPath := filepath.Join(configHome, "ns", "buck2", "client.pem")
+	assertCredentialFile(t, identityPath, "certificate\nprivate-key")
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "tls_client_cert = " + identityPath + "\n"; !strings.Contains(string(config), want) {
+		t.Fatalf("config does not contain %q:\n%s", want, config)
+	}
+
+	result.clientCertPEM = []byte("replacement-certificate")
+	result.clientKeyPEM = []byte("replacement-private-key")
+	if err := emitReapiBuck2Config(context.Background(), result, "", "json", true, time.Hour); err != nil {
+		t.Fatalf("second emitReapiBuck2Config: %v", err)
+	}
+	assertCredentialFile(t, identityPath, "replacement-certificate\nreplacement-private-key")
+}
+
 func assertFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)


### PR DESCRIPTION
## Summary

- store generated Buck2 mTLS identities in the Namespace user configuration directory, outside Buck2’s recursively scanned `.buckconfig.d`
- preserve sibling identity files for explicitly selected config paths outside `buckconfig.d`
- cover the default path with a regression test

## Verification

- `GIT_CONFIG_GLOBAL=/dev/null go test ./internal/cli/cmd/cluster`
- Buck2 `2026-09-09-016d70f4dbc35e2f11aba6658193e2c7405ccad3` successfully ran `audit cell` with the generated config and identity at `~/.config/ns/buck2/client.pem`
- control test with the identity at `~/.buckconfig.d/50-namespace.tls.pem` failed with the reported Buck2 config parser error