### PR TITLE
nsc: support no-expiry Bazel tokens

### DIFF
--- a/internal/cli/cmd/cluster/bazel_test.go
+++ b/internal/cli/cmd/cluster/bazel_test.go
@@ -29,6 +29,7 @@ func TestNewBazelCreateTokenCmd(t *testing.T) {
 	for name, wantDefault := range map[string]string{
 		"token":      "token.json",
 		"expires_in": "2160h0m0s",
+		"no_expiry":  "false",
 		"scope":      "user",
 	} {
 		flag := createToken.Flags().Lookup(name)
@@ -266,7 +267,7 @@ func TestNewBazelTokenRequest(t *testing.T) {
 	t.Parallel()
 
 	expiresAt := time.Now().Add(30 * 24 * time.Hour)
-	req, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "user")
+	req, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "user", false)
 	if err != nil {
 		t.Fatalf("newBazelTokenRequest: %v", err)
 	}
@@ -275,6 +276,9 @@ func TestNewBazelTokenRequest(t *testing.T) {
 	}
 	if req.GetScope() != iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE {
 		t.Fatalf("token scope = %v, want user scope", req.GetScope())
+	}
+	if !req.GetExpiresAt().AsTime().Equal(expiresAt) {
+		t.Fatalf("token expiration = %v, want %v", req.GetExpiresAt(), expiresAt)
 	}
 
 	grants := req.GetAccess().GetGrants()
@@ -291,7 +295,15 @@ func TestNewBazelTokenRequest(t *testing.T) {
 	assertGrant(grants[1], "bazel/storage", "write")
 	assertGrant(grants[2], "ingress", "access")
 
-	tenantReq, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "tenant")
+	noExpiryReq, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "user", true)
+	if err != nil {
+		t.Fatalf("newBazelTokenRequest without expiry: %v", err)
+	}
+	if noExpiryReq.GetExpiresAt() != nil {
+		t.Fatalf("unlimited token expiration = %v, want nil", noExpiryReq.GetExpiresAt())
+	}
+
+	tenantReq, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "tenant", false)
 	if err != nil {
 		t.Fatalf("newBazelTokenRequest tenant scope: %v", err)
 	}
@@ -299,7 +311,11 @@ func TestNewBazelTokenRequest(t *testing.T) {
 		t.Fatalf("token scope = %v, want tenant scope", tenantReq.GetScope())
 	}
 
-	if _, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "invalid"); err == nil {
+	if _, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "tenant", true); err == nil {
+		t.Fatal("expected unlimited tenant token error")
+	}
+
+	if _, err := newBazelTokenRequest("rbe-ci-token", expiresAt, "invalid", false); err == nil {
 		t.Fatal("expected invalid token scope error")
 	}
 }

--- a/internal/cli/cmd/cluster/createtoken.go
+++ b/internal/cli/cmd/cluster/createtoken.go
@@ -150,18 +150,20 @@ type reapiTokenCommandConfig struct {
 func newReapiTokenCmd(cfg reapiTokenCommandConfig) *cobra.Command {
 	var tokenFile, scope string
 	var expiresIn time.Duration
+	var noExpiry bool
 
-	return fncobra.Cmd(&cobra.Command{
+	cmd := fncobra.Cmd(&cobra.Command{
 		Use:   "create-token",
 		Short: cfg.short,
 	}).WithFlags(func(flags *pflag.FlagSet) {
 		flags.StringVar(&tokenFile, "token", "token.json", "Write token to this file in JSON format.")
 		fncobra.DurationVar(flags, &expiresIn, "expires_in", 90*24*time.Hour, "Duration until the token expires.")
+		flags.BoolVar(&noExpiry, "no_expiry", false, "Create a token with unlimited duration.")
 		flags.StringVar(&scope, "scope", "user", "Set the scope of the generated access token. Valid options: tenant, user. Tokens with user scope are bound to the tenant membership of the current user.")
 	}).Do(func(ctx context.Context) error {
 		expiresAt := time.Now().Add(expiresIn)
 		tokenName := fmt.Sprintf("%s-%s", cfg.tokenPrefix, ids.NewRandomBase32ID(4))
-		req, err := newReapiTokenRequest(tokenName, cfg.tokenDescription, expiresAt, scope)
+		req, err := newReapiTokenRequest(tokenName, cfg.tokenDescription, expiresAt, scope, noExpiry)
 		if err != nil {
 			return err
 		}
@@ -188,7 +190,11 @@ func newReapiTokenCmd(cfg reapiTokenCommandConfig) *cobra.Command {
 
 		fmt.Fprintf(console.Stdout(ctx), "Token ID:    %s\n", resp.Token.GetTokenId())
 		fmt.Fprintf(console.Stdout(ctx), "Name:        %s\n", resp.Token.GetName())
-		fmt.Fprintf(console.Stdout(ctx), "Expires At:  %s\n", expiresAt.Format(time.RFC3339))
+		if noExpiry {
+			fmt.Fprintln(console.Stdout(ctx), "Expires At:  Never")
+		} else {
+			fmt.Fprintf(console.Stdout(ctx), "Expires At:  %s\n", expiresAt.Format(time.RFC3339))
+		}
 		fmt.Fprintf(console.Stdout(ctx), "\nWrote token contents to %q\n\n", tokenFile)
 		fmt.Fprintf(console.Stdout(ctx), "Set up %s with:\n", cfg.setupLabel)
 
@@ -197,17 +203,19 @@ func newReapiTokenCmd(cfg reapiTokenCommandConfig) *cobra.Command {
 
 		return nil
 	})
+	cmd.MarkFlagsMutuallyExclusive("expires_in", "no_expiry")
+
+	return cmd
 }
 
-func newBazelTokenRequest(name string, expiresAt time.Time, scope string) (*iamv1beta.CreateRevokableTokenRequest, error) {
-	return newReapiTokenRequest(name, "Bazel remote execution access token", expiresAt, scope)
+func newBazelTokenRequest(name string, expiresAt time.Time, scope string, noExpiry bool) (*iamv1beta.CreateRevokableTokenRequest, error) {
+	return newReapiTokenRequest(name, "Bazel remote execution access token", expiresAt, scope, noExpiry)
 }
 
-func newReapiTokenRequest(name, description string, expiresAt time.Time, scope string) (*iamv1beta.CreateRevokableTokenRequest, error) {
+func newReapiTokenRequest(name, description string, expiresAt time.Time, scope string, noExpiry bool) (*iamv1beta.CreateRevokableTokenRequest, error) {
 	req := &iamv1beta.CreateRevokableTokenRequest{
 		Name:        name,
 		Description: description,
-		ExpiresAt:   timestamppb.New(expiresAt),
 		Access: &iamv1beta.AccessPolicy{
 			Grants: []*iamv1beta.Permission{
 				{ResourceType: "bazel/execution", ResourceId: "*", Actions: []string{"ensure"}},
@@ -216,9 +224,15 @@ func newReapiTokenRequest(name, description string, expiresAt time.Time, scope s
 			},
 		},
 	}
+	if !noExpiry {
+		req.ExpiresAt = timestamppb.New(expiresAt)
+	}
 
 	switch scope {
 	case "tenant":
+		if noExpiry {
+			return nil, fnerrors.BadInputError("--no_expiry requires --scope=user")
+		}
 		req.Scope = iamv1beta.RevokableToken_TENANT_SCOPE
 	case "user":
 		req.Scope = iamv1beta.RevokableToken_TENANT_MEMBERSHIP_SCOPE


### PR DESCRIPTION
Add `--no_expiry` support to `nsc bazel create-token` (and the shared REAPI token command).

The flag is mutually exclusive with `--expires_in`, limited to user-scoped tokens, and omits `expires_at` from the IAM request.

Tests cover flag availability, normal expiration, unlimited expiration, and tenant-scope rejection.